### PR TITLE
feat(integrations): webhook SLA probe + report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
   inclusion of deleted records via ``include_deleted``.
 - Admin endpoints to test webhook destinations and replay webhooks from the
   notification outbox.
+- Admin endpoint to probe webhook SLA, capturing TLS details and latency and
+  storing reports for later review.
 - Webhook rule creation probes target latency and TLS, warning on slow or
   self-signed endpoints.
 - Controlled cancellation flow with `/orders/{id}/void/request` and `/void/approve` endpoints, reversing stock, adjusting invoices and auditing each step.

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -106,6 +106,7 @@ from .routes_admin_privacy import router as admin_privacy_router
 from .routes_admin_qrpack import router as admin_qrpack_router
 from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
+from .routes_admin_webhooks import router as admin_webhooks_router
 from .routes_alerts import router as alerts_router
 from .routes_api_keys import router as api_keys_router
 from .routes_auth_2fa import router as auth_2fa_router
@@ -918,6 +919,7 @@ app.include_router(ready_router)
 app.include_router(help_router)
 app.include_router(support_router)
 app.include_router(admin_support_router)
+app.include_router(admin_webhooks_router)
 app.include_router(slo_router)
 app.include_router(support_bundle_router)
 app.include_router(legal_router)

--- a/api/app/routes_admin_webhooks.py
+++ b/api/app/routes_admin_webhooks.py
@@ -1,0 +1,28 @@
+"""Admin routes for probing webhook destinations."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, HttpUrl
+
+from .auth import User, role_required
+from .utils.responses import ok
+from .utils.webhook_probe import probe_webhook
+
+router = APIRouter()
+
+PROBE_REPORTS: dict[str, dict] = {}
+
+
+class ProbePayload(BaseModel):
+    url: HttpUrl
+
+
+@router.post("/admin/webhooks/probe")
+async def admin_webhook_probe(
+    payload: ProbePayload, user: User = Depends(role_required("super_admin"))
+) -> dict:
+    """Probe ``payload.url`` and store a report for later inspection."""
+    report = await probe_webhook(str(payload.url))
+    PROBE_REPORTS[str(payload.url)] = report
+    return ok(report)

--- a/api/app/routes_alerts.py
+++ b/api/app/routes_alerts.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 
 """Routes for managing alert rules and viewing notification outbox."""
 
-import ssl
-import time
 from contextlib import asynccontextmanager
 
-import httpx
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -18,6 +15,7 @@ from .models_tenant import AlertRule, NotificationOutbox
 from .utils.audit import audit
 from .utils.responses import ok
 from .utils.scrub import scrub_payload
+from .utils.webhook_probe import probe_webhook
 
 router = APIRouter()
 
@@ -42,35 +40,6 @@ async def _session(tenant_id: str):
         await engine.dispose()
 
 
-SLA_MS = 1000
-
-
-async def _probe_webhook(url: str) -> dict:
-    start = time.monotonic()
-    tls_self_signed = False
-    http_code: int | None = None
-    try:
-        async with httpx.AsyncClient(timeout=5) as client:
-            resp = await client.head(url)
-        http_code = resp.status_code
-    except httpx.HTTPError as exc:
-        cause = getattr(exc, "__cause__", None)
-        if isinstance(cause, ssl.SSLCertVerificationError):
-            tls_self_signed = True
-    latency_ms = int((time.monotonic() - start) * 1000)
-    warnings: list[str] = []
-    if latency_ms > SLA_MS:
-        warnings.append("slow")
-    if tls_self_signed:
-        warnings.append("tls_self_signed")
-    return {
-        "latency_ms": latency_ms,
-        "http_code": http_code,
-        "tls_self_signed": tls_self_signed,
-        "warnings": warnings,
-    }
-
-
 @router.post("/api/outlet/{tenant_id}/alerts/rules")
 @audit("create_alert_rule")
 async def create_rule(
@@ -84,7 +53,10 @@ async def create_rule(
         await session.commit()
     result = {"id": rule.id}
     if payload.channel == "webhook":
-        result["probe"] = await _probe_webhook(payload.target)
+        probe = await probe_webhook(payload.target)
+        result["probe"] = probe
+        if probe["warnings"]:
+            result["warning"] = "risky_webhook"
     return ok(result)
 
 

--- a/api/app/utils/webhook_probe.py
+++ b/api/app/utils/webhook_probe.py
@@ -1,0 +1,72 @@
+"""Utilities to probe webhook destinations for SLA compliance."""
+
+from __future__ import annotations
+
+import math
+import ssl
+import time
+from datetime import datetime, timezone
+
+import httpx
+
+from ..security.webhook_egress import is_allowed_url
+
+SLA_MS = 1000
+
+
+async def probe_webhook(url: str) -> dict:
+    """Probe ``url`` and return latency, TLS and status information."""
+    allowed = is_allowed_url(url)
+    warnings: list[str] = []
+    latencies: list[int] = []
+    codes: list[int | None] = []
+    tls_version: str | None = None
+    tls_expires_at: str | None = None
+    tls_self_signed = False
+
+    async with httpx.AsyncClient(timeout=5) as client:
+        for _ in range(3):
+            start = time.monotonic()
+            try:
+                resp = await client.head(url)
+                codes.append(resp.status_code)
+                stream = resp.extensions.get("network_stream")
+                if stream:
+                    ssl_obj = stream.get_extra_info("ssl_object")
+                    if ssl_obj:
+                        tls_version = ssl_obj.version()
+                        cert = ssl_obj.getpeercert()
+                        if cert and "notAfter" in cert:
+                            ts = ssl.cert_time_to_seconds(cert["notAfter"])
+                            tls_expires_at = (
+                                datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+                            )
+            except httpx.HTTPError as exc:
+                codes.append(None)
+                cause = getattr(exc, "__cause__", None)
+                if isinstance(cause, ssl.SSLCertVerificationError):
+                    tls_self_signed = True
+            finally:
+                latencies.append(int((time.monotonic() - start) * 1000))
+
+    if not allowed:
+        warnings.append("ip_not_allowed")
+    if tls_self_signed:
+        warnings.append("tls_self_signed")
+
+    lat_sorted = sorted(latencies)
+    p50 = lat_sorted[len(lat_sorted) // 2]
+    p95_index = max(math.ceil(len(lat_sorted) * 0.95) - 1, 0)
+    p95 = lat_sorted[p95_index]
+    if p95 > SLA_MS:
+        warnings.append("slow")
+    if any(code is None or code >= 400 for code in codes):
+        warnings.append("bad_status")
+
+    return {
+        "tls": {"version": tls_version, "expires_at": tls_expires_at},
+        "latency_ms": {"p50": p50, "p95": p95},
+        "status_codes": codes,
+        "allowed": allowed,
+        "warnings": warnings,
+    }

--- a/api/tests/test_admin_webhook_probe.py
+++ b/api/tests/test_admin_webhook_probe.py
@@ -1,0 +1,61 @@
+import asyncio
+import pathlib
+import sys
+import types
+import os
+
+from httpx import ASGITransport, AsyncClient
+import fakeredis.aioredis
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("DB_URL", "postgresql://localhost/db")
+os.environ.setdefault("REDIS_URL", "redis://localhost")
+os.environ.setdefault("SECRET_KEY", "x" * 32)
+os.environ.setdefault("ALLOWED_ORIGINS", "http://example.com")
+
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("Image"))
+sys.modules.setdefault("PIL.ImageOps", types.ModuleType("ImageOps"))
+
+from api.app.main import app  # noqa: E402
+from api.app.auth import create_access_token  # noqa: E402
+from api.app import routes_admin_webhooks  # noqa: E402
+
+app.state.redis = fakeredis.aioredis.FakeRedis()
+
+
+def test_probe_endpoint_stores_report(monkeypatch):
+    report = {
+        "tls": {"version": "TLSv1.3", "expires_at": None},
+        "latency_ms": {"p50": 10, "p95": 20},
+        "status_codes": [200, 200, 200],
+        "allowed": True,
+        "warnings": [],
+    }
+
+    async def fake_probe(url: str):
+        return report
+
+    monkeypatch.setattr(routes_admin_webhooks, "probe_webhook", fake_probe)
+
+    token = create_access_token({"sub": "admin@example.com", "role": "super_admin"})
+
+    async def _run():
+        async with AsyncClient(
+            transport=ASGITransport(app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/admin/webhooks/probe",
+                json={"url": "https://example.com/hook"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        return resp
+
+    resp = asyncio.run(_run())
+    assert resp.status_code == 200
+    assert resp.json()["data"] == report
+    assert (
+        routes_admin_webhooks.PROBE_REPORTS["https://example.com/hook"]
+        == report
+    )

--- a/docs/ALERTS_PROVIDERS.md
+++ b/docs/ALERTS_PROVIDERS.md
@@ -38,9 +38,12 @@ the `SLACK_WEBHOOK_URL` environment variable.
 
 ## Webhook Targets
 
-Creating an alert rule with `channel` set to `webhook` triggers a quick probe
-of the target URL. The API reports latency and TLS status and warns if the
-destination is slow or uses a self-signed certificate.
+Creating an alert rule with `channel` set to `webhook` triggers a probe of the
+target URL. The API captures TLS details, HTTP status codes and latency
+percentiles and checks the destination against the webhook IP allowlist.
+Use `/admin/webhooks/probe` to preflight URLs and store these reports. Any
+warnings (slow, invalid status, self-signed or blocked IPs) are surfaced during
+registration.
 
 ## Webhook Signing
 


### PR DESCRIPTION
## Summary
- add reusable webhook probe capturing TLS details, latency percentiles and status checks
- expose `/admin/webhooks/probe` to store probe reports
- surface webhook probe warnings during alert rule registration

## Testing
- `pytest api/tests/test_alert_rule_probe.py api/tests/test_admin_webhook_probe.py api/tests/test_webhook_egress.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad8faf0300832abdcd2abd43aa2503