### PR TITLE
feat(ops): daily owner digest

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -19,6 +19,24 @@ Run daily at 3 AM:
 0 3 * * * cd /path/to/neo && python scripts/purge_data.py --tenant TENANT_NAME
 ```
 
+## Owner Digest
+
+Operators can send a daily summary covering orders, average preparation
+time, top selling items, complimentary counts, tip totals and webhook
+breaker opens:
+
+```bash
+python scripts/owner_digest.py --tenant TENANT_NAME
+```
+
+### Example crontab
+
+Run nightly at 20:00 IST:
+
+```
+0 20 * * * cd /path/to/neo && python scripts/owner_digest.py --tenant TENANT_NAME
+```
+
 ## Support Bundle
 
 Administrators can download a diagnostic archive for a tenant:

--- a/scripts/owner_digest.py
+++ b/scripts/owner_digest.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Send a daily owner digest for a tenant.
+
+Summarises previous day's orders, average preparation time,
+most popular items, complimentary counts, tip totals and the
+number of webhook breaker opens. The digest is emitted via
+providers – console, optional WhatsApp and optional email – if
+their respective targets are configured in the environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+# Ensure ``api`` package is importable when running as a standalone script
+BASE_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(BASE_DIR))
+sys.path.append(str(BASE_DIR / "api"))
+
+from zoneinfo import ZoneInfo
+
+from app.db.tenant import get_engine as get_tenant_engine  # type: ignore
+from app.models_tenant import (  # type: ignore
+    Invoice,
+    Order,
+    OrderItem,
+)
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+import requests
+
+
+class ConsoleProvider:
+    """Provider that prints the digest to STDOUT."""
+
+    @staticmethod
+    def send(message: str) -> None:
+        print(message)
+
+
+class WhatsappProvider:
+    """Stub provider for WhatsApp delivery.
+
+    Requires ``OWNER_DIGEST_WA`` environment variable to be set
+    with the destination identifier.
+    """
+
+    @staticmethod
+    def send(message: str) -> None:  # pragma: no cover - stub
+        target = os.getenv("OWNER_DIGEST_WA")
+        if not target:
+            return
+        from api.app.providers import whatsapp_stub  # type: ignore
+
+        whatsapp_stub.send("owner.digest", {"text": message}, target)
+
+
+class EmailProvider:
+    """Stub provider for email delivery.
+
+    Requires ``OWNER_DIGEST_EMAIL`` environment variable to be
+    set with the recipient address.
+    """
+
+    @staticmethod
+    def send(message: str) -> None:  # pragma: no cover - stub
+        target = os.getenv("OWNER_DIGEST_EMAIL")
+        if not target:
+            return
+        from api.app.providers import email_stub  # type: ignore
+
+        email_stub.send(
+            "owner.digest", {"subject": "Owner Digest", "message": message}, target
+        )
+
+
+PROVIDERS = {
+    "console": ConsoleProvider(),
+    "whatsapp": WhatsappProvider(),
+    "email": EmailProvider(),
+}
+
+
+async def build_digest_line(tenant: str, day: date) -> str:
+    """Return a formatted digest line for ``tenant`` on ``day``."""
+    tz = os.getenv("DEFAULT_TZ", "UTC")
+    tzinfo = ZoneInfo(tz)
+    start = datetime.combine(day, time.min, tzinfo).astimezone(timezone.utc)
+    end = datetime.combine(day, time.max, tzinfo).astimezone(timezone.utc)
+
+    engine = get_tenant_engine(tenant)
+    sessionmaker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    try:
+        async with sessionmaker() as session:
+            orders = await _orders_count(session, start, end)
+            avg_prep = await _avg_prep_minutes(session, start, end)
+            top_items = await _top_items(session, start, end)
+            comps = await _comps_count(session, start, end)
+            tips = await _tips_total(session, start, end)
+    finally:
+        await engine.dispose()
+
+    breaker = _breaker_opens()
+    top_str = ", ".join(f"{name}({qty})" for name, qty in top_items)
+    return (
+        f"{day.isoformat()} | orders={orders} | avg_prep={avg_prep:.2f}m | "
+        f"top_items={top_str} | comps={comps} | tips={tips:.2f} | "
+        f"breaker_opens={breaker}"
+    )
+
+
+async def _orders_count(session: AsyncSession, start: datetime, end: datetime) -> int:
+    result = await session.scalar(
+        select(func.count())
+        .select_from(Order)
+        .where(Order.placed_at >= start, Order.placed_at <= end)
+    )
+    return int(result or 0)
+
+
+async def _avg_prep_minutes(
+    session: AsyncSession, start: datetime, end: datetime
+) -> float:
+    rows = await session.execute(
+        select(Order.placed_at, Order.served_at).where(
+            Order.served_at.is_not(None),
+            Order.placed_at.is_not(None),
+            Order.served_at >= start,
+            Order.served_at <= end,
+        )
+    )
+    durations = [
+        (served - placed).total_seconds()
+        for placed, served in rows.all()
+        if placed and served
+    ]
+    return (sum(durations) / len(durations) / 60.0) if durations else 0.0
+
+
+async def _top_items(
+    session: AsyncSession, start: datetime, end: datetime
+) -> list[tuple[str, int]]:
+    result = await session.execute(
+        select(OrderItem.name_snapshot, func.sum(OrderItem.qty).label("qty"))
+        .join(Order, Order.id == OrderItem.order_id)
+        .where(Order.placed_at >= start, Order.placed_at <= end)
+        .group_by(OrderItem.name_snapshot)
+        .order_by(desc("qty"))
+        .limit(5)
+    )
+    return [(name, int(qty)) for name, qty in result.all()]
+
+
+async def _comps_count(session: AsyncSession, start: datetime, end: datetime) -> int:
+    result = await session.scalar(
+        select(func.count())
+        .select_from(OrderItem)
+        .join(Order, Order.id == OrderItem.order_id)
+        .where(
+            Order.placed_at >= start,
+            Order.placed_at <= end,
+            OrderItem.price_snapshot == 0,
+        )
+    )
+    return int(result or 0)
+
+
+async def _tips_total(session: AsyncSession, start: datetime, end: datetime) -> float:
+    result = await session.scalar(
+        select(func.coalesce(func.sum(Invoice.tip), 0)).where(
+            Invoice.created_at >= start, Invoice.created_at <= end
+        )
+    )
+    return float(result or 0)
+
+
+def _breaker_opens() -> int:
+    url = os.getenv("METRICS_URL")
+    if not url:
+        base = os.getenv("PROXY_URL", "http://localhost:80").rstrip("/")
+        url = f"{base}/metrics"
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+    except Exception:
+        return 0
+    lines = resp.text.splitlines()
+    return sum(
+        1
+        for line in lines
+        if line.startswith("webhook_breaker_state") and line.strip().endswith(" 1")
+    )
+
+
+async def main(
+    tenant: str,
+    date_str: str | None = None,
+    providers: Iterable[str] | None = None,
+) -> str:
+    """Compute digest for ``tenant``/``date`` and send via ``providers``.
+
+    Returns the formatted digest line.
+    """
+    if date_str is None:
+        tz = os.getenv("DEFAULT_TZ", "UTC")
+        today = datetime.now(ZoneInfo(tz)).date()
+        day = today - timedelta(days=1)
+    else:
+        day = datetime.strptime(date_str, "%Y-%m-%d").date()
+
+    line = await build_digest_line(tenant, day)
+
+    for name in providers or ("console", "whatsapp", "email"):
+        provider = PROVIDERS.get(name)
+        if provider:
+            provider.send(line)
+    return line
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="Send a daily owner digest")
+    parser.add_argument("--tenant", required=True, help="Tenant identifier")
+    parser.add_argument("--date", help="Date in YYYY-MM-DD; defaults to yesterday")
+    args = parser.parse_args()
+    asyncio.run(main(args.tenant, args.date))
+
+
+if __name__ == "__main__":
+    _cli()

--- a/tests/test_owner_digest_cli.py
+++ b/tests/test_owner_digest_cli.py
@@ -1,0 +1,128 @@
+import importlib.util
+import os
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "api"))
+
+from app import models_tenant  # type: ignore
+from app.db.tenant import get_engine  # type: ignore
+from app.models_tenant import Invoice, Order, OrderItem, OrderStatus, Payment
+
+from tests._seed_tenant import seed_minimal_menu  # type: ignore
+
+os.environ.setdefault(
+    "POSTGRES_TENANT_DSN_TEMPLATE", "sqlite+aiosqlite:///./tenant_{tenant_id}.db"
+)
+os.environ.setdefault("DEFAULT_TZ", "UTC")
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+async def tenant_setup(tmp_path):
+    tenant_id = "test_owner_digest"
+    dsn = f"sqlite+aiosqlite:///{tmp_path}/tenant_{tenant_id}.db"
+    os.environ["POSTGRES_TENANT_DSN_TEMPLATE"] = dsn.replace(tenant_id, "{tenant_id}")
+    engine = get_engine(tenant_id)
+    async with engine.begin() as conn:
+        await conn.run_sync(models_tenant.Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    try:
+        async with Session() as session:
+            ids = await seed_minimal_menu(session)
+            order = Order(
+                table_id=str(ids["table_id"]),
+                status=OrderStatus.CONFIRMED,
+                placed_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                served_at=datetime(2024, 1, 1, 0, 5, tzinfo=timezone.utc),
+            )
+            session.add(order)
+            await session.flush()
+            oi1 = OrderItem(
+                order_id=order.id,
+                item_id=ids["veg_item_id"],
+                name_snapshot="Veg Item",
+                price_snapshot=100,
+                qty=2,
+                status="SERVED",
+            )
+            oi2 = OrderItem(
+                order_id=order.id,
+                item_id=ids["non_veg_item_id"],
+                name_snapshot="Non-Veg Item",
+                price_snapshot=150,
+                qty=1,
+                status="SERVED",
+            )
+            oi3 = OrderItem(
+                order_id=order.id,
+                item_id=ids["veg_item_id"],
+                name_snapshot="Free Item",
+                price_snapshot=0,
+                qty=1,
+                status="SERVED",
+            )
+            session.add_all([oi1, oi2, oi3])
+            invoice = Invoice(
+                order_group_id=order.id,
+                number="INV1",
+                bill_json={"subtotal": 350.0, "tax_breakup": {}, "total": 360.0},
+                tip=10.0,
+                total=360.0,
+                created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+            session.add(invoice)
+            await session.flush()
+            p1 = Payment(
+                invoice_id=invoice.id,
+                mode="cash",
+                amount=160.0,
+                verified=True,
+                created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+            p2 = Payment(
+                invoice_id=invoice.id,
+                mode="upi",
+                amount=200.0,
+                verified=True,
+                created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+            session.add_all([p1, p2])
+            await session.commit()
+        yield tenant_id
+    finally:
+        await engine.dispose()
+        db_path = engine.url.database
+        if db_path and os.path.exists(db_path):
+            os.remove(db_path)
+
+
+@pytest.mark.anyio
+async def test_owner_digest_line(tenant_setup, monkeypatch, capsys):
+    tenant_id = tenant_setup
+    spec = importlib.util.spec_from_file_location(
+        "owner_digest", "scripts/owner_digest.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    monkeypatch.setattr(module, "_breaker_opens", lambda: 3)
+
+    await module.main(tenant_id, "2024-01-01", providers=("console",))
+    captured = capsys.readouterr()
+    expected = (
+        "2024-01-01 | orders=1 | avg_prep=5.00m | "
+        "top_items=Veg Item(2), Non-Veg Item(1), Free Item(1) | "
+        "comps=1 | tips=10.00 | breaker_opens=3"
+    )
+    assert captured.out.strip() == expected


### PR DESCRIPTION
## Summary
- add owner digest script printing orders, prep time, popular items, comps, tips and breaker opens
- document owner digest usage and nightly cron example

## Testing
- `pytest tests/test_owner_digest_cli.py`
- `pytest tests` *(fails: test_logging::test_guest_4xx_sampling, test_logging::test_2xx_sampling, test_time_skew::test_time_skew_endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8fa26f94832a9b1145f66d72a314