### PR TITLE
feat(ops): live pilot telemetry dashboard

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -102,8 +102,9 @@ from .obs import capture_exception, init_sentry
 from .obs.logging import configure_logging
 from .otel import init_tracing
 from .routes_admin_menu import router as admin_menu_router
+from .routes_admin_ops import router as admin_ops_router
+from .routes_admin_pilot import router as admin_pilot_router
 from .routes_admin_privacy import router as admin_privacy_router
-from .routes_privacy_dsar import router as privacy_dsar_router
 from .routes_admin_qrpack import router as admin_qrpack_router
 from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
@@ -156,6 +157,7 @@ from .routes_postman import router as postman_router
 from .routes_preflight import router as preflight_router
 from .routes_print import router as print_router
 from .routes_print_bridge import router as print_bridge_router
+from .routes_privacy_dsar import router as privacy_dsar_router
 from .routes_push import router as push_router
 from .routes_pwa_version import router as pwa_version_router
 from .routes_qrpack import router as qrpack_router
@@ -165,17 +167,16 @@ from .routes_reports import router as reports_router
 from .routes_sandbox_bootstrap import router as sandbox_bootstrap_router
 from .routes_security import router as security_router
 from .routes_slo import router as slo_router
-from .routes_admin_ops import router as admin_ops_router
 from .routes_staff import router as staff_router
 from .routes_support import router as support_router
 from .routes_support_bundle import router as support_bundle_router
-from .routes_troubleshoot import router as troubleshoot_router
 from .routes_tables_map import router as tables_map_router
 from .routes_tables_qr_rotate import router as tables_qr_rotate_router
 from .routes_tables_sse import router as tables_sse_router
 from .routes_tenant_close import router as tenant_close_router
 from .routes_tenant_sandbox import router as tenant_sandbox_router
 from .routes_time_skew import router as time_skew_router
+from .routes_troubleshoot import router as troubleshoot_router
 from .routes_vapid import router as vapid_router
 from .routes_version import router as version_router
 from .routes_webhook_tools import router as webhook_tools_router
@@ -924,6 +925,7 @@ app.include_router(checkout_router)
 app.include_router(refunds_router)
 app.include_router(feedback_router)
 app.include_router(pilot_feedback_router)
+app.include_router(admin_pilot_router)
 app.include_router(media_router)
 app.include_router(api_keys_router)
 app.include_router(vapid_router)

--- a/api/app/routes_admin_pilot.py
+++ b/api/app/routes_admin_pilot.py
@@ -1,0 +1,99 @@
+"""Pilot telemetry endpoints."""
+
+from __future__ import annotations
+
+import statistics
+import time
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from .middlewares.logging import latency_samples
+from .routes_metrics import (
+    http_errors_total,
+    http_requests_total,
+    kds_oldest_kot_seconds,
+    orders_created_total,
+    webhook_breaker_state,
+)
+from .utils.responses import ok
+
+router = APIRouter()
+
+_CACHE: dict[str, Any] = {"ts": 0.0, "data": None}
+_LAST_ORDERS_TOTAL: float | None = None
+_LAST_ORDERS_TS: float | None = None
+_CACHE_TTL = 60
+
+
+def _orders_per_min(now: float) -> float:
+    """Compute orders per minute based on counter delta."""
+    global _LAST_ORDERS_TOTAL, _LAST_ORDERS_TS
+    total = orders_created_total._value.get()
+    if _LAST_ORDERS_TOTAL is None or _LAST_ORDERS_TS is None:
+        rate = 0.0
+    else:
+        diff = total - _LAST_ORDERS_TOTAL
+        elapsed = now - _LAST_ORDERS_TS
+        rate = diff / (elapsed / 60) if elapsed > 0 else 0.0
+    _LAST_ORDERS_TOTAL = total
+    _LAST_ORDERS_TS = now
+    return rate
+
+
+def _avg_prep() -> float:
+    """Average prep time from in-memory trackers."""
+    from . import main as main_mod  # local import to avoid circular
+
+    emas = [t.ema for t in main_mod.prep_trackers.values() if t.ema is not None]
+    return float(statistics.mean(emas)) if emas else 0.0
+
+
+def _breaker_open_pct() -> float:
+    metrics = webhook_breaker_state._metrics.values()
+    total = len(metrics)
+    if not total:
+        return 0.0
+    opened = sum(1 for m in metrics if m._value.get() == 1)
+    return (opened / total) * 100.0
+
+
+def _kot_queue_age() -> float:
+    metrics = kds_oldest_kot_seconds._metrics.values()
+    return max((m._value.get() for m in metrics), default=0.0)
+
+
+def _latency_p95() -> float:
+    samples = list(latency_samples)
+    if not samples:
+        return 0.0
+    samples.sort()
+    idx = max(int(len(samples) * 0.95) - 1, 0)
+    return float(samples[idx])
+
+
+def _error_rate() -> float:
+    total = sum(m._value.get() for m in http_requests_total._metrics.values())
+    errors = sum(m._value.get() for m in http_errors_total._metrics.values())
+    return errors / total if total else 0.0
+
+
+@router.get("/api/admin/pilot/telemetry")
+async def pilot_telemetry(_request: Request) -> dict[str, Any]:
+    """Return real-time pilot telemetry with 60s cache."""
+    now = time.time()
+    cached = _CACHE.get("data")
+    if cached and now - _CACHE["ts"] < _CACHE_TTL:
+        return ok(cached)
+
+    data = {
+        "orders_per_min": _orders_per_min(now),
+        "avg_prep": _avg_prep(),
+        "breaker_open_pct": _breaker_open_pct(),
+        "kot_queue_age": _kot_queue_age(),
+        "latency_p95_ms": _latency_p95(),
+        "error_rate": _error_rate(),
+    }
+    _CACHE["ts"] = now
+    _CACHE["data"] = data
+    return ok(data)

--- a/api/tests/test_admin_pilot_telemetry.py
+++ b/api/tests/test_admin_pilot_telemetry.py
@@ -1,0 +1,77 @@
+import os
+import pathlib
+import sys
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("ALLOWED_ORIGINS", "http://example.com")
+os.environ.setdefault("DB_URL", "postgresql://localhost/db")
+os.environ.setdefault("REDIS_URL", "redis://localhost/0")
+os.environ.setdefault("SECRET_KEY", "x" * 32)
+
+import types
+
+from fastapi import FastAPI
+
+from api.app import routes_admin_pilot  # noqa: E402
+from api.app.routes_metrics import orders_created_total  # noqa: E402
+
+sys.modules.setdefault("api.app.main", types.SimpleNamespace(prep_trackers={}))
+app = FastAPI()
+app.include_router(routes_admin_pilot.router)
+
+
+def setup_function() -> None:
+    routes_admin_pilot._CACHE["ts"] = 0.0
+    routes_admin_pilot._CACHE["data"] = None
+    routes_admin_pilot._LAST_ORDERS_TOTAL = None
+    routes_admin_pilot._LAST_ORDERS_TS = None
+    orders_created_total._value.set(0)  # type: ignore[attr-defined]
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+
+
+def test_telemetry_shape():
+    client = TestClient(app)
+    resp = client.get("/api/admin/pilot/telemetry")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert {
+        "orders_per_min",
+        "avg_prep",
+        "breaker_open_pct",
+        "kot_queue_age",
+        "latency_p95_ms",
+        "error_rate",
+    } == set(data.keys())
+
+
+def test_telemetry_cache(monkeypatch):
+    from api.app import routes_admin_pilot
+
+    class DummyTime:
+        def __init__(self):
+            self.now = 0.0
+
+        def time(self):
+            return self.now
+
+    dummy = DummyTime()
+    monkeypatch.setattr(routes_admin_pilot.time, "time", dummy.time)
+
+    client = TestClient(app)
+    resp1 = client.get("/api/admin/pilot/telemetry")
+    data1 = resp1.json()["data"]
+
+    orders_created_total.inc(10)
+    dummy.now = 30
+    resp2 = client.get("/api/admin/pilot/telemetry")
+    assert resp2.json()["data"] == data1
+
+    dummy.now = 100
+    orders_created_total.inc(5)
+    resp3 = client.get("/api/admin/pilot/telemetry")
+    data3 = resp3.json()["data"]
+    assert data3["orders_per_min"] != data1["orders_per_min"]

--- a/pwa/src/components/PilotTelemetryWidget.jsx
+++ b/pwa/src/components/PilotTelemetryWidget.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import { apiFetch } from '../api'
+
+export default function PilotTelemetryWidget() {
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    apiFetch('/admin/pilot/telemetry')
+      .then((res) => res.json())
+      .then((json) => setData(json.data))
+      .catch((err) => setError(err.message))
+  }, [])
+
+  if (error) return <p className="text-danger">{error}</p>
+  if (!data) return <p>Loading...</p>
+
+  const pct = (v) => `${v.toFixed(1)}%`
+  const secs = (v) => `${Math.round(v)}s`
+
+  return (
+    <div className="mb-6">
+      <h3 className="text-lg font-semibold mb-2">Pilot Telemetry</h3>
+      <div className="text-sm space-y-1">
+        <div className="flex justify-between"><span>Orders/min</span><span>{data.orders_per_min.toFixed(1)}</span></div>
+        <div className="flex justify-between"><span>Avg Prep</span><span>{secs(data.avg_prep)}</span></div>
+        <div className="flex justify-between"><span>Breaker Open</span><span>{pct(data.breaker_open_pct)}</span></div>
+        <div className="flex justify-between"><span>KOT Queue Age</span><span>{secs(data.kot_queue_age)}</span></div>
+        <div className="flex justify-between"><span>95p Latency</span><span>{Math.round(data.latency_p95_ms)}ms</span></div>
+        <div className="flex justify-between"><span>Error Rate</span><span>{pct(data.error_rate * 100)}</span></div>
+      </div>
+    </div>
+  )
+}

--- a/pwa/src/pages/AdminDashboard.jsx
+++ b/pwa/src/pages/AdminDashboard.jsx
@@ -3,6 +3,7 @@ import { useTheme } from '../contexts/ThemeContext'
 import { apiFetch } from '../api'
 import LimitsUsageWidget from '../components/LimitsUsageWidget'
 import OpsWidget from '../components/OpsWidget'
+import PilotTelemetryWidget from '../components/PilotTelemetryWidget'
 
 export default function AdminDashboard() {
   const { logo } = useTheme()
@@ -24,6 +25,7 @@ export default function AdminDashboard() {
       <h2 className="text-xl font-bold mb-4">Admin Dashboard</h2>
       <LimitsUsageWidget />
       <OpsWidget />
+      <PilotTelemetryWidget />
       {loading && <p>Loading...</p>}
       {error && <p className="text-danger">{error}</p>}
       {!loading && !error && (


### PR DESCRIPTION
## Summary
- add pilot telemetry endpoint with cached metrics
- display pilot telemetry in admin dashboard
- cover telemetry JSON shape and caching behavior

## Testing
- `pre-commit run --files api/app/middlewares/logging.py api/app/routes_admin_pilot.py api/app/main.py pwa/src/components/PilotTelemetryWidget.jsx pwa/src/pages/AdminDashboard.jsx api/tests/test_admin_pilot_telemetry.py`
- `pytest api/tests/test_admin_pilot_telemetry.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad9993ca48832a8d9f3b7dfcdcba46