### PR TITLE
chore(ci): weighted canary ramp + docs

### DIFF
--- a/deploy/blue_green.md
+++ b/deploy/blue_green.md
@@ -1,0 +1,13 @@
+# Blue/green rollouts
+
+The `scripts/weighted_canary_ramp.py` helper gradually shifts traffic from the
+existing stack (blue) to a new stack (green).
+
+```bash
+python scripts/weighted_canary_ramp.py --new neo-green --old neo-blue --base-url https://example.com
+```
+
+Traffic is ramped 5% → 25% → 50% → 100%. After each step the script checks
+`/ready` and verifies error budgets via `/admin/ops/slo`. Any health check
+failure or error budget burn aborts the rollout and restores 100% of traffic to
+the old stack.

--- a/scripts/weighted_canary_ramp.py
+++ b/scripts/weighted_canary_ramp.py
@@ -2,8 +2,10 @@
 """Safer weighted ramp with automatic rollback on failed health checks.
 
 Renders the Nginx upstream from a template and gradually shifts traffic from the
-old stack to the new one at 5%, 25% and 50% weights. If any step fails the
-configuration is reverted to route 100% to the old stack.
+old stack to the new one at 5%, 25%, 50% and finally 100% weights. After each
+step the script performs a readiness probe and verifies that the error budget is
+not being burned. If any check fails the configuration is reverted to route
+100% to the old stack.
 """
 
 from __future__ import annotations
@@ -15,6 +17,8 @@ from pathlib import Path
 from string import Template
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
+import json
+from urllib.request import Request
 
 
 def run(cmd: list[str]) -> None:
@@ -46,6 +50,17 @@ def render_conf(template: Path, dest: Path, new: str, old: str, weight: int) -> 
     run(["sudo", "systemctl", "reload", "nginx"])
 
 
+def check_error_budget(url: str, min_budget: float) -> None:
+    """Abort if any route has less than *min_budget* remaining."""
+    req = Request(url, headers={"Accept": "application/json"})
+    with urlopen(req, timeout=5) as resp:  # noqa: S310 # nosec - controlled URL
+        data = json.load(resp)
+    for route, stats in data.items():
+        budget = float(stats.get("error_budget", 1.0))
+        if budget < min_budget:
+            raise RuntimeError(f"error budget burned for {route}: {budget:.2%}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Weighted ramp with health checks and rollback"
@@ -67,15 +82,22 @@ def main() -> None:
         default="https://example.com",
         help="base URL for health checks",
     )
+    parser.add_argument(
+        "--min-budget",
+        type=float,
+        default=0.99,
+        help="minimum acceptable remaining error budget",
+    )
     args = parser.parse_args()
 
     template = Path(args.template)
     conf = Path(args.nginx_conf)
 
     try:
-        for pct in (5, 25, 50):
+        for pct in (5, 25, 50, 100):
             render_conf(template, conf, args.new, args.old, pct)
             healthcheck(f"{args.base_url}/ready")
+            check_error_budget(f"{args.base_url}/admin/ops/slo", args.min_budget)
     except Exception:
         render_conf(template, conf, args.new, args.old, 0)
         raise


### PR DESCRIPTION
## Summary
- add error budget checks and final 100% step to weighted canary ramp
- document blue/green rollouts with weighted canary ramp

## Testing
- `pytest -q` *(fails: cannot import name 'printer_watchdog')*

------
https://chatgpt.com/codex/tasks/task_e_68ad99c464e0832a9e615508c86697b7