### PR TITLE
feat(sec): staff device registry + PIN lockout

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -113,6 +113,7 @@ from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
 from .routes_admin_support_console import router as admin_support_console_router
 from .routes_admin_webhooks import router as admin_webhooks_router
+from .routes_admin_devices import router as admin_devices_router
 from .routes_integrations import router as integrations_router
 from .routes_alerts import router as alerts_router
 from .routes_api_keys import router as api_keys_router
@@ -946,6 +947,7 @@ app.include_router(vapid_router)
 app.include_router(postman_router)
 app.include_router(admin_qrpack_router)
 app.include_router(admin_qrposter_router)
+app.include_router(admin_devices_router)
 
 # Reports domain
 app.include_router(daybook_pdf_router)

--- a/api/app/middlewares/pin_security.py
+++ b/api/app/middlewares/pin_security.py
@@ -13,7 +13,7 @@ from ..audit import log_event
 from ..utils.responses import err
 
 MAX_ATTEMPTS = 5
-LOCK_TTL = 15 * 60  # 15 minutes
+LOCK_TTL = 10 * 60  # 10 minutes
 ROTATE_DAYS = 90
 WARN_DAYS = 80
 

--- a/api/app/models_master.py
+++ b/api/app/models_master.py
@@ -150,6 +150,17 @@ class SupportTicket(Base):
     created_at = Column(DateTime, server_default=func.now())
 
 
+class Device(Base):
+    """Registered staff devices."""
+
+    __tablename__ = "devices"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    fingerprint = Column(String, nullable=False, unique=True)
+    created_at = Column(DateTime, server_default=func.now())
+
+
 __all__ = [
     "Base",
     "Tenant",
@@ -160,4 +171,5 @@ __all__ = [
     "TwoFactorSecret",
     "TwoFactorBackupCode",
     "SupportTicket",
+    "Device",
 ]

--- a/api/app/routes_admin_devices.py
+++ b/api/app/routes_admin_devices.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+
+from .auth import User, role_required
+from .db import SessionLocal
+from .models_master import Device
+from .utils.responses import ok
+from .utils.audit import audit
+from .audit import log_event
+
+router = APIRouter()
+
+
+class DevicePayload(BaseModel):
+    name: str
+    fingerprint: str
+
+
+@router.post("/admin/devices/register")
+@audit("devices.register")
+async def register_device(
+    payload: DevicePayload,
+    user: User = Depends(role_required("super_admin", "manager")),
+) -> dict:
+    with SessionLocal() as session:
+        device = Device(name=payload.name, fingerprint=payload.fingerprint)
+        session.add(device)
+        session.commit()
+        return ok(
+            {
+                "id": device.id,
+                "name": device.name,
+                "fingerprint": device.fingerprint,
+            }
+        )
+
+
+@router.get("/admin/devices")
+@audit("devices.list")
+async def list_devices(
+    user: User = Depends(role_required("super_admin", "manager")),
+) -> dict:
+    with SessionLocal() as session:
+        items = [
+            {"id": d.id, "name": d.name, "fingerprint": d.fingerprint}
+            for d in session.query(Device).all()
+        ]
+    return ok(items)
+
+
+@router.post("/admin/staff/{username}/unlock_pin")
+@audit("staff.unlock_pin")
+async def unlock_pin(
+    username: str,
+    request: Request,
+    user: User = Depends(role_required("super_admin", "manager")),
+) -> dict:
+    redis = request.app.state.redis
+    tenant = request.headers.get("X-Tenant-ID", "demo")
+    async for key in redis.scan_iter(f"pin:lock:{tenant}:{username}:*"):
+        await redis.delete(key)
+    async for key in redis.scan_iter(f"pin:lockstatus:{tenant}:{username}:*"):
+        await redis.delete(key)
+    async for key in redis.scan_iter(f"pin:fail:{tenant}:{username}:*"):
+        await redis.delete(key)
+    log_event(username, "pin_unlock", tenant)
+    return ok(True)
+
+
+__all__ = ["router"]

--- a/api/tests/test_admin_devices.py
+++ b/api/tests/test_admin_devices.py
@@ -1,0 +1,53 @@
+import os
+import pathlib
+import sys
+
+from fastapi.testclient import TestClient
+import fakeredis.aioredis
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("DB_URL", "postgresql://localhost/test")
+os.environ.setdefault("REDIS_URL", "redis://localhost/0")
+os.environ.setdefault("SECRET_KEY", "x" * 32)
+os.environ.setdefault("ALLOWED_ORIGINS", "*")
+
+from api.app.auth import create_access_token
+from api.app.db import SessionLocal
+from api.app.models_master import Device
+from api.app.main import app
+
+client = TestClient(app)
+
+
+def setup_module():
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    with SessionLocal() as session:
+        session.query(Device).delete()
+        session.commit()
+
+
+def test_device_rbac() -> None:
+    admin = create_access_token({"sub": "admin@example.com", "role": "super_admin"})
+    cashier = create_access_token({"sub": "cashier1", "role": "cashier"})
+
+    resp = client.post(
+        "/admin/devices/register",
+        json={"name": "Tab1", "fingerprint": "abc"},
+        headers={"Authorization": f"Bearer {admin}"},
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(
+        "/admin/devices",
+        headers={"Authorization": f"Bearer {admin}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["name"] == "Tab1"
+
+    resp = client.post(
+        "/admin/devices/register",
+        json={"name": "Tab2", "fingerprint": "def"},
+        headers={"Authorization": f"Bearer {cashier}"},
+    )
+    assert resp.status_code == 403

--- a/api/tests/test_pin_lockout.py
+++ b/api/tests/test_pin_lockout.py
@@ -1,0 +1,43 @@
+import asyncio
+import os
+import pathlib
+import sys
+
+from fastapi.testclient import TestClient
+import fakeredis.aioredis
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("DB_URL", "postgresql://localhost/test")
+os.environ.setdefault("REDIS_URL", "redis://localhost/0")
+os.environ.setdefault("SECRET_KEY", "x" * 32)
+os.environ.setdefault("ALLOWED_ORIGINS", "*")
+
+from api.app.auth import User
+from api.app.main import app
+from api.app.routes_admin_devices import unlock_pin
+from starlette.requests import Request
+
+client = TestClient(app)
+
+
+def setup_module():
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+
+
+def test_pin_lockout_and_unlock() -> None:
+    for _ in range(5):
+        client.post("/login/pin", json={"username": "cashier1", "pin": "0000"})
+    resp = client.post("/login/pin", json={"username": "cashier1", "pin": "1234"})
+    assert resp.status_code == 403
+    lock_key = "pin:lock:demo:cashier1:testclient"
+    ttl = asyncio.get_event_loop().run_until_complete(app.state.redis.ttl(lock_key))
+    assert 0 < ttl <= 600
+    req = Request({"type": "http", "app": app, "headers": [], "path": "/admin/staff/cashier1/unlock_pin"})
+    asyncio.get_event_loop().run_until_complete(
+        unlock_pin("cashier1", req, User(username="admin@example.com", role="super_admin"))
+    )
+    exists = asyncio.get_event_loop().run_until_complete(
+        app.state.redis.exists(lock_key)
+    )
+    assert exists == 0

--- a/docs/device_security.md
+++ b/docs/device_security.md
@@ -1,0 +1,23 @@
+# Device Security
+
+## Register Device
+
+`POST /admin/devices/register`
+
+Body: `{ "name": "Front Tablet", "fingerprint": "abc123" }`
+
+Requires a `manager` or `super_admin` token. Adds the device to the registry and
+writes an audit log entry.
+
+## List Devices
+
+`GET /admin/devices`
+
+Returns all registered devices. Requires `manager` or `super_admin` token.
+
+## Unlock PIN
+
+`POST /admin/staff/{username}/unlock_pin`
+
+Clears the PIN lockout state for `username` after too many failed attempts.
+Requires `manager` or `super_admin` token and is audited.

--- a/docs/staff_pin.md
+++ b/docs/staff_pin.md
@@ -16,11 +16,12 @@ member.
 
 ## Login Lockout
 
-Staff PIN logins are locked for **15 minutes** after **5 failed attempts** for
+Staff PIN logins are locked for **10 minutes** after **5 failed attempts** for
 each combination of IP address and staff code. Once locked the endpoint
-responds with `err("AUTH_LOCKED")` and HTTP 403. Unlocking events as well as
-lockouts are written to the audit log. Resetting the PIN via the above endpoint
-also clears any lockout state.
+responds with `err("AUTH_LOCKED")` and HTTP 403. Managers can clear the
+lockout early via `POST /admin/staff/{username}/unlock_pin`. Unlocking events
+as well as lockouts are written to the audit log. Resetting the PIN via the
+above endpoint also clears any lockout state.
 
 ## PIN Rotation
 


### PR DESCRIPTION
## Summary
- register and list staff devices with manager-only endpoints
- enforce 10-minute PIN lockouts and allow manager unlocks

## Testing
- `pytest api/tests/test_pin_lockout.py -q`
- `pytest api/tests/test_admin_devices.py -q`
- `pytest tests/api_contract/test_contract.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad9b4d4e74832a9f029a4e5dced423