### PR TITLE
feat(promos): caps + windows + audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be documented in this file.
 - Dry-run mode for soft-deleted purge script with nightly CI report.
 - Stricter `/api/admin/preflight` checks for soft-delete indexes, quotas,
   webhook breaker metrics, and replica health.
+- Per-coupon usage caps (per day/guest/outlet) with valid-from/to windows and
+  usage auditing, returning helpful hints when limits are exceeded.
 - Owner dashboard displays licensing usage bars for tables, items, images, and exports.
 - Guests opting into WhatsApp receive order status updates when orders are
   accepted, out for delivery, or ready.

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Coupons can be marked as stackable and may specify a per-invoice `max_discount` 
 
 Attempts to combine a non-stackable coupon with others raise a `CouponError` with code `NON_STACKABLE`.
 
-Coupons may also define per-day, per-guest and per-outlet usage caps along with `valid_from`/`valid_to` windows. Usage is audited and exceeding a cap results in a `CouponError` with a hint describing the limitation.
+Coupons may also define per-day, per-guest and per-outlet usage caps along with `valid_from`/`valid_to` windows. Usage is audited and exceeding a cap results in a `CouponError` with a `hint` describing the limitation.
 
 ### Feedback
 

--- a/api/app/repos_sqlalchemy/invoices_repo_sql.py
+++ b/api/app/repos_sqlalchemy/invoices_repo_sql.py
@@ -119,11 +119,15 @@ async def _enforce_coupon_caps(
             continue
         if coupon.valid_from and now < coupon.valid_from:
             raise billing_service.CouponError(
-                "NOT_ACTIVE", f"Coupon {coupon.code} starts {coupon.valid_from.date()}"
+                "NOT_ACTIVE",
+                f"Coupon {coupon.code} starts {coupon.valid_from.date()}",
+                hint=f"Starts on {coupon.valid_from.date()}",
             )
         if coupon.valid_to and now > coupon.valid_to:
             raise billing_service.CouponError(
-                "EXPIRED", f"Coupon {coupon.code} expired on {coupon.valid_to.date()}"
+                "EXPIRED",
+                f"Coupon {coupon.code} expired on {coupon.valid_to.date()}",
+                hint=f"Expired on {coupon.valid_to.date()}",
             )
 
         if coupon.per_day_cap is not None:
@@ -136,7 +140,9 @@ async def _enforce_coupon_caps(
             )
             if day_count >= coupon.per_day_cap:
                 raise billing_service.CouponError(
-                    "DAILY_CAP", f"Coupon {coupon.code} limit reached today"
+                    "DAILY_CAP",
+                    f"Coupon {coupon.code} limit reached today",
+                    hint="Try again tomorrow",
                 )
 
         if guest_id is not None and coupon.per_guest_cap is not None:
@@ -148,7 +154,9 @@ async def _enforce_coupon_caps(
             )
             if guest_count >= coupon.per_guest_cap:
                 raise billing_service.CouponError(
-                    "GUEST_CAP", f"Coupon {coupon.code} already used"
+                    "GUEST_CAP",
+                    f"Coupon {coupon.code} already used",
+                    hint="Limit 1 per guest",
                 )
 
         if outlet_id is not None and coupon.per_outlet_cap is not None:
@@ -160,7 +168,9 @@ async def _enforce_coupon_caps(
             )
             if outlet_count >= coupon.per_outlet_cap:
                 raise billing_service.CouponError(
-                    "OUTLET_CAP", f"Outlet limit reached for {coupon.code}"
+                    "OUTLET_CAP",
+                    f"Outlet limit reached for {coupon.code}",
+                    hint="Outlet limit reached",
                 )
 
         session.add(

--- a/api/tests/test_coupons.py
+++ b/api/tests/test_coupons.py
@@ -26,6 +26,7 @@ def test_non_stackable_coupons_rejected():
     with pytest.raises(billing_service.CouponError) as exc:
         billing_service.compute_bill(items, "unreg", coupons=[c1, c2])
     assert exc.value.code == "NON_STACKABLE"
+    assert exc.value.hint == "Remove non-stackable coupon"
 
 
 def test_stackable_coupons_with_cap():

--- a/api/tests/test_coupons_rules.py
+++ b/api/tests/test_coupons_rules.py
@@ -105,6 +105,7 @@ async def test_non_stackable_codes_rejected(session):
         )
     assert exc.value.code == "NON_STACKABLE"
     assert "cannot be stacked" in str(exc.value)
+    assert exc.value.hint == "Remove non-stackable coupon"
 
 
 @pytest.mark.anyio

--- a/api/tests/test_happy_hour.py
+++ b/api/tests/test_happy_hour.py
@@ -136,3 +136,4 @@ def test_coupons_rejected_during_happy_hour(monkeypatch):
             now=datetime(2023, 1, 2, 10, 30),
         )
     assert exc.value.code == "HAPPY_HOUR"
+    assert exc.value.hint == "Try again outside happy hour"


### PR DESCRIPTION
## Summary
- add hint metadata to `CouponError`
- audit coupon usage while enforcing per-day, per-guest, and per-outlet caps with helpful hints
- document coupon limits and usage auditing

## Testing
- `pytest api/tests/test_coupon_caps.py api/tests/test_coupons.py api/tests/test_coupons_rules.py api/tests/test_happy_hour.py::test_coupons_rejected_during_happy_hour`
- `ruff check api/app/services/billing_service.py api/app/repos_sqlalchemy/invoices_repo_sql.py api/tests/test_coupon_caps.py api/tests/test_coupons.py api/tests/test_coupons_rules.py api/tests/test_happy_hour.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad8fc6fe9c832a82a70d2f7ea597c9