### PR TITLE
feat(privacy): DSAR export/delete + consent flags

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -103,6 +103,7 @@ from .obs.logging import configure_logging
 from .otel import init_tracing
 from .routes_admin_menu import router as admin_menu_router
 from .routes_admin_privacy import router as admin_privacy_router
+from .routes_privacy_dsar import router as privacy_dsar_router
 from .routes_admin_qrpack import router as admin_qrpack_router
 from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
@@ -125,6 +126,7 @@ from .routes_exports import router as exports_router
 from .routes_feedback import router as feedback_router
 from .routes_gst_monthly import router as gst_monthly_router
 from .routes_guest_bill import router as guest_bill_router
+from .routes_guest_consent import router as guest_consent_router
 from .routes_guest_menu import router as guest_menu_router
 from .routes_guest_order import router as guest_order_router
 from .routes_help import router as help_router
@@ -873,6 +875,7 @@ app.include_router(auth_2fa_router)
 app.include_router(guest_menu_router)
 app.include_router(guest_order_router)
 app.include_router(guest_bill_router)
+app.include_router(guest_consent_router)
 app.include_router(counter_guest_router)
 app.include_router(hotel_guest_router)
 app.include_router(invoice_pdf_router)
@@ -897,6 +900,7 @@ app.include_router(security_router)
 app.include_router(jobs_status_router)
 app.include_router(dlq_router)
 app.include_router(admin_privacy_router)
+app.include_router(privacy_dsar_router)
 app.include_router(outbox_admin_router)
 app.include_router(webhook_tools_router)
 app.include_router(orders_batch_router)

--- a/api/app/routes_guest_consent.py
+++ b/api/app/routes_guest_consent.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Guest consent capture endpoint."""
+
+from typing import AsyncGenerator
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .db.tenant import get_engine
+from .deps.tenant import get_tenant_id
+from .utils.audit import audit
+from .utils.responses import ok
+
+router = APIRouter(prefix="/g")
+
+
+class ConsentPayload(BaseModel):
+    phone: str | None = None
+    allow_analytics: bool = False
+    allow_wa: bool = False
+
+
+async def get_tenant_session(
+    tenant_id: str = Depends(get_tenant_id),
+) -> AsyncGenerator[AsyncSession, None]:
+    engine = get_engine(tenant_id)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with sessionmaker() as session:
+        yield session
+
+
+@router.post("/consent")
+@audit("guest_consent", {"phone"})
+async def save_consent(
+    payload: ConsentPayload,
+    session: AsyncSession = Depends(get_tenant_session),
+) -> dict:
+    if payload.phone:
+        res = await session.execute(
+            text(
+                "UPDATE customers SET allow_analytics=:a, allow_wa=:w WHERE phone=:p"
+            ),
+            {"a": payload.allow_analytics, "w": payload.allow_wa, "p": payload.phone},
+        )
+        if res.rowcount == 0:
+            await session.execute(
+                text(
+                    "INSERT INTO customers (name, phone, allow_analytics, allow_wa) VALUES ('', :p, :a, :w)"
+                ),
+                {"p": payload.phone, "a": payload.allow_analytics, "w": payload.allow_wa},
+            )
+        await session.commit()
+    return ok({})
+
+
+__all__ = ["router"]

--- a/api/app/routes_privacy_dsar.py
+++ b/api/app/routes_privacy_dsar.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+"""Privacy DSAR endpoints for data principals."""
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import text
+
+from .db import SessionLocal
+from .utils.audit import audit
+from .utils.responses import ok
+
+router = APIRouter()
+
+
+class DSARRequest(BaseModel):
+    phone: str | None = None
+    email: str | None = None
+    dry_run: bool = False
+
+    def filters(self) -> tuple[str, dict[str, Any]]:
+        clauses: list[str] = []
+        params: dict[str, Any] = {}
+        if self.phone:
+            clauses.append("phone = :phone")
+            params["phone"] = self.phone
+        if self.email:
+            clauses.append("email = :email")
+            params["email"] = self.email
+        if not clauses:
+            raise HTTPException(status_code=400, detail="phone or email required")
+        return " OR ".join(clauses), params
+
+
+@router.post("/privacy/dsar/export")
+@audit("dsar_export", {"phone", "email"})
+async def dsar_export(payload: DSARRequest) -> dict:
+    clause, params = payload.filters()
+    with SessionLocal() as session:
+        cust_rows = session.execute(
+            text(
+                f"SELECT id, name, phone, email, created_at, allow_analytics, allow_wa FROM customers WHERE {clause}"
+            ),
+            params,
+        ).mappings().all()
+        inv_rows = session.execute(
+            text(
+                f"SELECT id, name, phone, email, created_at FROM invoices WHERE {clause}"
+            ),
+            params,
+        ).mappings().all()
+        pay_rows = session.execute(
+            text(
+                "SELECT p.id, p.invoice_id, p.mode, p.amount, NULL as utr, p.verified, p.created_at "
+                "FROM payments p JOIN invoices i ON p.invoice_id = i.id WHERE " + clause
+            ),
+            params,
+        ).mappings().all()
+    return ok(
+        {
+            "customers": [dict(r) for r in cust_rows],
+            "invoices": [dict(r) for r in inv_rows],
+            "payments": [dict(r) for r in pay_rows],
+        }
+    )
+
+
+@router.post("/privacy/dsar/delete")
+@audit("dsar_delete", {"phone", "email"})
+async def dsar_delete(payload: DSARRequest) -> dict:
+    clause, params = payload.filters()
+    with SessionLocal() as session:
+        if payload.dry_run:
+            cust_count = session.execute(
+                text(f"SELECT COUNT(*) FROM customers WHERE {clause}"), params
+            ).scalar()
+            inv_count = session.execute(
+                text(f"SELECT COUNT(*) FROM invoices WHERE {clause}"), params
+            ).scalar()
+            pay_count = session.execute(
+                text(
+                    "SELECT COUNT(*) FROM payments p JOIN invoices i ON p.invoice_id = i.id WHERE "
+                    + clause
+                ),
+                params,
+            ).scalar()
+        else:
+            pay_res = session.execute(
+                text(
+                    "UPDATE payments SET utr = NULL WHERE invoice_id IN (SELECT id FROM invoices WHERE "
+                    + clause
+                    + ")"
+                ),
+                params,
+            )
+            inv_res = session.execute(
+                text(
+                    f"UPDATE invoices SET name = NULL, phone = NULL, email = NULL WHERE {clause}"
+                ),
+                params,
+            )
+            cust_res = session.execute(
+                text(
+                    f"UPDATE customers SET name = NULL, phone = NULL, email = NULL, allow_analytics = 0, allow_wa = 0 WHERE {clause}"
+                ),
+                params,
+            )
+            pay_count = pay_res.rowcount or 0
+            inv_count = inv_res.rowcount or 0
+            cust_count = cust_res.rowcount or 0
+            session.commit()
+    return ok(
+        {
+            "customers": cust_count,
+            "invoices": inv_count,
+            "payments": pay_count,
+            "dry_run": payload.dry_run,
+        }
+    )
+
+
+__all__ = ["router"]

--- a/docs/PRIVACY_DSAR.md
+++ b/docs/PRIVACY_DSAR.md
@@ -7,6 +7,13 @@ Two administrative endpoints expose one-click Data Subject Access Request (DSAR)
 
 Both endpoints accept a JSON body with either a `phone` or `email` field. The delete route also accepts a `dry_run` flag that reports the number of affected rows without modifying data.
 
+For self-service requests the API also exposes tenant-agnostic routes:
+
+- `POST /privacy/dsar/export`
+- `POST /privacy/dsar/delete`
+
+These return customer, invoice and payment records for the supplied phone or email with payment UTRs redacted. Delete anonymises matching rows and zeroes consent flags.
+
 All invocations are audited and leverage existing retention/anonymisation helpers.
 
 ## DPDP data principal rights

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -30,3 +30,6 @@ properties before transmission.
 Currently the backend emits a `feedback_submitted` event whenever a guest NPS
 entry is stored.
 
+Guest opt-ins for analytics and WhatsApp updates are persisted via the `/g/consent`
+endpoint and stored against the customer's record.
+

--- a/pwa/src/components/ConsentBanner.jsx
+++ b/pwa/src/components/ConsentBanner.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { apiFetch } from '../api'
 
 export default function ConsentBanner() {
   const [visible, setVisible] = useState(false)
@@ -22,6 +23,15 @@ export default function ConsentBanner() {
         'guestConsent',
         JSON.stringify({ analytics, wa })
       )
+    } catch (e) {
+      /* ignore */
+    }
+    try {
+      apiFetch('/g/consent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ allow_analytics: analytics, allow_wa: wa })
+      })
     } catch (e) {
       /* ignore */
     }

--- a/tests/test_privacy_dsar.py
+++ b/tests/test_privacy_dsar.py
@@ -1,0 +1,76 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from api.app import routes_privacy_dsar
+from api.app.db import SessionLocal, engine
+from api.app.models_tenant import AuditTenant
+
+
+def test_privacy_dsar_export_and_delete():
+    app = FastAPI()
+    app.include_router(routes_privacy_dsar.router)
+    client = TestClient(app)
+
+    with engine.begin() as conn:
+        conn.exec_driver_sql("DROP TABLE IF EXISTS customers")
+        conn.exec_driver_sql("DROP TABLE IF EXISTS invoices")
+        conn.exec_driver_sql("DROP TABLE IF EXISTS payments")
+        conn.exec_driver_sql(
+            "CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT, phone TEXT, email TEXT, allow_analytics BOOLEAN, allow_wa BOOLEAN, created_at DATETIME)"
+        )
+        conn.exec_driver_sql(
+            "CREATE TABLE invoices (id INTEGER PRIMARY KEY, name TEXT, phone TEXT, email TEXT, created_at DATETIME)"
+        )
+        conn.exec_driver_sql(
+            "CREATE TABLE payments (id INTEGER PRIMARY KEY, invoice_id INTEGER, mode TEXT, amount NUMERIC, utr TEXT, verified BOOLEAN, created_at DATETIME)"
+        )
+        conn.exec_driver_sql(
+            "INSERT INTO customers (id, name, phone, email, allow_analytics, allow_wa, created_at) VALUES (1,'Alice','111','a@example.com',0,0,'2023-01-01')"
+        )
+        conn.exec_driver_sql(
+            "INSERT INTO invoices (id, name, phone, email, created_at) VALUES (1,'Alice','111','a@example.com','2023-01-02')"
+        )
+        conn.exec_driver_sql(
+            "INSERT INTO payments (id, invoice_id, mode, amount, utr, verified, created_at) VALUES (1,1,'upi',10,'utr123',0,'2023-01-03')"
+        )
+
+    with SessionLocal() as s:
+        s.query(AuditTenant).delete()
+        s.commit()
+
+    resp = client.post('/privacy/dsar/export', json={'phone': '111'})
+    assert resp.status_code == 200
+    data = resp.json()['data']
+    assert data['customers'][0]['phone'] == '111'
+    assert data['payments'][0]['utr'] is None
+
+    with SessionLocal() as s:
+        row = s.query(AuditTenant).filter_by(action='dsar_export').first()
+        assert row is not None
+        assert row.meta['payload']['phone'] == '***'
+
+    resp = client.post('/privacy/dsar/delete', json={'phone': '111', 'dry_run': True})
+    counts = resp.json()['data']
+    assert counts['customers'] == 1
+    assert counts['payments'] == 1
+
+    resp = client.post('/privacy/dsar/delete', json={'phone': '111'})
+    assert resp.status_code == 200
+
+    with SessionLocal() as session:
+        cust = session.execute(
+            text('SELECT name, phone, email, allow_analytics, allow_wa FROM customers')
+        ).first()
+        inv = session.execute(
+            text('SELECT name, phone, email FROM invoices')
+        ).first()
+        pay = session.execute(text('SELECT utr FROM payments')).first()
+    assert cust == (None, None, None, 0, 0)
+    assert inv == (None, None, None)
+    assert pay == (None,)
+
+    with SessionLocal() as s:
+        row = s.query(AuditTenant).filter_by(action='dsar_delete').first()
+        assert row is not None
+        assert row.meta['payload']['phone'] == '***'


### PR DESCRIPTION
## Summary
- add public DSAR export/delete endpoints with payment UTR redaction
- log guest consent selections and store flags per customer
- wire guest consent banner to persist selections

## Testing
- `pytest tests/test_dsar.py tests/test_privacy_dsar.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad8f23255c832a98e662ac46286b49