### PR TITLE
feat(acc): sales register & GST summary exports

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -101,9 +101,10 @@ from .models_tenant import Table
 from .obs import capture_exception, init_sentry
 from .obs.logging import configure_logging
 from .otel import init_tracing
+from .routes_accounting import router as accounting_router
 from .routes_admin_menu import router as admin_menu_router
+from .routes_admin_ops import router as admin_ops_router
 from .routes_admin_privacy import router as admin_privacy_router
-from .routes_privacy_dsar import router as privacy_dsar_router
 from .routes_admin_qrpack import router as admin_qrpack_router
 from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
@@ -157,6 +158,7 @@ from .routes_postman import router as postman_router
 from .routes_preflight import router as preflight_router
 from .routes_print import router as print_router
 from .routes_print_bridge import router as print_bridge_router
+from .routes_privacy_dsar import router as privacy_dsar_router
 from .routes_push import router as push_router
 from .routes_pwa_version import router as pwa_version_router
 from .routes_qrpack import router as qrpack_router
@@ -166,17 +168,16 @@ from .routes_reports import router as reports_router
 from .routes_sandbox_bootstrap import router as sandbox_bootstrap_router
 from .routes_security import router as security_router
 from .routes_slo import router as slo_router
-from .routes_admin_ops import router as admin_ops_router
 from .routes_staff import router as staff_router
 from .routes_support import router as support_router
 from .routes_support_bundle import router as support_bundle_router
-from .routes_troubleshoot import router as troubleshoot_router
 from .routes_tables_map import router as tables_map_router
 from .routes_tables_qr_rotate import router as tables_qr_rotate_router
 from .routes_tables_sse import router as tables_sse_router
 from .routes_tenant_close import router as tenant_close_router
 from .routes_tenant_sandbox import router as tenant_sandbox_router
 from .routes_time_skew import router as time_skew_router
+from .routes_troubleshoot import router as troubleshoot_router
 from .routes_vapid import router as vapid_router
 from .routes_version import router as version_router
 from .routes_webhook_tools import router as webhook_tools_router
@@ -938,6 +939,7 @@ app.include_router(daybook_pdf_router)
 app.include_router(digest_router)
 app.include_router(reports_router)
 app.include_router(csp_router)
+app.include_router(accounting_router)
 app.include_router(gst_monthly_router)
 app.include_router(exports_router)
 app.include_router(export_all_router)

--- a/api/app/routes_accounting.py
+++ b/api/app/routes_accounting.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+"""Accounting export routes."""
+
+import csv
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from io import StringIO
+
+from fastapi import APIRouter, HTTPException, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .db.tenant import get_engine
+from .models_tenant import Invoice
+
+router = APIRouter()
+
+
+@asynccontextmanager
+async def _session(tenant_id: str):
+    """Yield an ``AsyncSession`` for ``tenant_id``."""
+    engine = get_engine(tenant_id)
+    sessionmaker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        await engine.dispose()
+
+
+@router.get("/api/outlet/{tenant_id}/accounting/sales_register.csv")
+async def sales_register_csv(tenant_id: str, start: str, end: str) -> Response:
+    """Return a CSV sales register for the given date range."""
+    try:
+        start_dt = datetime.strptime(start, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        end_dt = datetime.strptime(end, "%Y-%m-%d").replace(
+            tzinfo=timezone.utc
+        ) + timedelta(days=1)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid date") from exc
+    if end_dt <= start_dt:
+        raise HTTPException(status_code=400, detail="invalid range")
+
+    async with _session(tenant_id) as session:
+        rows = (
+            await session.execute(
+                select(
+                    Invoice.number, Invoice.bill_json, Invoice.total, Invoice.created_at
+                )
+                .where(Invoice.created_at >= start_dt, Invoice.created_at < end_dt)
+                .order_by(Invoice.id)
+            )
+        ).all()
+
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["date", "invoice_no", "subtotal", "tax", "total"])
+    for number, bill, total, created_at in rows:
+        subtotal = bill.get("subtotal", 0)
+        tax = sum((bill.get("tax_breakup") or {}).values())
+        writer.writerow(
+            [
+                created_at.date().isoformat(),
+                number,
+                f"{subtotal:.1f}",
+                f"{tax:.1f}",
+                f"{float(total):.1f}",
+            ]
+        )
+
+    resp = Response(content=output.getvalue(), media_type="text/csv")
+    resp.headers["Content-Disposition"] = "attachment; filename=sales_register.csv"
+    return resp
+
+
+@router.get("/api/outlet/{tenant_id}/accounting/gst_summary.csv")
+async def gst_summary_csv(tenant_id: str, start: str, end: str) -> Response:
+    """Return a CSV GST summary for the given date range."""
+    try:
+        start_dt = datetime.strptime(start, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        end_dt = datetime.strptime(end, "%Y-%m-%d").replace(
+            tzinfo=timezone.utc
+        ) + timedelta(days=1)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid date") from exc
+    if end_dt <= start_dt:
+        raise HTTPException(status_code=400, detail="invalid range")
+
+    async with _session(tenant_id) as session:
+        results = (
+            (
+                await session.execute(
+                    select(Invoice.gst_breakup).where(
+                        Invoice.created_at >= start_dt, Invoice.created_at < end_dt
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    summary: dict[str, dict[str, Decimal]] = {}
+    for breakup in results:
+        if not breakup:
+            continue
+        for rate, tax in breakup.items():
+            rate_str = str(rate)
+            tax_val = Decimal(str(tax))
+            taxable = tax_val * Decimal("100") / Decimal(str(rate))
+            entry = summary.setdefault(
+                rate_str,
+                {"taxable": Decimal("0"), "cgst": Decimal("0"), "sgst": Decimal("0")},
+            )
+            half = tax_val / Decimal("2")
+            entry["taxable"] += taxable
+            entry["cgst"] += half
+            entry["sgst"] += half
+
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["gst_rate", "taxable_value", "cgst", "sgst", "total"])
+    for rate in sorted(summary.keys(), key=lambda r: Decimal(r)):
+        vals = summary[rate]
+        total = vals["taxable"] + vals["cgst"] + vals["sgst"]
+        writer.writerow(
+            [
+                rate,
+                f"{vals['taxable']:.1f}",
+                f"{vals['cgst']:.1f}",
+                f"{vals['sgst']:.1f}",
+                f"{total:.1f}",
+            ]
+        )
+
+    resp = Response(content=output.getvalue(), media_type="text/csv")
+    resp.headers["Content-Disposition"] = "attachment; filename=gst_summary.csv"
+    return resp

--- a/docs/EXPORTS.md
+++ b/docs/EXPORTS.md
@@ -83,3 +83,24 @@ python scripts/export_resume.py \
   --cursor abc123
 ```
 
+## Accounting exports
+
+Lightweight CSVs allow hand-off to ledger software without a full integration.
+
+```
+GET /api/outlet/{tenant}/accounting/sales_register.csv?start=YYYY-MM-DD&end=YYYY-MM-DD
+GET /api/outlet/{tenant}/accounting/gst_summary.csv?start=YYYY-MM-DD&end=YYYY-MM-DD
+```
+
+### Importing into Tally
+
+1. Download the relevant CSV export.
+2. In Tally, navigate to **Gateway of Tally → Import Data → Vouchers**.
+3. Choose the CSV file and accept the import prompts.
+
+### Importing into Zoho Books
+
+1. Download the CSV export.
+2. In Zoho Books, go to **Sales → Invoices → More Options → Import Invoices**.
+3. Upload the file and map the columns as prompted.
+


### PR DESCRIPTION
## Summary
- add CSV exports for sales register and GST summaries
- expose accounting routes through main app
- document Tally and Zoho import steps

## Testing
- `pre-commit run --files api/app/routes_accounting.py api/app/main.py docs/EXPORTS.md api/tests/test_reports.py`
- `pytest api/tests/test_reports.py::test_sales_register_csv api/tests/test_reports.py::test_gst_summary_csv`


------
https://chatgpt.com/codex/tasks/task_e_68ad9b6918c4832a8606ec54801acead