### PR TITLE
feat(acc): sales register + GST summary exports

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -101,21 +101,17 @@ from .models_tenant import Table
 from .obs import capture_exception, init_sentry
 from .obs.logging import configure_logging
 from .otel import init_tracing
-from .routes_accounting import router as accounting_router
+from .routes_accounting_exports import router as accounting_exports_router
+from .routes_admin_devices import router as admin_devices_router
 from .routes_admin_menu import router as admin_menu_router
 from .routes_admin_ops import router as admin_ops_router
-
 from .routes_admin_pilot import router as admin_pilot_router
-
 from .routes_admin_privacy import router as admin_privacy_router
 from .routes_admin_qrpack import router as admin_qrpack_router
 from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
 from .routes_admin_support_console import router as admin_support_console_router
 from .routes_admin_webhooks import router as admin_webhooks_router
-from .routes_admin_devices import router as admin_devices_router
-from .routes_print_test import router as print_test_router
-from .routes_integrations import router as integrations_router
 from .routes_alerts import router as alerts_router
 from .routes_api_keys import router as api_keys_router
 from .routes_auth_2fa import router as auth_2fa_router
@@ -144,6 +140,7 @@ from .routes_help import router as help_router
 from .routes_hotel_guest import router as hotel_guest_router
 from .routes_hotel_housekeeping import router as hotel_hk_router
 from .routes_housekeeping import router as housekeeping_router
+from .routes_integrations import router as integrations_router
 from .routes_invoice_pdf import router as invoice_pdf_router
 from .routes_jobs_status import router as jobs_status_router
 from .routes_kot import router as kot_router
@@ -166,6 +163,7 @@ from .routes_postman import router as postman_router
 from .routes_preflight import router as preflight_router
 from .routes_print import router as print_router
 from .routes_print_bridge import router as print_bridge_router
+from .routes_print_test import router as print_test_router
 from .routes_privacy_dsar import router as privacy_dsar_router
 from .routes_push import router as push_router
 from .routes_pwa_version import router as pwa_version_router
@@ -956,7 +954,7 @@ app.include_router(daybook_pdf_router)
 app.include_router(digest_router)
 app.include_router(reports_router)
 app.include_router(csp_router)
-app.include_router(accounting_router)
+app.include_router(accounting_exports_router)
 app.include_router(gst_monthly_router)
 app.include_router(exports_router)
 app.include_router(export_all_router)

--- a/api/app/routes_accounting_exports.py
+++ b/api/app/routes_accounting_exports.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+"""Accounting export routes."""
+
+import csv
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from io import StringIO
+
+from fastapi import APIRouter, HTTPException, Query, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .db.tenant import get_engine
+from .models_tenant import Invoice
+
+router = APIRouter()
+
+
+@asynccontextmanager
+async def _session(tenant_id: str):
+    """Yield an ``AsyncSession`` for ``tenant_id``."""
+    engine = get_engine(tenant_id)
+    sessionmaker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        await engine.dispose()
+
+
+@router.get("/api/outlet/{tenant_id}/accounting/sales_register.csv")
+async def sales_register_csv(
+    tenant_id: str,
+    from_: str = Query(alias="from"),
+    to: str = Query(alias="to"),
+    composition: bool = False,
+) -> Response:
+    """Return a CSV sales register for the given date range."""
+    try:
+        start_dt = datetime.strptime(from_, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        end_dt = datetime.strptime(to, "%Y-%m-%d").replace(
+            tzinfo=timezone.utc
+        ) + timedelta(days=1)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid date") from exc
+    if end_dt <= start_dt:
+        raise HTTPException(status_code=400, detail="invalid range")
+
+    async with _session(tenant_id) as session:
+        rows = (
+            await session.execute(
+                select(
+                    Invoice.number, Invoice.bill_json, Invoice.total, Invoice.created_at
+                )
+                .where(Invoice.created_at >= start_dt, Invoice.created_at < end_dt)
+                .order_by(Invoice.id)
+            )
+        ).all()
+
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["date", "invoice_no", "subtotal", "tax", "total"])
+    for number, bill, total, created_at in rows:
+        subtotal = bill.get("subtotal", 0)
+        if composition:
+            tax = 0
+            grand_total = subtotal
+        else:
+            tax = sum((bill.get("tax_breakup") or {}).values())
+            grand_total = float(total)
+        writer.writerow(
+            [
+                created_at.date().isoformat(),
+                number,
+                f"{subtotal:.1f}",
+                f"{tax:.1f}",
+                f"{grand_total:.1f}",
+            ]
+        )
+
+    resp = Response(content=output.getvalue(), media_type="text/csv")
+    resp.headers["Content-Disposition"] = "attachment; filename=sales_register.csv"
+    return resp
+
+
+@router.get("/api/outlet/{tenant_id}/accounting/gst_summary.csv")
+async def gst_summary_csv(
+    tenant_id: str,
+    from_: str = Query(alias="from"),
+    to: str = Query(alias="to"),
+    composition: bool = False,
+) -> Response:
+    """Return a CSV GST summary for the given date range."""
+    try:
+        start_dt = datetime.strptime(from_, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        end_dt = datetime.strptime(to, "%Y-%m-%d").replace(
+            tzinfo=timezone.utc
+        ) + timedelta(days=1)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid date") from exc
+    if end_dt <= start_dt:
+        raise HTTPException(status_code=400, detail="invalid range")
+
+    async with _session(tenant_id) as session:
+        results = (
+            (
+                await session.execute(
+                    select(Invoice.gst_breakup).where(
+                        Invoice.created_at >= start_dt, Invoice.created_at < end_dt
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    summary: dict[str, dict[str, Decimal]] = {}
+    for breakup in results:
+        if not breakup:
+            continue
+        for rate, tax in breakup.items():
+            rate_str = str(rate)
+            tax_val = Decimal(str(tax))
+            taxable = (
+                tax_val * Decimal("100") / Decimal(str(rate))
+                if not composition
+                else Decimal("0")
+            )
+            entry = summary.setdefault(
+                rate_str,
+                {
+                    "taxable": Decimal("0"),
+                    "cgst": Decimal("0"),
+                    "sgst": Decimal("0"),
+                    "igst": Decimal("0"),
+                },
+            )
+            if composition:
+                entry["taxable"] += taxable
+                continue
+            half = tax_val / Decimal("2")
+            entry["taxable"] += taxable
+            entry["cgst"] += half
+            entry["sgst"] += half
+
+    output = StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["gst_rate", "taxable_value", "cgst", "sgst", "igst", "total"])
+    for rate in sorted(summary.keys(), key=lambda r: Decimal(r)):
+        vals = summary[rate]
+        total = vals["taxable"] + vals["cgst"] + vals["sgst"] + vals["igst"]
+        writer.writerow(
+            [
+                rate,
+                f"{vals['taxable']:.1f}",
+                f"{vals['cgst']:.1f}",
+                f"{vals['sgst']:.1f}",
+                f"{vals['igst']:.1f}",
+                f"{total:.1f}",
+            ]
+        )
+
+    resp = Response(content=output.getvalue(), media_type="text/csv")
+    resp.headers["Content-Disposition"] = "attachment; filename=gst_summary.csv"
+    return resp

--- a/api/tests/test_accounting_exports.py
+++ b/api/tests/test_accounting_exports.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import csv
+import io
+import os
+import pathlib
+import sys
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from api.app import db as app_db
+from api.app import models_tenant, routes_accounting_exports
+
+sys.modules.setdefault("db", app_db)
+os.environ.setdefault(
+    "POSTGRES_TENANT_DSN_TEMPLATE", "sqlite+aiosqlite:///./tenant_{tenant_id}.db"
+)
+from api.app.db.tenant import get_engine
+from api.app.models_tenant import (
+    Category,
+    Invoice,
+    MenuItem,
+    Order,
+    OrderItem,
+    OrderStatus,
+    Payment,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+async def tenant_session() -> AsyncSession:
+    engine = get_engine("demo")
+    async with engine.begin() as conn:
+        await conn.run_sync(models_tenant.Base.metadata.create_all)
+    sessionmaker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        if engine.url.get_backend_name().startswith("sqlite"):
+            await engine.dispose()
+            db_path = engine.url.database
+            if db_path and db_path != ":memory":
+                import os
+
+                if os.path.exists(db_path):
+                    os.remove(db_path)
+        else:
+            async with engine.begin() as conn:
+                await conn.execute(text('DROP SCHEMA IF EXISTS "demo" CASCADE'))
+            await engine.dispose()
+
+
+@pytest.fixture
+async def seeded_session(tenant_session):
+    invoice = Invoice(
+        order_group_id=1,
+        number="INV1",
+        bill_json={"subtotal": 100.0, "tax_breakup": {5: 5.0}, "total": 105.0},
+        total=105.0,
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    tenant_session.add(invoice)
+    await tenant_session.flush()
+    payment = Payment(
+        invoice_id=invoice.id,
+        mode="cash",
+        amount=105.0,
+        verified=True,
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    tenant_session.add(payment)
+    await tenant_session.commit()
+    return tenant_session
+
+
+@pytest.fixture
+async def gst_seeded_session(tenant_session):
+    cat = Category(name="Food", sort=1)
+    tenant_session.add(cat)
+    await tenant_session.flush()
+
+    item1 = MenuItem(
+        category_id=cat.id,
+        name="Item1",
+        price=100,
+        gst_rate=5,
+        hsn_sac="1001",
+        is_veg=False,
+    )
+    item2 = MenuItem(
+        category_id=cat.id,
+        name="Item2",
+        price=200,
+        gst_rate=12,
+        hsn_sac="2002",
+        is_veg=False,
+    )
+    tenant_session.add_all([item1, item2])
+    await tenant_session.flush()
+
+    order = Order(table_id=1, status=OrderStatus.NEW)
+    tenant_session.add(order)
+    await tenant_session.flush()
+
+    oi1 = OrderItem(
+        order_id=order.id,
+        item_id=item1.id,
+        name_snapshot=item1.name,
+        price_snapshot=item1.price,
+        qty=2,
+        status="served",
+    )
+    oi2 = OrderItem(
+        order_id=order.id,
+        item_id=item2.id,
+        name_snapshot=item2.name,
+        price_snapshot=item2.price,
+        qty=1,
+        status="served",
+    )
+    tenant_session.add_all([oi1, oi2])
+    await tenant_session.flush()
+
+    bill = {"subtotal": 400.0, "tax_breakup": {5: 10.0, 12: 24.0}, "total": 434.0}
+    invoice = Invoice(
+        order_group_id=order.id,
+        number="INV1",
+        bill_json=bill,
+        gst_breakup=bill.get("tax_breakup"),
+        total=bill["total"],
+        created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+    )
+    tenant_session.add(invoice)
+    await tenant_session.commit()
+    return tenant_session
+
+
+@pytest.mark.anyio
+async def test_sales_register_csv(seeded_session, monkeypatch):
+    @asynccontextmanager
+    async def fake_session(tenant_id: str):
+        yield seeded_session
+
+    monkeypatch.setattr(routes_accounting_exports, "_session", fake_session)
+
+    app = FastAPI()
+    app.include_router(routes_accounting_exports.router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/outlet/demo/accounting/sales_register.csv?from=2024-01-01&to=2024-01-01"
+        )
+        assert resp.status_code == 200
+        rows = list(csv.reader(io.StringIO(resp.text)))
+        assert rows[0] == ["date", "invoice_no", "subtotal", "tax", "total"]
+        assert rows[1] == ["2024-01-01", "INV1", "100.0", "5.0", "105.0"]
+
+
+@pytest.mark.anyio
+async def test_gst_summary_csv(gst_seeded_session, monkeypatch):
+    @asynccontextmanager
+    async def fake_session(tenant_id: str):
+        yield gst_seeded_session
+
+    monkeypatch.setattr(routes_accounting_exports, "_session", fake_session)
+
+    app = FastAPI()
+    app.include_router(routes_accounting_exports.router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/outlet/demo/accounting/gst_summary.csv?from=2024-01-01&to=2024-01-31"
+        )
+        assert resp.status_code == 200
+        rows = list(csv.reader(io.StringIO(resp.text)))
+        assert rows[0] == [
+            "gst_rate",
+            "taxable_value",
+            "cgst",
+            "sgst",
+            "igst",
+            "total",
+        ]
+        assert rows[1] == ["5", "200.0", "5.0", "5.0", "0.0", "210.0"]
+        assert rows[2] == ["12", "200.0", "12.0", "12.0", "0.0", "224.0"]

--- a/docs/EXPORTS.md
+++ b/docs/EXPORTS.md
@@ -114,8 +114,8 @@ with a `complete` event.
 Lightweight CSVs allow hand-off to ledger software without a full integration.
 
 ```
-GET /api/outlet/{tenant}/accounting/sales_register.csv?start=YYYY-MM-DD&end=YYYY-MM-DD
-GET /api/outlet/{tenant}/accounting/gst_summary.csv?start=YYYY-MM-DD&end=YYYY-MM-DD
+GET /api/outlet/{tenant}/accounting/sales_register.csv?from=YYYY-MM-DD&to=YYYY-MM-DD
+GET /api/outlet/{tenant}/accounting/gst_summary.csv?from=YYYY-MM-DD&to=YYYY-MM-DD
 ```
 
 ### Importing into Tally


### PR DESCRIPTION
## Summary
- expose sales register and GST summary export endpoints using from/to date filters
- document accounting exports and add tests for GST splits

## Testing
- `pre-commit run --files api/app/routes_accounting_exports.py api/app/main.py docs/EXPORTS.md api/tests/test_accounting_exports.py`
- `pytest api/tests/test_accounting_exports.py`


------
https://chatgpt.com/codex/tasks/task_e_68ada9e1f5d0832a8264860373dd3f96