### PR TITLE
feat(obs): Web Vitals RUM (consent-gated)

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -163,6 +163,7 @@ from .routes_qrpack import router as qrpack_router
 from .routes_ready import router as ready_router
 from .routes_refunds import router as refunds_router
 from .routes_reports import router as reports_router
+from .routes_rum import router as rum_router
 from .routes_sandbox_bootstrap import router as sandbox_bootstrap_router
 from .routes_security import router as security_router
 from .routes_slo import router as slo_router
@@ -892,6 +893,7 @@ app.include_router(orders_batch_router)
 app.include_router(housekeeping_router)
 app.include_router(hotel_hk_router)
 app.include_router(metrics_router)
+app.include_router(rum_router)
 app.include_router(owner_analytics_router)
 app.include_router(owner_sla_router)
 app.include_router(dashboard_router)

--- a/api/app/routes_rum.py
+++ b/api/app/routes_rum.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Routes for Real User Monitoring (Web Vitals)."""
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from prometheus_client import Histogram
+import uuid
+
+from .deps.tenant import get_tenant_id
+from .db import master
+from .flags import get as get_flag
+from .models_master import Tenant
+from .utils.responses import ok
+
+router = APIRouter(prefix="/rum")
+
+# Histograms for Web Vitals
+lcp_hist = Histogram(
+    "web_vitals_lcp_seconds",
+    "Largest Contentful Paint (s)",
+    ["ctx"],
+    buckets=(0.5, 1, 2.5, 4, 6, 10),
+)
+cls_hist = Histogram(
+    "web_vitals_cls",
+    "Cumulative Layout Shift",
+    ["ctx"],
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2),
+)
+inp_hist = Histogram(
+    "web_vitals_inp_seconds",
+    "Interaction to Next Paint (s)",
+    ["ctx"],
+    buckets=(0.1, 0.25, 0.5, 1, 2.5, 4, 6, 10),
+)
+
+
+class VitalsPayload(BaseModel):
+    ctx: str = "guest"
+    lcp: float | None = None
+    cls: float | None = None
+    inp: float | None = None
+    consent: bool = False
+
+
+async def _analytics_enabled(tenant_id: str) -> bool:
+    try:
+        tid = uuid.UUID(tenant_id)
+    except ValueError:
+        tid = None
+    tenant = None
+    if tid is not None:
+        async with master.get_session() as session:
+            tenant = await session.get(Tenant, tid)
+    return get_flag("analytics", tenant)
+
+
+@router.post("/vitals")
+async def collect_vitals(
+    payload: VitalsPayload,
+    tenant_id: str = Depends(get_tenant_id),
+) -> dict:
+    if not payload.consent or not await _analytics_enabled(tenant_id):
+        return ok({})
+
+    labels = {"ctx": payload.ctx}
+    if payload.lcp is not None:
+        lcp_hist.labels(**labels).observe(payload.lcp)
+    if payload.cls is not None:
+        cls_hist.labels(**labels).observe(payload.cls)
+    if payload.inp is not None:
+        inp_hist.labels(**labels).observe(payload.inp)
+    return ok({})
+
+
+__all__ = ["router"]

--- a/api/tests/test_rum_vitals.py
+++ b/api/tests/test_rum_vitals.py
@@ -1,0 +1,45 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.app.routes_rum as routes_rum
+from api.app.routes_rum import router, lcp_hist
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+
+def _metric_sum() -> float:
+    return lcp_hist.labels(ctx="guest")._sum.get()
+
+
+def test_requires_flag_and_consent(monkeypatch):
+    before = _metric_sum()
+
+    monkeypatch.setattr(routes_rum, "get_flag", lambda name, tenant=None: False)
+    client.post(
+        "/rum/vitals",
+        json={"lcp": 1.2, "consent": True},
+        headers={"X-Tenant-ID": "demo"},
+    )
+    assert _metric_sum() == before
+
+    monkeypatch.setattr(routes_rum, "get_flag", lambda name, tenant=None: True)
+    client.post(
+        "/rum/vitals",
+        json={"lcp": 1.2, "consent": False},
+        headers={"X-Tenant-ID": "demo"},
+    )
+    assert _metric_sum() == before
+
+    client.post(
+        "/rum/vitals",
+        json={"lcp": 1.2, "consent": True},
+        headers={"X-Tenant-ID": "demo"},
+    )
+    assert _metric_sum() == before + 1.2

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -34,3 +34,11 @@ entry is stored.
 Guest opt-ins for analytics and WhatsApp updates are persisted via the `/g/consent`
 endpoint and stored against the customer's record.
 
+## Web Vitals RUM
+
+When the `analytics` feature flag is enabled and a guest or admin has granted
+consent, the PWA reports [Web Vitals](https://web.dev/vitals/) metrics for both
+contexts. Largest Contentful Paint (LCP), Cumulative Layout Shift (CLS) and
+Interaction to Next Paint (INP) are POSTed to `/rum/vitals` and exported as
+Prometheus histograms.
+

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.14.1"
+    "react-router-dom": "^6.14.1",
+    "web-vitals": "^3.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/pwa/src/main.jsx
+++ b/pwa/src/main.jsx
@@ -10,6 +10,9 @@ import ProtectedRoute from './ProtectedRoute'
 import './index.css'
 import { AuthProvider } from './contexts/AuthContext'
 import { ThemeProvider } from './contexts/ThemeContext'
+import { initRUM } from './rum'
+
+initRUM(window.location.pathname.startsWith('/admin') ? 'admin' : 'guest')
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/pwa/src/rum.js
+++ b/pwa/src/rum.js
@@ -1,0 +1,33 @@
+import { onCLS, onINP, onLCP } from 'web-vitals'
+
+export function initRUM(ctx) {
+  let consent = false
+  try {
+    const stored = localStorage.getItem('guestConsent')
+    consent = stored ? JSON.parse(stored).analytics : false
+  } catch (e) {
+    consent = false
+  }
+  if (!consent) return
+
+  const send = (metric) => {
+    const body = {
+      ctx,
+      consent: true,
+    }
+    if (metric.name === 'CLS') body.cls = metric.value
+    else if (metric.name === 'LCP') body.lcp = metric.value / 1000
+    else if (metric.name === 'INP') body.inp = metric.value / 1000
+
+    fetch('/rum/vitals', {
+      method: 'POST',
+      keepalive: true,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  onLCP(send)
+  onCLS(send)
+  onINP(send)
+}


### PR DESCRIPTION
## Summary
- add /rum/vitals endpoint to collect LCP, CLS, and INP behind analytics flag and consent
- capture web vitals in the PWA and report to the API
- document Web Vitals RUM and add coverage tests

## Testing
- `pytest api/tests/test_rum_vitals.py -q`
- `npx prettier --check src/main.jsx src/rum.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad9b644eac832a9b03ffa3b1b965f9