### PR TITLE
feat(integrations): webhook marketplace stubs + probe

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -102,20 +102,16 @@ from .obs import capture_exception, init_sentry
 from .obs.logging import configure_logging
 from .otel import init_tracing
 from .routes_accounting import router as accounting_router
+from .routes_admin_devices import router as admin_devices_router
 from .routes_admin_menu import router as admin_menu_router
 from .routes_admin_ops import router as admin_ops_router
-
 from .routes_admin_pilot import router as admin_pilot_router
-
 from .routes_admin_privacy import router as admin_privacy_router
 from .routes_admin_qrpack import router as admin_qrpack_router
 from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
 from .routes_admin_support_console import router as admin_support_console_router
 from .routes_admin_webhooks import router as admin_webhooks_router
-from .routes_admin_devices import router as admin_devices_router
-from .routes_print_test import router as print_test_router
-from .routes_integrations import router as integrations_router
 from .routes_alerts import router as alerts_router
 from .routes_api_keys import router as api_keys_router
 from .routes_auth_2fa import router as auth_2fa_router
@@ -144,6 +140,8 @@ from .routes_help import router as help_router
 from .routes_hotel_guest import router as hotel_guest_router
 from .routes_hotel_housekeeping import router as hotel_hk_router
 from .routes_housekeeping import router as housekeeping_router
+from .routes_integrations import router as integrations_router
+from .routes_integrations_marketplace import router as integrations_marketplace_router
 from .routes_invoice_pdf import router as invoice_pdf_router
 from .routes_jobs_status import router as jobs_status_router
 from .routes_kot import router as kot_router
@@ -166,6 +164,7 @@ from .routes_postman import router as postman_router
 from .routes_preflight import router as preflight_router
 from .routes_print import router as print_router
 from .routes_print_bridge import router as print_bridge_router
+from .routes_print_test import router as print_test_router
 from .routes_privacy_dsar import router as privacy_dsar_router
 from .routes_push import router as push_router
 from .routes_pwa_version import router as pwa_version_router
@@ -926,6 +925,7 @@ app.include_router(admin_support_console_router)
 app.include_router(admin_webhooks_router)
 app.include_router(print_test_router)
 app.include_router(integrations_router)
+app.include_router(integrations_marketplace_router)
 app.include_router(slo_router)
 app.include_router(support_bundle_router)
 app.include_router(legal_router)

--- a/api/app/routes_integrations_marketplace.py
+++ b/api/app/routes_integrations_marketplace.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Routes exposing a simple integration marketplace with webhook probes."""
+
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, HttpUrl
+
+from .auth import User, role_required
+from .utils.responses import ok
+from .utils.webhook_probe import probe_webhook
+
+router = APIRouter()
+
+INTEGRATIONS: Dict[str, Dict[str, Any]] = {
+    "google_sheets": {
+        "name": "Google Sheets",
+        "sample_payload": {"event": "row.append", "data": {"cells": ["A", "B"]}},
+    },
+    "slack": {
+        "name": "Slack",
+        "sample_payload": {"text": "Hello from Neo"},
+    },
+    "zoho_books": {
+        "name": "Zoho Books",
+        "sample_payload": {"event": "invoice.paid"},
+    },
+}
+
+TENANT_INTEGRATIONS: Dict[str, Dict[str, Dict[str, Any]]] = {}
+
+
+class ConnectPayload(BaseModel):
+    type: str
+    url: HttpUrl | None = None
+    key: str | None = None
+
+
+@router.get("/api/outlet/{tenant}/integrations/marketplace")
+async def list_marketplace(
+    tenant: str, user: User = Depends(role_required("super_admin"))
+) -> dict:
+    configs = TENANT_INTEGRATIONS.get(tenant, {})
+    items = [
+        {
+            "type": key,
+            "name": cfg["name"],
+            "sample_payload": cfg["sample_payload"],
+            "connected": key in configs,
+        }
+        for key, cfg in INTEGRATIONS.items()
+    ]
+    return ok(items)
+
+
+@router.post("/api/outlet/{tenant}/integrations/connect")
+async def connect_integration(
+    tenant: str,
+    payload: ConnectPayload,
+    user: User = Depends(role_required("super_admin")),
+) -> dict:
+    cfg = INTEGRATIONS.get(payload.type)
+    if not cfg:
+        raise HTTPException(status_code=404, detail="UNKNOWN_INTEGRATION")
+    dest = payload.url or payload.key
+    if dest is None:
+        raise HTTPException(status_code=400, detail="MISSING_DESTINATION")
+    probe_report = None
+    if payload.url:
+        probe_report = await probe_webhook(str(payload.url))
+    TENANT_INTEGRATIONS.setdefault(tenant, {})[payload.type] = {
+        "url": str(payload.url) if payload.url else None,
+        "key": payload.key,
+    }
+    return ok(
+        {
+            "type": payload.type,
+            "config": TENANT_INTEGRATIONS[tenant][payload.type],
+            "probe": probe_report,
+        }
+    )
+
+
+__all__ = ["router", "INTEGRATIONS", "TENANT_INTEGRATIONS"]

--- a/api/tests/test_integrations_marketplace.py
+++ b/api/tests/test_integrations_marketplace.py
@@ -1,0 +1,78 @@
+import asyncio
+import os
+import pathlib
+import sys
+import types
+
+import fakeredis.aioredis
+from httpx import ASGITransport, AsyncClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("DB_URL", "postgresql://localhost/db")
+os.environ.setdefault("REDIS_URL", "redis://localhost")
+os.environ.setdefault("SECRET_KEY", "x" * 32)
+os.environ.setdefault("ALLOWED_ORIGINS", "http://example.com")
+
+sys.modules.setdefault("PIL", types.ModuleType("PIL"))
+sys.modules.setdefault("PIL.Image", types.ModuleType("Image"))
+sys.modules.setdefault("PIL.ImageOps", types.ModuleType("ImageOps"))
+sys.modules.setdefault(
+    "api.app.services.printer_watchdog", types.ModuleType("printer_watchdog")
+)
+
+from api.app import routes_integrations_marketplace  # noqa: E402
+from api.app.auth import create_access_token  # noqa: E402
+from api.app.main import app  # noqa: E402
+
+app.state.redis = fakeredis.aioredis.FakeRedis()
+
+
+def test_list_marketplace():
+    token = create_access_token({"sub": "admin@example.com", "role": "super_admin"})
+
+    async def _run():
+        async with AsyncClient(
+            transport=ASGITransport(app), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/outlet/t1/integrations/marketplace",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        return resp
+
+    resp = asyncio.run(_run())
+    assert resp.status_code == 200
+    types_list = {item["type"] for item in resp.json()["data"]}
+    assert {"google_sheets", "slack", "zoho_books"}.issubset(types_list)
+
+
+def test_connect_integration(monkeypatch):
+    report = {"allowed": True}
+
+    async def fake_probe(url: str):
+        return report
+
+    monkeypatch.setattr(routes_integrations_marketplace, "probe_webhook", fake_probe)
+
+    token = create_access_token({"sub": "admin@example.com", "role": "super_admin"})
+
+    async def _run():
+        async with AsyncClient(
+            transport=ASGITransport(app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/api/outlet/t1/integrations/connect",
+                json={"type": "slack", "url": "https://example.com/hook"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        return resp
+
+    resp = asyncio.run(_run())
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["probe"] == report
+    assert (
+        routes_integrations_marketplace.TENANT_INTEGRATIONS["t1"]["slack"]["url"]
+        == "https://example.com/hook"
+    )

--- a/docs/integrations_marketplace.md
+++ b/docs/integrations_marketplace.md
@@ -1,0 +1,23 @@
+# Integration Marketplace
+
+The API exposes stub endpoints for managing simple webhook integrations per tenant.
+
+## List available integrations
+
+```
+GET /api/outlet/{tenant}/integrations/marketplace
+```
+
+Returns available integration types along with sample payloads and connection status.
+
+## Connect an integration
+
+```
+POST /api/outlet/{tenant}/integrations/connect
+{
+  "type": "slack",
+  "url": "https://example.com/hook"
+}
+```
+
+Validates the URL with a probe and stores the configuration for the tenant.


### PR DESCRIPTION
## Summary
- add integration marketplace endpoints with webhook probe
- wire marketplace routes into main app
- document integration marketplace and add tests

## Testing
- `pre-commit run --files api/app/routes_integrations_marketplace.py api/app/main.py api/tests/test_integrations_marketplace.py docs/integrations_marketplace.md`
- `cd api && pytest tests/test_integrations_marketplace.py`


------
https://chatgpt.com/codex/tasks/task_e_68adabc8e800832a8c7399626bee0715