### PR TITLE
feat(ui): owner SLA/ops widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ All notable changes to this project will be documented in this file.
 
   "Request more" link.
 - Track per-route SLO metrics, expose `/admin/ops/slo` endpoint and Grafana dashboard.
+- Owner dashboard includes SLA/ops widget with uptime, webhook success rate,
+  breaker open time, and median KOT prep time.
 
 - Script to bulk seed a large dataset for local scale testing.
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -160,6 +160,7 @@ from .routes_reports import router as reports_router
 from .routes_sandbox_bootstrap import router as sandbox_bootstrap_router
 from .routes_security import router as security_router
 from .routes_slo import router as slo_router
+from .routes_admin_ops import router as admin_ops_router
 from .routes_staff import router as staff_router
 from .routes_support import router as support_router
 from .routes_support_bundle import router as support_bundle_router
@@ -890,6 +891,7 @@ app.include_router(counter_admin_router)
 app.include_router(staff_router)
 app.include_router(admin_menu_router)
 app.include_router(slo_router)
+app.include_router(admin_ops_router)
 app.include_router(limits_router)
 app.include_router(menu_import_router)
 app.include_router(alerts_router)

--- a/api/app/routes_admin_ops.py
+++ b/api/app/routes_admin_ops.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import statistics
+import time
+from fastapi import APIRouter, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .routes_preflight import preflight
+from .routes_metrics import (
+    webhook_attempts_total,
+    webhook_failures_total,
+)
+from .db.tenant import get_engine
+from .models_tenant import Order
+from .utils.responses import ok
+
+router = APIRouter()
+
+@router.get("/api/admin/ops/summary")
+async def admin_ops_summary(request: Request) -> dict:
+    """Return uptime and delivery metrics for owners."""
+    pf = await preflight()
+    uptime = pf.get("status")
+
+    attempts = sum(m._value.get() for m in webhook_attempts_total._metrics.values())
+    failures = sum(m._value.get() for m in webhook_failures_total._metrics.values())
+    success_rate = (attempts - failures) / attempts if attempts else 1.0
+
+    redis = getattr(request.app.state, "redis", None)
+    now = int(time.time())
+    open_seconds = 0
+    if redis:
+        for key in await redis.keys("cb:*:until"):
+            until = await redis.get(key)
+            if until:
+                open_seconds += max(0, int(until) - now)
+
+    tenant = request.headers.get("X-Tenant-ID", "demo")
+    engine = get_engine(tenant)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with sessionmaker() as session:
+        rows = await session.execute(
+            select(Order.accepted_at, Order.ready_at).where(
+                Order.accepted_at.isnot(None), Order.ready_at.isnot(None)
+            )
+        )
+        durations = [
+            (ready - accepted).total_seconds()
+            for accepted, ready in rows.all()
+            if accepted and ready
+        ]
+    await engine.dispose()
+    median_prep = statistics.median(durations) if durations else 0.0
+
+    data = {
+        "uptime": uptime,
+        "webhook_success_rate": success_rate,
+        "breaker_open_time": open_seconds,
+        "median_kot_prep_time": median_prep,
+    }
+    return ok(data)

--- a/api/tests/test_admin_ops_summary.py
+++ b/api/tests/test_admin_ops_summary.py
@@ -1,0 +1,64 @@
+import asyncio
+import datetime
+import time
+import pathlib
+import sys
+
+import fakeredis.aioredis
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from api.app import routes_admin_ops
+from api.app.models_tenant import Base, Order, OrderStatus
+from api.app.routes_metrics import webhook_attempts_total, webhook_failures_total
+
+
+def test_admin_ops_summary(tmp_path, monkeypatch):
+    app = FastAPI()
+    app.include_router(routes_admin_ops.router)
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+
+    webhook_attempts_total.labels(destination="x").inc(5)
+    webhook_failures_total.labels(destination="x").inc(1)
+
+    now = int(time.time())
+    asyncio.run(app.state.redis.set("cb:x:until", now + 30))
+
+    async def fake_preflight():
+        return {"status": "ok"}
+
+    monkeypatch.setattr(routes_admin_ops, "preflight", fake_preflight)
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path}/t.db")
+
+    async def init_db():
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+    asyncio.run(init_db())
+
+    async def seed():
+        async with AsyncSession(engine) as session:
+            now_dt = datetime.datetime.utcnow()
+            order = Order(
+                table_id=1,
+                status=OrderStatus.READY,
+                accepted_at=now_dt,
+                ready_at=now_dt + datetime.timedelta(seconds=30),
+            )
+            session.add(order)
+            await session.commit()
+    asyncio.run(seed())
+
+    monkeypatch.setattr(routes_admin_ops, "get_engine", lambda tenant: engine)
+
+    client = TestClient(app)
+    resp = client.get("/api/admin/ops/summary", headers={"X-Tenant-ID": "t1"})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["uptime"] == "ok"
+    assert round(data["webhook_success_rate"], 1) == 0.8
+    assert data["breaker_open_time"] >= 30
+    assert data["median_kot_prep_time"] == 30.0

--- a/pwa/src/components/OpsWidget.jsx
+++ b/pwa/src/components/OpsWidget.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { apiFetch } from '../api'
+
+export default function OpsWidget() {
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    apiFetch('/admin/ops/summary')
+      .then((res) => res.json())
+      .then((json) => setData(json.data))
+      .catch((err) => setError(err.message))
+  }, [])
+
+  if (error) return <p className="text-danger">{error}</p>
+  if (!data) return <p>Loading...</p>
+
+  const pct = (v) => (v * 100).toFixed(1)
+  const seconds = (v) => `${Math.round(v)}s`
+
+  return (
+    <div className="mb-6">
+      <h3 className="text-lg font-semibold mb-2">Ops</h3>
+      <div className="text-sm space-y-1">
+        <div className="flex justify-between"><span>Uptime</span><span>{data.uptime}</span></div>
+        <div className="flex justify-between"><span>Webhook Success</span><span>{pct(data.webhook_success_rate)}%</span></div>
+        <div className="flex justify-between"><span>Breaker Open Time</span><span>{seconds(data.breaker_open_time)}</span></div>
+        <div className="flex justify-between"><span>Median KOT Prep</span><span>{data.median_kot_prep_time ? seconds(data.median_kot_prep_time) : 'N/A'}</span></div>
+      </div>
+    </div>
+  )
+}

--- a/pwa/src/pages/AdminDashboard.jsx
+++ b/pwa/src/pages/AdminDashboard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTheme } from '../contexts/ThemeContext'
 import { apiFetch } from '../api'
 import LimitsUsageWidget from '../components/LimitsUsageWidget'
+import OpsWidget from '../components/OpsWidget'
 
 export default function AdminDashboard() {
   const { logo } = useTheme()
@@ -22,6 +23,7 @@ export default function AdminDashboard() {
       {logo && <img src={logo} alt="Logo" className="h-16 mb-4" />}
       <h2 className="text-xl font-bold mb-4">Admin Dashboard</h2>
       <LimitsUsageWidget />
+      <OpsWidget />
       {loading && <p>Loading...</p>}
       {error && <p className="text-danger">{error}</p>}
       {!loading && !error && (


### PR DESCRIPTION
## Summary
- add `/api/admin/ops/summary` endpoint exposing uptime, webhook metrics, breaker cooldown, and median KOT prep time
- show new Ops widget on owner dashboard
- document the new operations widget in the changelog

## Testing
- `pip install pypdf schemathesis`
- `pytest api/tests/test_admin_ops_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad8fcb1e2c832ab4b41ac7ede62fbf