### PR TITLE
feat(analytics): multi-outlet summary + CSV

### DIFF
--- a/api/app/routes_owner_aggregate.py
+++ b/api/app/routes_owner_aggregate.py
@@ -4,16 +4,21 @@ from __future__ import annotations
 
 import json
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time, timezone
+from io import StringIO
+from zoneinfo import ZoneInfo
+import csv
+import statistics
 from typing import Iterable
 
-from fastapi import APIRouter, HTTPException, Request, Response
-from sqlalchemy import select
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from .db.replica import read_only, replica_session
 from .db.tenant import get_engine
 from .models_master import Tenant
+from .models_tenant import Invoice, Order, OrderItem
 from .pdf.render import render_template
 from .repos_sqlalchemy import dashboard_repo_sql, invoices_repo_sql
 
@@ -53,6 +58,121 @@ def _parse_scope(request: Request) -> list[str]:
         raise HTTPException(status_code=403, detail="forbidden")
     return [h.strip() for h in header.split(",") if h.strip()]
 
+
+@router.get("/api/analytics/outlets")
+@read_only
+async def analytics_outlets(
+    request: Request,
+    ids: str,
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+    format: str | None = None,
+):
+    tenant_scope = set(_parse_scope(request))
+    requested = [tid.strip() for tid in ids.split(",") if tid.strip()]
+    if not requested:
+        raise HTTPException(status_code=400, detail="ids required")
+    if not set(requested).issubset(tenant_scope):
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    start_date = datetime.strptime(from_, "%Y-%m-%d").date()
+    end_date = datetime.strptime(to, "%Y-%m-%d").date()
+    if start_date > end_date:
+        raise HTTPException(status_code=400, detail="invalid range")
+
+    info = await _get_tenants_info(requested)
+    total_orders = 0
+    total_sales = 0.0
+    top: dict[str, int] = {}
+    durations: list[float] = []
+    per_outlet: list[dict] = []
+
+    for tid in requested:
+        tz = info.get(tid, {}).get("tz", "UTC")
+        tzinfo = ZoneInfo(tz)
+        start_dt = datetime.combine(start_date, time.min, tzinfo).astimezone(timezone.utc)
+        end_dt = datetime.combine(end_date, time.max, tzinfo).astimezone(timezone.utc)
+        async with _session(tid) as session:
+            orders = await session.scalar(
+                select(func.count())
+                .select_from(Order)
+                .where(Order.placed_at >= start_dt, Order.placed_at <= end_dt)
+            )
+            sales = await session.scalar(
+                select(func.coalesce(func.sum(Invoice.total), 0)).where(
+                    Invoice.created_at >= start_dt, Invoice.created_at <= end_dt
+                )
+            )
+            result = await session.execute(
+                select(OrderItem.name_snapshot, func.sum(OrderItem.qty).label("qty"))
+                .join(Order, Order.id == OrderItem.order_id)
+                .where(Order.placed_at >= start_dt, Order.placed_at <= end_dt)
+                .group_by(OrderItem.name_snapshot)
+                .order_by(desc("qty"))
+                .limit(5)
+            )
+            items = [(n, int(q)) for n, q in result.all()]
+            rows = await session.execute(
+                select(Order.accepted_at, Order.ready_at).where(
+                    Order.accepted_at.is_not(None),
+                    Order.ready_at.is_not(None),
+                    Order.accepted_at >= start_dt,
+                    Order.ready_at <= end_dt,
+                )
+            )
+            durs = [
+                (ready - accepted).total_seconds()
+                for accepted, ready in rows.all()
+                if accepted and ready
+            ]
+
+        o = int(orders or 0)
+        s = float(sales or 0.0)
+        total_orders += o
+        total_sales += s
+        for name, qty in items:
+            top[name] = top.get(name, 0) + qty
+        durations.extend(durs)
+        per_outlet.append(
+            {
+                "id": tid,
+                "orders": o,
+                "sales": s,
+                "aov": float(s / o) if o else 0.0,
+                "median_prep": statistics.median(durs) if durs else 0.0,
+            }
+        )
+
+    aov = float(total_sales / total_orders) if total_orders else 0.0
+    top_items = sorted(top.items(), key=lambda x: x[1], reverse=True)[:5]
+    median_prep = statistics.median(durations) if durations else 0.0
+    data = {
+        "orders": total_orders,
+        "sales": total_sales,
+        "aov": aov,
+        "top_items": [{"name": n, "qty": q} for n, q in top_items],
+        "median_prep": median_prep,
+    }
+
+    if format == "csv":
+        output = StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["outlet_id", "orders", "sales", "aov", "median_prep"])
+        for row in per_outlet:
+            writer.writerow(
+                [
+                    row["id"],
+                    row["orders"],
+                    f"{row['sales']:.2f}",
+                    f"{row['aov']:.2f}",
+                    f"{row['median_prep']:.2f}",
+                ]
+            )
+        resp = Response(content=output.getvalue(), media_type="text/csv")
+        resp.headers["Content-Disposition"] = "attachment; filename=outlets.csv"
+        return resp
+
+    return data
 
 @router.get("/api/owner/{owner_id}/dashboard/charts")
 @read_only

--- a/api/tests/test_analytics_outlets.py
+++ b/api/tests/test_analytics_outlets.py
@@ -1,0 +1,187 @@
+import pathlib
+import sys
+from datetime import datetime, timedelta, timezone
+from contextlib import asynccontextmanager
+
+import fakeredis
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy import select
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from api.app import models_tenant
+from api.app.models_tenant import Invoice, Order, OrderItem, OrderStatus, Payment
+from api.app import routes_owner_aggregate
+
+
+async def _seed(amount: float, prep: int) -> tuple[AsyncSession, any]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(models_tenant.Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    session = Session()
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    item_name = "Burger" if amount == 100 else "Fries"
+    for i in range(3):
+        placed = base + timedelta(days=i)
+        order = Order(
+            table_id=1,
+            status=OrderStatus.NEW,
+            placed_at=placed,
+            accepted_at=placed,
+            ready_at=placed + timedelta(seconds=prep),
+        )
+        session.add(order)
+        await session.flush()
+        session.add(
+            OrderItem(
+                order_id=order.id,
+                item_id=1,
+                name_snapshot=item_name,
+                qty=1,
+                price_snapshot=amount - 5,
+                status="served",
+            )
+        )
+        bill = {"subtotal": amount - 5, "tax_breakup": {5: 5}, "total": amount}
+        invoice = Invoice(
+            order_group_id=order.id,
+            number=f"INV{i}",
+            bill_json=bill,
+            gst_breakup=bill["tax_breakup"],
+            total=amount,
+            created_at=placed,
+        )
+        session.add(invoice)
+        await session.flush()
+        session.add(
+            Payment(
+                invoice_id=invoice.id,
+                mode="cash",
+                amount=amount,
+                created_at=placed,
+            )
+        )
+    await session.commit()
+    return session, engine
+
+
+@pytest.fixture
+async def seeded_sessions():
+    s1, e1 = await _seed(100, 600)
+    s2, e2 = await _seed(200, 1200)
+    yield {"t1": s1, "t2": s2}
+    await s1.close()
+    await s2.close()
+    await e1.dispose()
+    await e2.dispose()
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(routes_owner_aggregate.router)
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    return app
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_summary_and_csv(app, seeded_sessions, monkeypatch):
+    @asynccontextmanager
+    async def fake_session(tid: str):
+        yield seeded_sessions[tid]
+
+    async def fake_info(ids):
+        return {tid: {"tz": "UTC"} for tid in ids}
+
+    monkeypatch.setattr(routes_owner_aggregate, "_session", fake_session)
+    monkeypatch.setattr(routes_owner_aggregate, "_get_tenants_info", fake_info)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/analytics/outlets",
+            params={"ids": "t1,t2", "from": "2024-01-01", "to": "2024-01-03"},
+            headers={"x-tenant-ids": "t1,t2"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["orders"] == 6
+        assert data["sales"] == 900.0
+        assert data["aov"] == 150.0
+        assert data["median_prep"] == 900.0
+        assert {"name": "Burger", "qty": 3} in data["top_items"]
+        assert {"name": "Fries", "qty": 3} in data["top_items"]
+
+        resp_csv = await client.get(
+            "/api/analytics/outlets",
+            params={
+                "ids": "t1,t2",
+                "from": "2024-01-01",
+                "to": "2024-01-03",
+                "format": "csv",
+            },
+            headers={"x-tenant-ids": "t1,t2"},
+        )
+        assert resp_csv.headers["content-type"].startswith("text/csv")
+        body = resp_csv.text
+        assert "t1,3,300.00,100.00,600.00" in body
+        assert "t2,3,600.00,200.00,1200.00" in body
+
+
+@pytest.mark.anyio
+async def test_tenant_scope(app, seeded_sessions, monkeypatch):
+    @asynccontextmanager
+    async def fake_session(tid: str):
+        yield seeded_sessions[tid]
+
+    monkeypatch.setattr(routes_owner_aggregate, "_session", fake_session)
+
+    async def fake_info(ids):
+        return {tid: {"tz": "UTC"} for tid in ids}
+
+    monkeypatch.setattr(routes_owner_aggregate, "_get_tenants_info", fake_info)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/analytics/outlets",
+            params={"ids": "t1,t2", "from": "2024-01-01", "to": "2024-01-01"},
+            headers={"x-tenant-ids": "t1"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_date_boundaries(app, seeded_sessions, monkeypatch):
+    @asynccontextmanager
+    async def fake_session(tid: str):
+        yield seeded_sessions[tid]
+
+    monkeypatch.setattr(routes_owner_aggregate, "_session", fake_session)
+
+    async def fake_info(ids):
+        return {tid: {"tz": "UTC"} for tid in ids}
+
+    monkeypatch.setattr(routes_owner_aggregate, "_get_tenants_info", fake_info)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/analytics/outlets",
+            params={"ids": "t1,t2", "from": "2024-01-02", "to": "2024-01-02"},
+            headers={"x-tenant-ids": "t1,t2"},
+        )
+    data = resp.json()
+    assert data["orders"] == 2
+    assert data["sales"] == 300.0
+    assert data["aov"] == 150.0
+    assert data["median_prep"] == 900.0

--- a/docs/owner_analytics.md
+++ b/docs/owner_analytics.md
@@ -24,3 +24,15 @@ The optional ``range`` parameter accepts 7, 30 or 90 days and defaults to 30.
 It returns a time‑series payload exposing D0/D7/D30 retention counts, active
 outlets and average orders per outlet. Results are cached for ten minutes and
 require a ``super_admin`` role bearer token.
+
+## Multi‑outlet summary
+
+Owners may aggregate performance across specific outlets:
+
+```
+GET /api/analytics/outlets?ids=t1,t2&from=YYYY-MM-DD&to=YYYY-MM-DD
+```
+
+The response includes combined orders, sales, average order value, top items
+and median preparation time for the selected outlets. Adding ``format=csv``
+returns a CSV export with per‑outlet metrics.


### PR DESCRIPTION
## Summary
- add `/api/analytics/outlets` to aggregate orders, sales, top items and prep times across outlets with optional CSV export
- document multi-outlet analytics usage for owners
- cover analytics and edge cases with new tests

## Testing
- `python -m pytest api/tests/test_analytics_outlets.py -q`
- `python -m pytest api/tests/test_owner_aggregate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9b429820832a81010dc9a36c9f4f