### PR TITLE
Add tenant ID header to RUM and validate vitals input

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -41,5 +41,14 @@ consent, the PWA reports [Web Vitals](https://web.dev/vitals/) for each route
 without using any third-party libraries. Largest Contentful Paint (LCP),
 Cumulative Layout Shift (CLS), Interaction to Next Paint (INP) and Time to
 First Byte (TTFB) are POSTed to `/rum/vitals` along with the current route and
-exported as Prometheus histograms.
+exported as Prometheus histograms. Clients **must** include the `X-Tenant-ID`
+header in these requests. The PWA adds this automatically when the
+`VITE_TENANT_ID` build-time variable is set:
+
+```sh
+VITE_TENANT_ID=<tenant> npm run build
+```
+
+The value will be sent as `X-Tenant-ID` in all API calls including the RUM
+endpoint.
 

--- a/pwa/src/rum.js
+++ b/pwa/src/rum.js
@@ -1,3 +1,5 @@
+import { apiFetch } from './api'
+
 export function initRUM() {
   let consent = false
   try {
@@ -45,7 +47,7 @@ export function initRUM() {
   if (nav) metrics.ttfb = nav.responseStart / 1000
 
   const send = () => {
-    fetch('/rum/vitals', {
+    apiFetch('/rum/vitals', {
       method: 'POST',
       keepalive: true,
       headers: { 'Content-Type': 'application/json' },

--- a/tests/test_rum_vitals.py
+++ b/tests/test_rum_vitals.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api.app.main import app
+
+
+def _client() -> TestClient:
+    return TestClient(app)
+
+
+def test_route_whitelist_accept_and_reject():
+    client = _client()
+    # accepted and normalized
+    ok_resp = client.post(
+        "/rum/vitals",
+        headers={"X-Tenant-ID": "tenant"},
+        json={"route": "/admin/foo?x=1", "consent": True},
+    )
+    assert ok_resp.status_code == 200
+
+    # rejected unknown route
+    bad_resp = client.post(
+        "/rum/vitals",
+        headers={"X-Tenant-ID": "tenant"},
+        json={"route": "/evil", "consent": True},
+    )
+    assert bad_resp.status_code == 422
+
+    # rejected long route
+    long_route = "/" + "a" * 65
+    long_resp = client.post(
+        "/rum/vitals",
+        headers={"X-Tenant-ID": "tenant"},
+        json={"route": long_route, "consent": True},
+    )
+    assert long_resp.status_code == 422
+
+
+def test_invalid_vital_values_return_422():
+    client = _client()
+    resp = client.post(
+        "/rum/vitals",
+        headers={"X-Tenant-ID": "tenant"},
+        json={"route": "/admin", "lcp": -1, "consent": True},
+    )
+    assert resp.status_code == 422
+
+    resp2 = client.post(
+        "/rum/vitals",
+        headers={"X-Tenant-ID": "tenant"},
+        json={"route": "/admin", "cls": 3, "consent": True},
+    )
+    assert resp2.status_code == 422


### PR DESCRIPTION
## Summary
- ensure PWA rum reports include X-Tenant-ID via `apiFetch`
- validate and whitelist routes plus bounds for vitals payload
- document tenant header requirement and VITE_TENANT_ID build config

## Testing
- `node -e "import('./api.bundle.mjs').then(({apiFetch})=>{global.fetch=(u,o)=>{console.log('headers',o.headers);return Promise.resolve({});};apiFetch('/rum/vitals',{method:'POST'});});"`
- `pytest tests/test_rum_vitals.py`


------
https://chatgpt.com/codex/tasks/task_e_68adaccbb254832aa9fe0d06118e820b