### PR TITLE
feat(ops): pilot telemetry endpoint (cached)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Guard hot queries with a p95 regression check.
 - Enforce environment validation at application startup and audit required
   variables during the CI lint step.
+- Pilot telemetry endpoint exposing ops dashboard metrics (cached 60s).
 - Lock out staff PIN login for 15 minutes after 5 failed attempts per user/IP
   and log lock/unlock events.
 - Require staff PIN rotation every 90 days with a warning emitted after 80 days.

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -102,20 +102,15 @@ from .obs import capture_exception, init_sentry
 from .obs.logging import configure_logging
 from .otel import init_tracing
 from .routes_accounting import router as accounting_router
+from .routes_admin_devices import router as admin_devices_router
 from .routes_admin_menu import router as admin_menu_router
 from .routes_admin_ops import router as admin_ops_router
-
-from .routes_admin_pilot import router as admin_pilot_router
-
 from .routes_admin_privacy import router as admin_privacy_router
 from .routes_admin_qrpack import router as admin_qrpack_router
 from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
 from .routes_admin_support_console import router as admin_support_console_router
 from .routes_admin_webhooks import router as admin_webhooks_router
-from .routes_admin_devices import router as admin_devices_router
-from .routes_print_test import router as print_test_router
-from .routes_integrations import router as integrations_router
 from .routes_alerts import router as alerts_router
 from .routes_api_keys import router as api_keys_router
 from .routes_auth_2fa import router as auth_2fa_router
@@ -144,6 +139,7 @@ from .routes_help import router as help_router
 from .routes_hotel_guest import router as hotel_guest_router
 from .routes_hotel_housekeeping import router as hotel_hk_router
 from .routes_housekeeping import router as housekeeping_router
+from .routes_integrations import router as integrations_router
 from .routes_invoice_pdf import router as invoice_pdf_router
 from .routes_jobs_status import router as jobs_status_router
 from .routes_kot import router as kot_router
@@ -162,10 +158,12 @@ from .routes_owner_aggregate import router as owner_aggregate_router
 from .routes_owner_analytics import router as owner_analytics_router
 from .routes_owner_sla import router as owner_sla_router
 from .routes_pilot_feedback import router as pilot_feedback_router
+from .routes_pilot_telemetry import router as pilot_telemetry_router
 from .routes_postman import router as postman_router
 from .routes_preflight import router as preflight_router
 from .routes_print import router as print_router
 from .routes_print_bridge import router as print_bridge_router
+from .routes_print_test import router as print_test_router
 from .routes_privacy_dsar import router as privacy_dsar_router
 from .routes_push import router as push_router
 from .routes_pwa_version import router as pwa_version_router
@@ -942,7 +940,7 @@ app.include_router(checkout_router)
 app.include_router(refunds_router)
 app.include_router(feedback_router)
 app.include_router(pilot_feedback_router)
-app.include_router(admin_pilot_router)
+app.include_router(pilot_telemetry_router)
 app.include_router(media_router)
 app.include_router(api_keys_router)
 app.include_router(vapid_router)

--- a/pwa/src/components/PilotTelemetryWidget.jsx
+++ b/pwa/src/components/PilotTelemetryWidget.jsx
@@ -23,11 +23,12 @@ export default function PilotTelemetryWidget() {
       <h3 className="text-lg font-semibold mb-2">Pilot Telemetry</h3>
       <div className="text-sm space-y-1">
         <div className="flex justify-between"><span>Orders/min</span><span>{data.orders_per_min.toFixed(1)}</span></div>
-        <div className="flex justify-between"><span>Avg Prep</span><span>{secs(data.avg_prep)}</span></div>
-        <div className="flex justify-between"><span>Breaker Open</span><span>{pct(data.breaker_open_pct)}</span></div>
-        <div className="flex justify-between"><span>KOT Queue Age</span><span>{secs(data.kot_queue_age)}</span></div>
-        <div className="flex justify-between"><span>95p Latency</span><span>{Math.round(data.latency_p95_ms)}ms</span></div>
-        <div className="flex justify-between"><span>Error Rate</span><span>{pct(data.error_rate * 100)}</span></div>
+        <div className="flex justify-between"><span>Avg Prep</span><span>{secs(data.avg_prep_s)}</span></div>
+        <div className="flex justify-between"><span>Breaker Open</span><span>{pct(data.webhook_breaker_open_pct)}</span></div>
+        <div className="flex justify-between"><span>KOT Queue Oldest</span><span>{secs(data.kot_queue_oldest_s)}</span></div>
+        <div className="flex justify-between"><span>95p Latency</span><span>{Math.round(data.p95_latency_ms)}ms</span></div>
+        <div className="flex justify-between"><span>Error Rate</span><span>{pct(data.error_rate_5m * 100)}</span></div>
+        <div className="flex justify-between"><span>SSE Clients</span><span>{data.sse_clients}</span></div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- add cached admin pilot telemetry endpoint with ops metrics
- wire new endpoint into FastAPI app and dashboard widget
- document pilot telemetry endpoint

## Testing
- `pre-commit run --files CHANGELOG.md api/app/main.py api/app/routes_pilot_telemetry.py api/tests/test_pilot_telemetry.py pwa/src/components/PilotTelemetryWidget.jsx`
- `pytest api/tests/test_pilot_telemetry.py`


------
https://chatgpt.com/codex/tasks/task_e_68adabefdc94832a97e6dcaf5504a70f