### PR TITLE
chore(a11y): pa11y CI + minor fixes

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -1,0 +1,24 @@
+name: Pa11y
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  accessibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install Python dependencies
+        run: pip install -r api/requirements.txt
+      - name: Run Pa11y
+        run: |
+          python start_app.py &
+          sleep 5
+          npx pa11y-ci -c pa11y-ci.json

--- a/pa11y-ci.json
+++ b/pa11y-ci.json
@@ -5,8 +5,8 @@
     "screenCapture": "pa11y-screenshots/${TIMESTAMP}.png"
   },
   "urls": [
-    "http://localhost:8000/g/demo/menu",
-    "http://localhost:8000/g/demo/cart",
-    "http://localhost:8000/g/demo/checkout"
+    "http://localhost:8000/guest",
+    "http://localhost:8000/admin",
+    "http://localhost:8000/kds"
   ]
 }

--- a/pwa/src/Admin.jsx
+++ b/pwa/src/Admin.jsx
@@ -21,7 +21,10 @@ export default function Admin() {
   return (
     <div className="p-4">
       {warning && (
-        <div className="mb-4 border border-warning bg-warning p-2 text-white">
+        <div
+          role="alert"
+          className="mb-4 border border-warning bg-warning p-2 text-white"
+        >
           {warning}
         </div>
       )}
@@ -29,7 +32,7 @@ export default function Admin() {
       <div className="mt-4">
         <Link
           to="/admin/troubleshoot"
-          className="text-blue-600 underline hover:text-blue-800"
+          className="text-blue-600 underline hover:text-blue-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
         >
           Troubleshoot common issues
         </Link>

--- a/pwa/src/pages/AdminDashboard.jsx
+++ b/pwa/src/pages/AdminDashboard.jsx
@@ -42,11 +42,17 @@ export default function AdminDashboard() {
           </tbody>
         </table>
       )}
-      <footer className="mt-8 text-sm text-gray-500">
-        <a href="/legal/subprocessors" className="mx-2 hover:underline">
+      <footer className="mt-8 text-sm text-gray-600">
+        <a
+          href="/legal/subprocessors"
+          className="mx-2 hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+        >
           Subprocessors
         </a>
-        <a href="/legal/sla" className="mx-2 hover:underline">
+        <a
+          href="/legal/sla"
+          className="mx-2 hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+        >
           SLA
         </a>
       </footer>

--- a/pwa/src/pages/GuestOrder.jsx
+++ b/pwa/src/pages/GuestOrder.jsx
@@ -74,7 +74,7 @@ export default function GuestOrder() {
           </li>
         ))}
       </ul>
-      <footer className="mt-8 text-sm text-gray-500">
+      <footer className="mt-8 text-sm text-gray-600">
         <a
           href="/legal/privacy"
           className="mx-2 hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
@@ -87,10 +87,16 @@ export default function GuestOrder() {
         >
           Terms
         </a>
-        <a href="/legal/refund" className="mx-2 hover:underline">
+        <a
+          href="/legal/refund"
+          className="mx-2 hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+        >
           Refunds
         </a>
-        <a href="/legal/contact" className="mx-2 hover:underline">
+        <a
+          href="/legal/contact"
+          className="mx-2 hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+        >
           Contact
         </a>
       </footer>

--- a/pwa/src/pages/KitchenDashboard.jsx
+++ b/pwa/src/pages/KitchenDashboard.jsx
@@ -38,6 +38,7 @@ export default function KitchenDashboard() {
     <div className="p-4">
       {printerStale && (
         <div
+          role="alert"
           className="mb-4 rounded bg-red-600 p-2 text-white"
           data-testid="printer-alert"
         >


### PR DESCRIPTION
## Summary
- add pa11y workflow to check guest, admin and KDS interfaces
- wire up pa11y-ci config for core entry points
- improve accessibility labels, focus outlines and alerts

## Testing
- `pre-commit run --files pa11y-ci.json .github/workflows/pa11y.yml pwa/src/Admin.jsx pwa/src/pages/GuestOrder.jsx pwa/src/pages/AdminDashboard.jsx pwa/src/pages/KitchenDashboard.jsx`
- `npx --yes pa11y-ci -c pa11y-ci.json` *(fails: Failed to launch the browser process - libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8f9896c0832aace105e0b1d6cb91