### PR TITLE
feat(sec): CSP report-only collector + admin viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Cache last 50 invoice PDFs per outlet for offline review.
+- Collect CSP violation reports via `/csp/report` with paginated admin viewer and query/token redaction.
 - /time/skew endpoint returns server epoch for client clock skew detection.
 - Guard hot queries with a p95 regression check.
 - Enforce environment validation at application startup and audit required

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Per-tenant product analytics can be enabled with tenant consent. See
 
 Owner and admin accounts can enable optional TOTP-based two-factor authentication. See [`docs/auth_2fa.md`](docs/auth_2fa.md) for available endpoints. Sensitive operations like secret rotation, full exports and tenant closure require a fresh step-up verification.
 
-Responses include a strict Content-Security-Policy with per-request nonces applied to inline styles and scripts in printable invoices and KOT pages. HTML pages also emit a `Content-Security-Policy-Report-Only` header directing violation details to `/csp/report`. The endpoint retains the latest 500 reports for 24 hours with any `token` query parameters redacted; administrators can review them at `/admin/csp/reports`.
+Responses include a strict Content-Security-Policy with per-request nonces applied to inline styles and scripts in printable invoices and KOT pages. HTML pages also emit a `Content-Security-Policy-Report-Only` header directing violation details to `/csp/report`. The endpoint retains the latest 500 reports for 24 hours with tokens and query strings stripped; administrators can review paginated results at `/admin/csp/reports`.
 
 Guest-facing order endpoints accept an `Idempotency-Key` header (UUID). Successful responses are cached for 24 hours and the key is recorded in audit logs to guard against duplicate charges.
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -114,7 +114,7 @@ from .routes_backup import router as backup_router
 from .routes_checkout_gateway import router as checkout_router
 from .routes_counter_admin import router as counter_admin_router
 from .routes_counter_guest import router as counter_guest_router
-from .routes_csp import router as csp_router
+from .routes_csp_report import router as csp_router
 from .routes_dashboard import router as dashboard_router
 from .routes_dashboard_charts import router as dashboard_charts_router
 from .routes_daybook_pdf import router as daybook_pdf_router


### PR DESCRIPTION
## Summary
- collect CSP violation reports, stripping tokens and query strings
- expose paginated admin endpoint to review recent reports

## Testing
- `pre-commit run --files CHANGELOG.md README.md api/app/main.py api/app/routes_csp_report.py api/tests/test_csp_reports.py`
- `pytest api/tests/test_csp_reports.py api/tests/test_csp_report_only_header.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad8f17f7f8832aad06c1c07b110c9b