### PR TITLE
chore(ops): backup smoke + weekly restore drill

### DIFF
--- a/.github/workflows/backup-smoke.yml
+++ b/.github/workflows/backup-smoke.yml
@@ -1,0 +1,23 @@
+name: backup-smoke
+
+on:
+  schedule:
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+jobs:
+  restore:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y age postgresql-client
+      - name: Run backup smoke
+        env:
+          POSTGRES_URL: ${{ secrets.POSTGRES_URL_STAGING }}
+          BACKUP_PUBLIC_KEY: ${{ secrets.BACKUP_PUBLIC_KEY_STAGING }}
+          BACKUP_PRIVATE_KEY: ${{ secrets.BACKUP_PRIVATE_KEY_STAGING }}
+        run: |
+          scripts/backup_smoke.sh

--- a/deploy/BACKUP_RESTORE.md
+++ b/deploy/BACKUP_RESTORE.md
@@ -89,3 +89,10 @@ Schedule a weekly check via cron::
 
     0 4 * * 0 python /path/to/scripts/backup_verify.py \
         --file "/var/backups/TENANT-*.sql" --sqlite-tmp /tmp/verify.db
+
+### CI smoke test
+
+`scripts/backup_smoke.sh` exercises the full backup pipeline by dumping the
+primary database, encrypting the SQL with `age`, restoring it into a temporary
+Postgres database, and reporting the encrypted size and timings. The
+`backup-smoke` GitHub workflow runs this weekly against the staging cluster.

--- a/scripts/backup_smoke.sh
+++ b/scripts/backup_smoke.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${POSTGRES_URL:?POSTGRES_URL is required}"
+: "${BACKUP_PUBLIC_KEY:?BACKUP_PUBLIC_KEY is required}"
+: "${BACKUP_PRIVATE_KEY:?BACKUP_PRIVATE_KEY is required}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+DUMP="$TMPDIR/db.sql"
+ENC="$DUMP.age"
+TMP_DB="backup_smoke_$RANDOM"
+BASE="${POSTGRES_URL%/*}"
+ADMIN_URL="$BASE/postgres"
+RESTORE_URL="$BASE/$TMP_DB"
+
+start=$(date +%s)
+pg_dump "$POSTGRES_URL" > "$DUMP"
+age --encrypt -r "$BACKUP_PUBLIC_KEY" -o "$ENC" "$DUMP"
+dump_time=$(( $(date +%s) - start ))
+size=$(du -h "$ENC" | cut -f1)
+
+psql "$ADMIN_URL" -c "DROP DATABASE IF EXISTS \"$TMP_DB\";" >/dev/null
+psql "$ADMIN_URL" -c "CREATE DATABASE \"$TMP_DB\";" >/dev/null
+
+KEY_FILE="$TMPDIR/key.txt"
+printf '%s' "$BACKUP_PRIVATE_KEY" > "$KEY_FILE"
+start=$(date +%s)
+age --decrypt -i "$KEY_FILE" "$ENC" | psql "$RESTORE_URL" >/dev/null
+restore_time=$(( $(date +%s) - start ))
+
+psql "$ADMIN_URL" -c "DROP DATABASE \"$TMP_DB\";" >/dev/null
+
+echo "size=$size dump_time=${dump_time}s restore_time=${restore_time}s"


### PR DESCRIPTION
## Summary
- add backup_smoke.sh to exercise dump, encrypt, and restore
- schedule weekly backup-smoke workflow for staging
- document CI restore drill in backup docs

## Testing
- `pre-commit run --files scripts/backup_smoke.sh .github/workflows/backup-smoke.yml deploy/BACKUP_RESTORE.md`
- `pytest tests/test_config.py`
- `pytest tests api/tests --ignore=api/tests/test_slo_metrics.py --ignore=api/tests/test_time_skew.py` *(fails: KeyboardInterrupt with multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8fc2c4e4832a8ddeac355bca6c72