### PR TITLE
feat(pilot): NPS & daily digest

### DIFF
--- a/api/app/routes_pilot_feedback.py
+++ b/api/app/routes_pilot_feedback.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime, time
+
+from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
-from fastapi import APIRouter
 
 
 class PilotFeedbackIn(BaseModel):
     """Incoming NPS feedback from pilot users."""
 
     score: int = Field(..., ge=0, le=10, description="0-10 NPS score")
-    comment: str | None = Field(
-        default=None, description="Optional free-form comment"
+    comment: str | None = Field(default=None, description="Optional free-form comment")
+    contact_opt_in: bool = Field(
+        default=False, description="Consent for follow-up contact"
     )
 
 
@@ -35,3 +37,33 @@ async def submit_pilot_feedback(tenant: str, fb: PilotFeedbackIn) -> dict:
     record = PilotFeedbackRecord(**fb.model_dump(), timestamp=datetime.utcnow())
     PILOT_FEEDBACK_STORE.setdefault(tenant, []).append(record)
     return {"received": True}
+
+
+@router.get("/api/pilot/admin/feedback/summary")
+async def pilot_feedback_summary(
+    from_: date = Query(..., alias="from"),
+    to: date | None = Query(None, alias="to"),
+) -> dict:
+    """Return aggregated score buckets for the given date range."""
+
+    end = to or from_
+    start_dt = datetime.combine(from_, time.min)
+    end_dt = datetime.combine(end, time.max)
+    records = [
+        r
+        for recs in PILOT_FEEDBACK_STORE.values()
+        for r in recs
+        if start_dt <= r.timestamp <= end_dt
+    ]
+    total = len(records)
+    promoters = sum(1 for r in records if r.score >= 9)
+    passives = sum(1 for r in records if 7 <= r.score <= 8)
+    detractors = sum(1 for r in records if r.score <= 6)
+    return {
+        "data": {
+            "promoters": promoters,
+            "passives": passives,
+            "detractors": detractors,
+            "responses": total,
+        }
+    }

--- a/api/tests/test_pilot_feedback.py
+++ b/api/tests/test_pilot_feedback.py
@@ -3,10 +3,12 @@ import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
+from datetime import date
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api.app.routes_pilot_feedback import router, PILOT_FEEDBACK_STORE
+from api.app.routes_pilot_feedback import PILOT_FEEDBACK_STORE, router
 from scripts import pilot_nps_digest
 
 app = FastAPI()
@@ -18,13 +20,18 @@ def setup_module():
     PILOT_FEEDBACK_STORE.clear()
 
 
-def test_submit_and_digest():
-    assert client.post(
-        "/api/pilot/demo/feedback", json={"score": 10}
-    ).status_code == 200
+def test_submit_summary_and_digest():
+    today = date.today().isoformat()
     assert (
         client.post(
-            "/api/pilot/demo/feedback", json={"score": 9, "comment": "great"}
+            "/api/pilot/demo/feedback",
+            json={"score": 10, "contact_opt_in": True},
+        ).status_code
+        == 200
+    )
+    assert (
+        client.post(
+            "/api/pilot/demo/feedback", json={"score": 7, "comment": "ok"}
         ).status_code
         == 200
     )
@@ -34,5 +41,15 @@ def test_submit_and_digest():
         ).status_code
         == 200
     )
+    resp = client.get(f"/api/pilot/admin/feedback/summary?from={today}&to={today}")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data == {
+        "promoters": 1,
+        "passives": 1,
+        "detractors": 1,
+        "responses": 3,
+    }
+
     summary = pilot_nps_digest.build_digest()
-    assert "demo: nps=33.3 count=3" in summary
+    assert "demo: nps=0.0 count=3" in summary

--- a/docs/PILOT_SURVEY.md
+++ b/docs/PILOT_SURVEY.md
@@ -15,5 +15,9 @@ Use this form to collect staff feedback after the pilot.
 - Share a summary with stakeholders after the pilot.
 
 ## API
-Submit NPS feedback via `POST /api/pilot/{tenant}/feedback` with JSON `{"score": 9, "comment": "Great"}`.
-A daily cron runs `scripts/pilot_nps_digest.py` to email NPS summaries per outlet.
+Submit NPS feedback via `POST /api/pilot/{tenant}/feedback` with JSON
+`{"score": 9, "comment": "Great", "contact_opt_in": true}`.
+Review aggregated results with
+`GET /api/pilot/admin/feedback/summary?from=YYYY-MM-DD&to=YYYY-MM-DD`.
+`scripts/pilot_nps_digest.py` emails a daily summary at **20:00 IST** using the
+configured mailer.


### PR DESCRIPTION
## Summary
- capture pilot NPS with optional contact opt-in
- provide admin summary endpoint with NPS score buckets
- send daily pilot NPS digest via existing mailer

## Testing
- `pre-commit run --files api/app/routes_pilot_feedback.py scripts/pilot_nps_digest.py api/tests/test_pilot_feedback.py docs/PILOT_SURVEY.md`
- `pytest api/tests/test_pilot_feedback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad99987948832aa1ff9b6e24f72cae