### PR TITLE
feat(pwa): offline queue + bg sync for orders

### DIFF
--- a/docs/PWA.md
+++ b/docs/PWA.md
@@ -21,6 +21,8 @@ basic offline support.
 * Guest and counter POST requests are queued when offline and replayed via
   background sync with an `Idempotency-Key` header to deduplicate on the
   server.
+* `static/js/bg_sync.js` exposes a `bgSyncPost()` helper to enqueue API
+  requests when offline and flush them once connectivity returns.
 * Invoice PDFs are cached per outlet with an LRU cap of 50 for offline review.
 * Updates are picked up when the service worker changes.
 

--- a/static/js/bg_sync.js
+++ b/static/js/bg_sync.js
@@ -1,0 +1,36 @@
+export async function bgSyncPost(url, options = {}) {
+  const headers = new Headers(options.headers || {})
+  if (!headers.has('content-type')) {
+    headers.set('content-type', 'application/json')
+  }
+  const key =
+    headers.get('Idempotency-Key') ||
+    (globalThis.crypto?.randomUUID
+      ? globalThis.crypto.randomUUID()
+      : Math.random().toString(36).slice(2))
+  headers.set('Idempotency-Key', key)
+  const body =
+    typeof options.body === 'string'
+      ? options.body
+      : JSON.stringify(options.body || {})
+  if (navigator.onLine) {
+    return fetch(url, { method: 'POST', headers, body })
+  }
+  const reg = await navigator.serviceWorker.ready
+  reg.active?.postMessage({
+    type: 'BG_SYNC_ENQUEUE',
+    req: {
+      key,
+      url,
+      method: 'POST',
+      headers: Array.from(headers.entries()),
+      body,
+    },
+  })
+  await reg.sync.register('api-queue')
+  return { queued: true, key }
+}
+
+if (typeof window !== 'undefined') {
+  window.bgSyncPost = bgSyncPost
+}

--- a/static/sw.js
+++ b/static/sw.js
@@ -47,6 +47,14 @@ self.addEventListener('message', event => {
     notifyClients()
     event.waitUntil(self.registration.sync.register('order-queue'))
   }
+  if (event.data?.type === 'BG_SYNC_ENQUEUE') {
+    event.waitUntil(
+      enqueueRequest(event.data.req).then(() =>
+        self.registration.sync.register(API_QUEUE_TAG)
+      )
+    )
+    return
+  }
 });
 
 self.addEventListener('fetch', event => {

--- a/tests/js/bg_sync.test.js
+++ b/tests/js/bg_sync.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { bgSyncPost } from '../../static/js/bg_sync.js'
+
+test('offline enqueue queues request', async () => {
+  const messages = []
+  Object.defineProperty(global, 'navigator', {
+    value: {
+      onLine: false,
+      serviceWorker: {
+        ready: Promise.resolve({
+          active: { postMessage: m => messages.push(m) },
+          sync: { register: tag => messages.push({ tag }) },
+        }),
+      },
+    },
+    configurable: true,
+  })
+  global.fetch = () => {
+    throw new Error('should not fetch offline')
+  }
+  const res = await bgSyncPost('/api/test', { body: { a: 1 } })
+  assert.equal(res.queued, true)
+  assert.ok(res.key)
+  assert.equal(messages[0].type, 'BG_SYNC_ENQUEUE')
+  assert.equal(messages[1].tag, 'api-queue')
+})
+
+test('online fetch bypasses queue', async () => {
+  let called = false
+  Object.defineProperty(global, 'navigator', {
+    value: { onLine: true, serviceWorker: { ready: Promise.resolve({}) } },
+    configurable: true,
+  })
+  global.fetch = async (url, opts) => {
+    called = true
+    assert(opts.headers.get('Idempotency-Key'))
+    return { ok: true }
+  }
+  await bgSyncPost('/api/test', { body: { a: 1 } })
+  assert(called)
+})


### PR DESCRIPTION
## Summary
- add bgSyncPost helper for resilient API POSTs
- wire service worker to store offline API requests and register background sync
- document PWA background sync helper

## Testing
- `node --test tests/js/bg_sync.test.js`
- `pytest tests/test_orders_batch_dedupe.py`

------
https://chatgpt.com/codex/tasks/task_e_68adabc31b5c832aa84afeec113a10a1