### PR TITLE
ci: add GHCR publish workflow

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,31 @@
+name: Push Docker image to GHCR
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          file: ./Dockerfile
+          tags: ghcr.io/${{ github.repository_owner }}/neo-api:latest
+

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -10,9 +10,9 @@ A `trivy` workflow builds the API and worker images and fails if any HIGH or CRI
 
 A nightly `pdf-smoke` workflow renders sample invoice and KOT PDFs for the demo tenant, asserting 200 responses within two seconds and uploading the outputs as build artifacts.
 
-1. **build-and-push** – builds the API and worker images and pushes them to the registry tagged with the commit SHA.
+1. **build-and-push** – builds the API image and pushes it to GitHub Container Registry (GHCR) tagged as `neo-api:latest`.
 2. **deploy-staging** – upgrades the staging environment via Helm, scrubs restored data to purge real PII (fakes names, phones, and emails; clears payment UTRs; rotates table/room/counter QR tokens), audits environment examples, runs `/api/admin/preflight`, smoke and canary probes, `pa11y-ci`, and Playwright smoke tests.
 3. **manual-approval** – requires a human reviewer before production rollout.
 4. **deploy-prod** – performs a blue/green deployment, repeats preflight and smoke/canary checks, and automatically rolls back on failure.
 
-Secrets such as `REGISTRY_*` and `KUBE_CONFIG_*` are required for registry and cluster access.
+KUBE_CONFIG_* secrets are required for cluster access; GHCR authentication uses the provided `GITHUB_TOKEN`.


### PR DESCRIPTION
## Summary
- add workflow to build and push Docker image to GitHub Container Registry
- document GHCR usage in CI/CD guide

## Testing
- `pre-commit run --files .github/workflows/ghcr.yml docs/CI_CD.md`
- `pytest` *(fails: ImportError: cannot import name 'printer_watchdog')*

------
https://chatgpt.com/codex/tasks/task_e_68ad9a9681e4832ab05e7a226628cfb6