### PR TITLE
docs(legal): subprocessors + SLA pages

### DIFF
--- a/api/app/routes_help.py
+++ b/api/app/routes_help.py
@@ -32,6 +32,13 @@ async def help_center(request: Request, tenant_id: str | None = None) -> HTMLRes
         html = markdown(md)
         sections.append(f"<article><h2>{title}</h2>{html}</article>")
 
+    sections.append(
+        "<article><h2>Legal</h2><ul>"
+        "<li><a href='/legal/subprocessors'>Subprocessors</a></li>"
+        "<li><a href='/legal/sla'>Service Level Agreement</a></li>"
+        "</ul></article>"
+    )
+
     body = "".join(sections) or "<p>No help available.</p>"
     html = f"<html><head><title>Help</title></head><body>{body}</body></html>"
 

--- a/docs/LEGAL_SLA.md
+++ b/docs/LEGAL_SLA.md
@@ -1,0 +1,7 @@
+# Service Level Agreement
+
+We target 99.9% uptime for the service.
+
+Support is available 09:00–18:00 IST, Monday through Friday.
+
+See the [/legal/sla](/legal/sla) page for the published SLA.

--- a/docs/LEGAL_SUBPROCESSORS.md
+++ b/docs/LEGAL_SUBPROCESSORS.md
@@ -1,0 +1,9 @@
+# Subprocessors
+
+We engage the following subprocessors to support our service:
+
+- AWS – cloud infrastructure
+- SendGrid – transactional email
+- Stripe – payment processing
+
+See the [/legal/subprocessors](/legal/subprocessors) page for more details.

--- a/tests/test_help_pages.py
+++ b/tests/test_help_pages.py
@@ -11,6 +11,8 @@ def test_help_renders_docs():
     assert "Owner Onboarding" in resp.text
     assert "Cashier &amp; KDS Cheat Sheet" in resp.text
     assert "Troubleshooting" in resp.text
+    assert "Subprocessors" in resp.text
+    assert "Service Level Agreement" in resp.text
 
 
 def test_help_includes_branding():

--- a/tests/test_legal_pages.py
+++ b/tests/test_legal_pages.py
@@ -16,6 +16,8 @@ def test_legal_pages_served():
         "privacy": "Privacy Policy",
         "refund": "Cancellation & Refund Policy",
         "contact": "Contact Us",
+        "subprocessors": "Subprocessors",
+        "sla": "Service Level Agreement",
     }
     for page, title in pages.items():
         resp = client.get(f"/legal/{page}")


### PR DESCRIPTION
## Summary
- document service subprocessors
- document SLA targets
- link legal pages from admin help

## Testing
- `pytest tests/test_help_pages.py tests/test_legal_pages.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad8f5f3134832aaec595186b91b28d