### PR TITLE
perf(export): chunked CSV with caps + progress

### DIFF
--- a/docs/EXPORTS.md
+++ b/docs/EXPORTS.md
@@ -1,6 +1,8 @@
 # Exports
 
 Big export endpoints support cursor-based pagination so interrupted downloads can resume.
+Each request is capped at **100 000 rows**; when the cap is hit the response includes an
+`X-Row-Limit` header and a `Next-Cursor` value to continue from.
 Export downloads are provided via tenant-scoped, signed URLs to ensure isolation.
 
 ## Owner data export
@@ -82,4 +84,16 @@ python scripts/export_resume.py \
   --output daily.csv \
   --cursor abc123
 ```
+
+## Progress via SSE
+
+Provide a `job` query parameter when starting an export and listen on the
+corresponding progress stream:
+
+```bash
+curl -N http://localhost:8000/api/outlet/demo/exports/daily/progress/abc
+```
+
+The stream emits `progress` events with the number of rows exported and ends
+with a `complete` event.
 


### PR DESCRIPTION
## Summary
- stream export tables directly to CSV to avoid buffering
- cap exports at 100k rows and signal remaining work via `Next-Cursor`
- expose export progress over SSE

## Testing
- `pytest api/tests/test_exports_zip.py::test_daily_export_zip -q`
- `pytest api/tests/test_exports_zip.py::test_range_too_large -q`
- `pytest api/tests/test_exports_zip.py::test_daily_export_cursor -q`
- `pytest api/tests/test_exports_zip.py::test_daily_export_cap_hint -q`
- `pytest api/tests/test_export_streaming.py::test_daily_export_streaming -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9b5c50e8832a93542656c523d18b