### PR TITLE
feat(kds): expo view with aging + hotkeys

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -203,6 +203,7 @@ sys.modules.setdefault("repos_sqlalchemy", app_repos_sqlalchemy)
 sys.modules.setdefault("utils", app_utils)
 kds_router = importlib.import_module(".routes_kds", __package__).router
 kds_sla_router = importlib.import_module(".routes_kds_sla", __package__).router
+kds_expo_router = importlib.import_module(".routes_kds_expo", __package__).router
 superadmin_router = importlib.import_module(".routes_superadmin", __package__).router
 
 
@@ -883,6 +884,7 @@ app.include_router(order_void_router)
 app.include_router(kot_router)
 app.include_router(kds_router)
 app.include_router(kds_sla_router)
+app.include_router(kds_expo_router)
 
 # Admin domain
 app.include_router(counter_admin_router)

--- a/api/app/routes_kds_expo.py
+++ b/api/app/routes_kds_expo.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .deps.tenant import get_tenant_id
+from .domain import OrderStatus
+from .models_tenant import MenuItem, Order, OrderItem, Table
+from .db.tenant import get_engine
+from .utils.responses import ok
+from .utils.audit import audit
+from .routes_kds import _transition_order
+
+router = APIRouter(prefix="/kds")
+
+
+@asynccontextmanager
+async def _session(tenant_id: str):
+    engine = get_engine(tenant_id)
+    sessionmaker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        await engine.dispose()
+
+
+@router.get("/expo")
+async def list_expo(tenant_id: str = Depends(get_tenant_id)) -> dict:
+    async with _session(tenant_id) as session:
+        result = await session.execute(
+            select(
+                Order.id,
+                Table.code,
+                Order.ready_at,
+                MenuItem.allergens,
+            )
+            .join(Table, Order.table_id == Table.id)
+            .join(OrderItem, OrderItem.order_id == Order.id)
+            .join(MenuItem, MenuItem.id == OrderItem.item_id)
+            .where(Order.status == OrderStatus.READY.value)
+            .order_by(Order.ready_at)
+        )
+        rows = result.all()
+
+    now = datetime.now(timezone.utc)
+    tickets: dict[int, dict] = {}
+    for row in rows:
+        info = tickets.setdefault(
+            row.id,
+            {
+                "order_id": row.id,
+                "table": row.code,
+                "ready_at": row.ready_at,
+                "allergen_badges": set(),
+            },
+        )
+        if row.allergens:
+            info["allergen_badges"].update(row.allergens)
+
+    for ticket in tickets.values():
+        ready_at = ticket.pop("ready_at")
+        if ready_at and ready_at.tzinfo is None:
+            ready_at = ready_at.replace(tzinfo=timezone.utc)
+        ticket["age_s"] = (now - ready_at).total_seconds() if ready_at else 0.0
+        ticket["allergen_badges"] = sorted(ticket["allergen_badges"])
+
+    return ok({"tickets": list(tickets.values())})
+
+
+@router.post("/expo/{order_id}/picked")
+@audit("expo.picked")
+async def mark_picked(order_id: int, tenant_id: str = Depends(get_tenant_id)) -> dict:
+    return await _transition_order(tenant_id, order_id, OrderStatus.SERVED)

--- a/docs/kds_routes.md
+++ b/docs/kds_routes.md
@@ -9,12 +9,14 @@ Experimental Kitchen Display System endpoints.
 | POST | /api/outlet/{tenant_id}/kds/order/{order_id}/progress | Move an order to in-progress. |
 | POST | /api/outlet/{tenant_id}/kds/order/{order_id}/ready | Mark an order as ready. |
 | POST | /api/outlet/{tenant_id}/kds/order/{order_id}/serve | Mark an order as served. |
-| POST | /api/outlet/{tenant_id}/kds/order/{order_id}/picked | Mark a ready order as picked up. |
-| GET | /api/outlet/{tenant_id}/kds/expo | List ready tickets with aging and allergen badges. |
+| POST | /kds/expo/{order_id}/picked | Mark a ready order as picked up. |
+| GET | /kds/expo | List ready tickets with aging and allergen badges. |
 | GET | /api/outlet/{tenant_id}/kot/{order_id}.pdf | Printable KOT for an order (PDF/HTML). |
 | GET | /api/outlet/{tenant_id}/print/status | Printer agent heartbeat and retry queue length. |
 
 These endpoints rely on tenant databases and are wired into the main application.
+
+The `/kds/expo` endpoints resolve the tenant via the `X-Tenant-ID` request header.
 
 The queue endpoint returns a payload:
 

--- a/pwa/src/pages/ExpoDashboard.jsx
+++ b/pwa/src/pages/ExpoDashboard.jsx
@@ -4,41 +4,41 @@ import { apiFetch } from '../api'
 
 export default function ExpoDashboard() {
   const { logo } = useTheme()
-  const [orders, setOrders] = useState([])
+  const [tickets, setTickets] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
-  const fetchOrders = () => {
+  const fetchTickets = () => {
     setLoading(true)
     apiFetch('/kds/expo')
       .then((res) => res.json())
       .then((data) => {
-        setOrders(data.orders || [])
+        setTickets(data.tickets || [])
       })
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false))
   }
 
   useEffect(() => {
-    fetchOrders()
+    fetchTickets()
   }, [])
 
   const markPicked = (id) => {
-    apiFetch(`/kds/order/${id}/picked`, { method: 'POST' })
-      .then(() => fetchOrders())
+    apiFetch(`/kds/expo/${id}/picked`, { method: 'POST' })
+      .then(() => fetchTickets())
       .catch((err) => setError(err.message))
   }
 
   useEffect(() => {
     const handler = (e) => {
-      const idx = parseInt(e.key, 10)
-      if (!isNaN(idx) && idx > 0 && idx <= orders.length) {
-        markPicked(orders[idx - 1].id)
+      if (e.key.toLowerCase() === 'p' && tickets.length > 0) {
+        const newest = tickets[tickets.length - 1]
+        markPicked(newest.order_id)
       }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [orders])
+  }, [tickets])
 
   return (
     <div className="p-4">
@@ -48,33 +48,26 @@ export default function ExpoDashboard() {
       {error && <p className="text-danger">{error}</p>}
       {!loading && !error && (
         <ul className="space-y-4">
-          {orders.map((o, idx) => (
-            <li key={o.id} className="border p-2 rounded">
+          {tickets.map((t) => (
+            <li key={t.order_id} className="border p-2 rounded">
               <div className="flex justify-between">
                 <span className="font-semibold">
-                  Table {o.table_code}
-                  {o.allergens.length > 0 && (
+                  Table {t.table}
+                  {t.allergen_badges.length > 0 && (
                     <span className="ml-2 rounded bg-red-100 px-1 text-red-800 text-xs">
                       Allergy
                     </span>
                   )}
                 </span>
                 <span className="text-sm text-gray-600">
-                  {Math.round(o.aging_secs / 60)}m
+                  {Math.round(t.age_s / 60)}m
                 </span>
               </div>
-              <ul className="mt-2 text-sm">
-                {o.items.map((it, i) => (
-                  <li key={i}>
-                    {it.qty} x {it.name}
-                  </li>
-                ))}
-              </ul>
               <button
                 className="mt-2 bg-blue-600 text-white px-2 py-1 rounded"
-                onClick={() => markPicked(o.id)}
+                onClick={() => markPicked(t.order_id)}
               >
-                Picked [{idx + 1}]
+                Picked
               </button>
             </li>
           ))}

--- a/tests/test_kds_expo.py
+++ b/tests/test_kds_expo.py
@@ -1,0 +1,70 @@
+import asyncio
+from datetime import datetime, timezone, timedelta
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.app.routes_kds_expo import router
+from api.app.utils.responses import ok
+from api.app.models_tenant import AuditTenant
+from api.app.db import SessionLocal
+
+
+class DummyResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class Row:
+    def __init__(self, ready_at):
+        self.id = 1
+        self.code = "T1"
+        self.ready_at = ready_at
+        self.allergens = ["nuts"]
+
+
+class DummySession:
+    async def execute(self, *_args, **_kwargs):
+        ready_at = datetime.now(timezone.utc) - timedelta(seconds=30)
+        return DummyResult([Row(ready_at)])
+
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def dummy_session(_tenant_id):
+    yield DummySession()
+
+
+async def fake_transition(tenant_id, order_id, dest):
+    return ok({"status": dest.value})
+
+
+def test_ready_to_picked(monkeypatch):
+    monkeypatch.setattr("api.app.routes_kds_expo._session", dummy_session)
+    monkeypatch.setattr("api.app.routes_kds_expo._transition_order", fake_transition)
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    with SessionLocal() as s:
+        s.query(AuditTenant).delete()
+        s.commit()
+
+    resp = client.get("/kds/expo", headers={"X-Tenant-ID": "t1"})
+    assert resp.status_code == 200
+    tickets = resp.json()["data"]["tickets"]
+    assert tickets[0]["order_id"] == 1
+    assert tickets[0]["allergen_badges"] == ["nuts"]
+
+    resp = client.post("/kds/expo/1/picked", headers={"X-Tenant-ID": "t1"})
+    assert resp.status_code == 200
+
+    with SessionLocal() as s:
+        row = s.query(AuditTenant).filter_by(action="expo.picked").first()
+        assert row is not None
+        assert row.meta["path"] == "/kds/expo/1/picked"


### PR DESCRIPTION
## Summary
- add dedicated KDS expo API with ticket aging and allergen badges
- allow marking expo tickets as picked with auditing
- wire new expo view into frontend with `P` hotkey

## Testing
- `pytest tests/test_kds_expo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ada9c4af6c832a8f7174eaa5bace1b