### PR TITLE
chore(ops): weekly encrypted backup restore drill

### DIFF
--- a/deploy/BACKUP_RESTORE.md
+++ b/deploy/BACKUP_RESTORE.md
@@ -94,5 +94,7 @@ Schedule a weekly check via cron::
 
 `scripts/backup_smoke.sh` exercises the full backup pipeline by dumping the
 primary database, encrypting the SQL with `age`, restoring it into a temporary
-Postgres database, and reporting the encrypted size and timings. The
-`backup-smoke` GitHub workflow runs this weekly against the staging cluster.
+Postgres database, and running a basic tenant count query. It reports the
+encrypted size, timings, and row count. The `backup-smoke` GitHub workflow runs
+this weekly against the staging cluster and posts a summary to the workflow
+run.


### PR DESCRIPTION
## Summary
- add tenant count query and step summary to backup smoke drill
- document weekly workflow reporting

## Testing
- `pre-commit run --files scripts/backup_smoke.sh deploy/BACKUP_RESTORE.md`
- `pytest -q` *(fails: cannot import name 'printer_watchdog')*

------
https://chatgpt.com/codex/tasks/task_e_68ad99c834e0832abdcf38ad7d71abae