### PR TITLE
feat(print): enrich test route preview

### DIFF
--- a/api/app/routes_print_test.py
+++ b/api/app/routes_print_test.py
@@ -1,7 +1,7 @@
 """Admin test route for printers."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
 from fastapi import APIRouter, Request
@@ -16,11 +16,13 @@ class PrintTestPayload(BaseModel):
 
 
 @router.post("/admin/print/test")
-async def admin_print_test(payload: PrintTestPayload, request: Request) -> PlainTextResponse:
+async def admin_print_test(
+    payload: PrintTestPayload, request: Request
+) -> PlainTextResponse:
     """Return preview text and publish a test print event."""
-    timestamp = datetime.utcnow().isoformat()
+    timestamp = datetime.now(timezone.utc).isoformat()
     outlet = "demo"
-    title = "test"
+    title = request.app.title
     preview = f"outlet: {outlet}\ntitle: {title}\ntimestamp: {timestamp}\n"
     redis = request.app.state.redis
     await redis.publish(f"print:test:{payload.printer}", preview)

--- a/api/tests/test_print_test_route.py
+++ b/api/tests/test_print_test_route.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import fakeredis.aioredis
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -7,10 +9,12 @@ from api.app.routes_print_test import router
 
 def test_admin_print_test_previews_and_publishes():
     fake = fakeredis.aioredis.FakeRedis()
-    calls = {"count": 0}
+    calls = {"count": 0, "channel": None, "msg": None}
 
     async def fake_publish(channel, msg):
         calls["count"] += 1
+        calls["channel"] = channel
+        calls["msg"] = msg
 
     fake.publish = fake_publish
     app = FastAPI()
@@ -24,4 +28,7 @@ def test_admin_print_test_previews_and_publishes():
     assert "outlet" in body
     assert "title" in body
     assert "timestamp" in body
+    ts_line = next(line for line in body.splitlines() if line.startswith("timestamp:"))
+    datetime.fromisoformat(ts_line.split("timestamp: ", 1)[1])
     assert calls["count"] == 1
+    assert calls["channel"] == "print:test:80mm"

--- a/docs/PRINTING.md
+++ b/docs/PRINTING.md
@@ -29,9 +29,10 @@ browser before sending it to hardware.
 
 ## Admin test route
 
-POST `/admin/print/test` accepts `{"printer": "58mm"|"80mm"}` and returns the
-ESC/POS text used for preview while also publishing a message for connected print
-agents. This helps verify printer connectivity from the dashboard.
+POST `/admin/print/test` accepts `{"printer": "58mm"|"80mm"}` and returns
+preview text containing the outlet name, a title, and a current ISO timestamp
+while also publishing a message for connected print agents. This helps verify
+printer connectivity from the dashboard.
 
 ## Security
 


### PR DESCRIPTION
## Summary
- enrich /admin/print/test preview with app title and ISO timestamp
- verify preview formatting and Redis publish in tests
- document the admin print test route

## Testing
- `pre-commit run --files api/app/routes_print_test.py api/tests/test_print_test_route.py docs/PRINTING.md`
- `PYTHONPATH=. pytest api/tests/test_print_test_route.py::test_admin_print_test_previews_and_publishes -q`


------
https://chatgpt.com/codex/tasks/task_e_68adaca5d230832a894fe65115bcdcb3