### PR TITLE
dx(rate): standard 429 payloads with retry hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ The API includes a Redis-backed rate limiter that blocks an IP after three conse
 
 Anonymous guest POSTs under `/g/*` are capped at 256KB. When rate limits are
 exceeded, endpoints return HTTP 429 with JSON
-`{"code": "RATE_LIMIT", "message": "TooManyRequests", "hint": "retry in 10s"}`.
+`{"code": "RATE_LIMIT", "hint": "retry in 10s"}`.
 
 ### Idempotency
 
@@ -501,7 +501,7 @@ All HTTP responses follow a simple envelope structure of
 `{"ok": true, "data": ...}` for success or
 `{"ok": false, "error": {"code": ..., "message": ...}}` for failures,
 except rate-limit errors which return
-`{"code": "RATE_LIMIT", "message": "TooManyRequests", "hint": "retry in Xs"}`.
+`{"code": "RATE_LIMIT", "hint": "retry in Xs"}`.
 Prometheus metrics are exposed at `/metrics`. Key metrics include:
 
 - `http_requests_total`: total HTTP requests labelled by path/method/status

--- a/api/app/middlewares/guest_ratelimit.py
+++ b/api/app/middlewares/guest_ratelimit.py
@@ -7,7 +7,7 @@ from starlette.requests import Request
 
 from ..security import ratelimit
 from ..utils import ratelimits
-from ..utils.responses import rate_limited
+from ..utils.rate_limit import rate_limited
 from .guest_utils import _is_guest_post
 
 

--- a/api/app/routes_auth_2fa.py
+++ b/api/app/routes_auth_2fa.py
@@ -22,7 +22,8 @@ from .db import SessionLocal
 from .models_master import TwoFactorBackupCode, TwoFactorSecret
 from .security import ratelimit
 from .utils import ratelimits
-from .utils.responses import ok, rate_limited
+from .utils.responses import ok
+from .utils.rate_limit import rate_limited
 
 router = APIRouter()
 

--- a/api/app/routes_auth_magic.py
+++ b/api/app/routes_auth_magic.py
@@ -16,7 +16,8 @@ from .auth import ALGORITHM, SECRET_KEY, Token, create_access_token
 from .providers import email_stub
 from .security import ratelimit
 from .utils import ratelimits
-from .utils.responses import ok, rate_limited
+from .utils.responses import ok
+from .utils.rate_limit import rate_limited
 
 router = APIRouter()
 

--- a/api/app/routes_export_all.py
+++ b/api/app/routes_export_all.py
@@ -29,7 +29,7 @@ from .models_tenant import (
 from .routes_exports import DEFAULT_LIMIT, SCAN_LIMIT, _session
 from .security import ratelimit
 from .utils import ratelimits
-from .utils.responses import rate_limited
+from .utils.rate_limit import rate_limited
 
 router = APIRouter()
 

--- a/api/app/routes_exports.py
+++ b/api/app/routes_exports.py
@@ -22,7 +22,8 @@ from .pdf.render import render_invoice
 from .repos_sqlalchemy import invoices_repo_sql
 from .security import ratelimit
 from .utils import ratelimits
-from .utils.responses import err, rate_limited
+from .utils.responses import err
+from .utils.rate_limit import rate_limited
 
 router = APIRouter()
 

--- a/api/app/routes_webhook_tools.py
+++ b/api/app/routes_webhook_tools.py
@@ -17,7 +17,8 @@ from .security.webhook_egress import is_allowed_url
 from .security import ratelimit
 from .utils import ratelimits
 from .utils.audit import audit
-from .utils.responses import ok, rate_limited
+from .utils.responses import ok
+from .utils.rate_limit import rate_limited
 from .utils.webhook_signing import sign
 
 router = APIRouter()

--- a/api/app/utils/rate_limit.py
+++ b/api/app/utils/rate_limit.py
@@ -1,0 +1,12 @@
+from fastapi.responses import JSONResponse
+from starlette.status import HTTP_429_TOO_MANY_REQUESTS
+
+
+def rate_limited(retry_after: int) -> JSONResponse:
+    """Return a standardized rate limit response."""
+    hint = f"retry in {max(retry_after, 0)}s"
+    body = {"code": "RATE_LIMIT", "hint": hint}
+    return JSONResponse(body, status_code=HTTP_429_TOO_MANY_REQUESTS)
+
+
+__all__ = ["rate_limited"]

--- a/api/app/utils/responses.py
+++ b/api/app/utils/responses.py
@@ -1,8 +1,5 @@
 from typing import Any, Dict
 
-from fastapi.responses import JSONResponse
-from starlette.status import HTTP_429_TOO_MANY_REQUESTS
-
 
 def ok(data: Any) -> Dict[str, Any]:
     """Return a success envelope."""
@@ -25,10 +22,3 @@ def err(
         error["details"] = details
 
     return {"ok": False, "request_id": request_id_ctx.get(None), "error": error}
-
-
-def rate_limited(retry_after: int) -> JSONResponse:
-    """Return a standardized rate limit response."""
-    hint = f"retry in {max(retry_after, 0)}s"
-    body = {"code": "RATE_LIMIT", "hint": hint}
-    return JSONResponse(body, status_code=HTTP_429_TOO_MANY_REQUESTS)

--- a/docs/guest_rate_limit.md
+++ b/docs/guest_rate_limit.md
@@ -4,7 +4,7 @@
 endpoints. It uses `security.ratelimit.allow` to enforce a limit of 60 requests
 per minute with a burst capacity of 100. When the limit is exceeded, the
 middleware responds with HTTP 429 and JSON
-`{"code": "RATE_LIMIT", "message": "TooManyRequests", "hint": "retry in Xs"}`.
+`{"code": "RATE_LIMIT", "hint": "retry in Xs"}`.
 
 Guest POST bodies are also capped at 256KB; larger payloads trigger a
 `PAYLOAD_TOO_LARGE` (HTTP 413) response.


### PR DESCRIPTION
## Summary
- add rate_limit utility for consistent 429 JSON with retry hints
- use helper across magic link, guest order, exports, and webhook test endpoints
- document RATE_LIMIT payload shape in README and guest rate limit guide

## Testing
- `pytest api/tests/test_auth_magic.py -q`
- `pytest api/tests/test_exports_rate_limit.py -q`
- `pytest api/tests/test_webhook_tools.py -q`
- `pytest api/tests/test_guards_and_limits.py::test_guest_post_rate_limit -q`
- `pytest api/tests/test_export_all.py::test_export_all_bundle -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad8fb2ca40832a979174dbbebe65ca