### PR TITLE
chore(sec): ZAP baseline scan workflow

### DIFF
--- a/.github/workflows/zap_baseline.yml
+++ b/.github/workflows/zap_baseline.yml
@@ -1,0 +1,20 @@
+name: zap-baseline
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  zap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ZAP Baseline Scan
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: ${{ secrets.STAGING_URL }}
+          allowlist: |
+            /auth
+            /callback
+          cmd_options: '-r zap_report.html'
+          artifact_name: zap-baseline-report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ All notable changes to this project will be documented in this file.
 - Guests opting into WhatsApp receive order status updates when orders are
   accepted, out for delivery, or ready.
 - PWA manifest referencing external icons to enable install prompts on supported devices.
-- OWASP ZAP baseline security scan against staging with auth paths allowlisted.
+- OWASP ZAP baseline security scan against staging with auth paths allowlisted and HTML report artifact.
 - Optional PostHog/Mixpanel analytics with per-tenant consent and PII redaction.
 
 - WhatsApp guest notifications are gated by the `WHATSAPP_GUEST_UPDATES_ENABLED`


### PR DESCRIPTION
## Summary
- scan staging with OWASP ZAP baseline, allowlisting auth and callback paths
- document ZAP baseline workflow in changelog

## Testing
- `pre-commit run --files CHANGELOG.md .github/workflows/zap_baseline.yml`
- `pytest -q` *(fails: import file mismatch between tests/test_slo_metrics.py and api/tests/test_slo_metrics.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8f356130832aa694b1b85299df8c