### PR TITLE
feat(kds): expo view with aging + hotkeys

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -102,20 +102,16 @@ from .obs import capture_exception, init_sentry
 from .obs.logging import configure_logging
 from .otel import init_tracing
 from .routes_accounting import router as accounting_router
+from .routes_admin_devices import router as admin_devices_router
 from .routes_admin_menu import router as admin_menu_router
 from .routes_admin_ops import router as admin_ops_router
-
 from .routes_admin_pilot import router as admin_pilot_router
-
 from .routes_admin_privacy import router as admin_privacy_router
 from .routes_admin_qrpack import router as admin_qrpack_router
 from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
 from .routes_admin_support_console import router as admin_support_console_router
 from .routes_admin_webhooks import router as admin_webhooks_router
-from .routes_admin_devices import router as admin_devices_router
-from .routes_print_test import router as print_test_router
-from .routes_integrations import router as integrations_router
 from .routes_alerts import router as alerts_router
 from .routes_api_keys import router as api_keys_router
 from .routes_auth_2fa import router as auth_2fa_router
@@ -144,6 +140,7 @@ from .routes_help import router as help_router
 from .routes_hotel_guest import router as hotel_guest_router
 from .routes_hotel_housekeeping import router as hotel_hk_router
 from .routes_housekeeping import router as housekeeping_router
+from .routes_integrations import router as integrations_router
 from .routes_invoice_pdf import router as invoice_pdf_router
 from .routes_jobs_status import router as jobs_status_router
 from .routes_kot import router as kot_router
@@ -166,6 +163,7 @@ from .routes_postman import router as postman_router
 from .routes_preflight import router as preflight_router
 from .routes_print import router as print_router
 from .routes_print_bridge import router as print_bridge_router
+from .routes_print_test import router as print_test_router
 from .routes_privacy_dsar import router as privacy_dsar_router
 from .routes_push import router as push_router
 from .routes_pwa_version import router as pwa_version_router
@@ -202,6 +200,7 @@ sys.modules.setdefault("models_tenant", app_models_tenant)
 sys.modules.setdefault("repos_sqlalchemy", app_repos_sqlalchemy)
 sys.modules.setdefault("utils", app_utils)
 kds_router = importlib.import_module(".routes_kds", __package__).router
+kds_expo_router = importlib.import_module(".routes_kds_expo", __package__).router
 kds_sla_router = importlib.import_module(".routes_kds_sla", __package__).router
 superadmin_router = importlib.import_module(".routes_superadmin", __package__).router
 
@@ -882,6 +881,7 @@ app.include_router(order_void_router)
 # KDS/KOT domain
 app.include_router(kot_router)
 app.include_router(kds_router)
+app.include_router(kds_expo_router)
 app.include_router(kds_sla_router)
 
 # Admin domain

--- a/api/app/routes_kds.py
+++ b/api/app/routes_kds.py
@@ -10,18 +10,21 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, HTTPException, Request
-from sqlalchemy import select, update, func
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-
 from db.tenant import get_engine
 from domain import OrderStatus, can_transition
-from models_tenant import MenuItem, Order, OrderItem, Table
+from fastapi import APIRouter, HTTPException, Request
+from models_tenant import Order, OrderItem
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
 from .hooks import order_rejection
-from .services import ema as ema_service, push, whatsapp, notifications
+from .services import ema as ema_service
+from .services import notifications, push, whatsapp
+
 try:  # pragma: no cover - optional watchdog
     from .services import printer_watchdog
 except Exception:  # pragma: no cover - fallback when watchdog unavailable
+
     class _StubWatchdog:
         async def check(self, *_args, **_kwargs):
             return True, 0, 0
@@ -29,9 +32,10 @@ except Exception:  # pragma: no cover - fallback when watchdog unavailable
     printer_watchdog = _StubWatchdog()
 
 from repos_sqlalchemy import orders_repo_sql
-from .routes_metrics import kds_oldest_kot_seconds
-from utils.responses import ok
 from utils.audit import audit
+from utils.responses import ok
+
+from .routes_metrics import kds_oldest_kot_seconds
 
 router = APIRouter()
 
@@ -98,60 +102,8 @@ async def list_queue(tenant_id: str, request: Request) -> dict:
         "printer_stale": stale,
         "retry_queue": qlen,
         "kot_delay": delayed,
-
     }
     return ok(data)
-
-
-@router.get("/api/outlet/{tenant_id}/kds/expo")
-@audit("list_kds_expo")
-async def list_expo(tenant_id: str) -> dict:
-    """Return ready orders with aging and allergen info."""
-    async with _session(tenant_id) as session:
-        result = await session.execute(
-            select(
-                Order.id,
-                Table.code,
-                Order.ready_at,
-                OrderItem.qty,
-                OrderItem.name_snapshot,
-                MenuItem.allergens,
-            )
-            .join(Table, Order.table_id == Table.id)
-            .join(OrderItem, OrderItem.order_id == Order.id)
-            .join(MenuItem, MenuItem.id == OrderItem.item_id)
-            .where(Order.status == OrderStatus.READY.value)
-            .order_by(Order.ready_at)
-        )
-        rows = result.all()
-
-    orders: dict[int, dict] = {}
-    now = datetime.now(timezone.utc)
-    for row in rows:
-        info = orders.setdefault(
-            row.id,
-            {
-                "id": row.id,
-                "table_code": row.code,
-                "ready_at": row.ready_at,
-                "items": [],
-                "allergens": set(),
-            },
-        )
-        info["items"].append({"name": row.name_snapshot, "qty": row.qty})
-        if row.allergens:
-            info["allergens"].update(row.allergens)
-
-    for order in orders.values():
-        ready_at = order.pop("ready_at")
-        if ready_at and ready_at.tzinfo is None:
-            ready_at = ready_at.replace(tzinfo=timezone.utc)
-        order["aging_secs"] = (
-            (now - ready_at).total_seconds() if ready_at else 0.0
-        )
-        order["allergens"] = sorted(order["allergens"])
-
-    return ok({"orders": list(orders.values())})
 
 
 async def _transition_order(tenant_id: str, order_id: int, dest: OrderStatus) -> dict:
@@ -236,13 +188,6 @@ async def ready_order(tenant_id: str, order_id: int) -> dict:
 @audit("serve_order")
 async def serve_order(tenant_id: str, order_id: int) -> dict:
     """Mark an order as served."""
-    return await _transition_order(tenant_id, order_id, OrderStatus.SERVED)
-
-
-@router.post("/api/outlet/{tenant_id}/kds/order/{order_id}/picked")
-@audit("picked_order")
-async def picked_order(tenant_id: str, order_id: int) -> dict:
-    """Alias for serving an order from the expo screen."""
     return await _transition_order(tenant_id, order_id, OrderStatus.SERVED)
 
 

--- a/api/app/routes_kds_expo.py
+++ b/api/app/routes_kds_expo.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from domain import OrderStatus
+from fastapi import APIRouter, HTTPException
+from models_tenant import MenuItem, Order, OrderItem, Table
+from sqlalchemy import select, update
+from utils.audit import audit
+from utils.responses import ok
+
+from .routes_kds import _session
+
+router = APIRouter()
+
+
+@router.get("/api/outlet/{tenant_id}/kds/expo")
+@audit("list_kds_expo")
+async def list_expo(tenant_id: str) -> dict:
+    """Return ready orders with aging and allergen badges."""
+    async with _session(tenant_id) as session:
+        result = await session.execute(
+            select(
+                Order.id,
+                Table.code,
+                Order.ready_at,
+                MenuItem.allergens,
+            )
+            .join(Table, Order.table_id == Table.id)
+            .join(OrderItem, OrderItem.order_id == Order.id)
+            .join(MenuItem, MenuItem.id == OrderItem.item_id)
+            .where(Order.status == OrderStatus.READY.value)
+            .order_by(Order.ready_at)
+        )
+        rows = result.all()
+
+    tickets: dict[int, dict] = {}
+    now = datetime.now(timezone.utc)
+    for row in rows:
+        info = tickets.setdefault(
+            row.id,
+            {
+                "order_id": row.id,
+                "table": row.code,
+                "ready_at": row.ready_at,
+                "allergens": set(),
+            },
+        )
+        if row.allergens:
+            info["allergens"].update(row.allergens)
+
+    orders_out = []
+    for info in tickets.values():
+        ready_at = info.pop("ready_at")
+        if ready_at and ready_at.tzinfo is None:
+            ready_at = ready_at.replace(tzinfo=timezone.utc)
+        age_s = (now - ready_at).total_seconds() if ready_at else 0.0
+        orders_out.append(
+            {
+                "order_id": info["order_id"],
+                "table": info["table"],
+                "age_s": age_s,
+                "allergen_badges": sorted(info["allergens"]),
+            }
+        )
+
+    return ok({"orders": orders_out})
+
+
+@router.post("/api/outlet/{tenant_id}/kds/expo/{order_id}/picked")
+@audit("expo.picked")
+async def pick_order(tenant_id: str, order_id: int) -> dict:
+    """Mark a ready order as picked up."""
+    async with _session(tenant_id) as session:
+        result = await session.execute(select(Order.status).where(Order.id == order_id))
+        current = result.scalar_one_or_none()
+        if current is None:
+            raise HTTPException(status_code=404, detail="order not found")
+        if current != OrderStatus.READY:
+            raise HTTPException(status_code=400, detail="invalid transition")
+        await session.execute(
+            update(Order)
+            .where(Order.id == order_id)
+            .values(status=OrderStatus.SERVED.value)
+        )
+        await session.commit()
+    return ok({"status": OrderStatus.SERVED.value})

--- a/api/tests/test_kds_expo.py
+++ b/api/tests/test_kds_expo.py
@@ -1,0 +1,89 @@
+import datetime
+import pathlib
+import sys
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+import api.app.db as app_db  # noqa: E402
+import api.app.domain as app_domain  # noqa: E402
+import api.app.models_tenant as app_models_tenant  # noqa: E402
+import api.app.repos_sqlalchemy as app_repos_sqlalchemy  # noqa: E402
+import api.app.utils as app_utils  # noqa: E402
+
+sys.modules.setdefault("db", app_db)
+sys.modules.setdefault("domain", app_domain)
+sys.modules.setdefault("models_tenant", app_models_tenant)
+sys.modules.setdefault("repos_sqlalchemy", app_repos_sqlalchemy)
+sys.modules.setdefault("utils", app_utils)
+
+from api.app import routes_kds_expo  # noqa: E402
+from api.app.db import SessionLocal  # noqa: E402
+from api.app.domain import OrderStatus  # noqa: E402
+from api.app.models_tenant import AuditTenant  # noqa: E402
+
+app = FastAPI()
+app.include_router(routes_kds_expo.router)
+client = TestClient(app)
+
+
+class DummySession:
+    def __init__(self):
+        self.status = OrderStatus.READY
+        self.ready_at = datetime.datetime.now(
+            datetime.timezone.utc
+        ) - datetime.timedelta(seconds=30)
+
+    async def execute(self, query):
+        name = getattr(query, "__visit_name__", "")
+        if name == "select":
+            return SimpleNamespace(
+                all=lambda: [
+                    SimpleNamespace(
+                        id=1,
+                        code="T1",
+                        ready_at=self.ready_at,
+                        allergens=["nuts"],
+                    )
+                ],
+                scalar_one_or_none=lambda: self.status,
+                first=lambda: SimpleNamespace(status=self.status),
+            )
+        elif name == "update":
+            self.status = OrderStatus.SERVED
+            return SimpleNamespace(rowcount=1)
+        return SimpleNamespace()
+
+    async def commit(self):
+        return None
+
+
+@asynccontextmanager
+async def fake_session(_tenant_id: str):
+    yield DummySession()
+
+
+def test_ready_to_picked_flow(monkeypatch):
+    monkeypatch.setattr(routes_kds_expo, "_session", fake_session)
+    with SessionLocal() as s:
+        s.query(AuditTenant).delete()
+        s.commit()
+
+    resp = client.get("/api/outlet/demo/kds/expo")
+    assert resp.status_code == 200
+    data = resp.json()["data"]["orders"][0]
+    assert data["table"] == "T1"
+    assert data["allergen_badges"] == ["nuts"]
+
+    resp = client.post("/api/outlet/demo/kds/expo/1/picked")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == OrderStatus.SERVED.value
+
+    with SessionLocal() as s:
+        row = s.query(AuditTenant).filter_by(action="expo.picked").first()
+        assert row is not None
+        assert row.meta["target"]["order_id"] == "1"

--- a/docs/kds_routes.md
+++ b/docs/kds_routes.md
@@ -9,8 +9,8 @@ Experimental Kitchen Display System endpoints.
 | POST | /api/outlet/{tenant_id}/kds/order/{order_id}/progress | Move an order to in-progress. |
 | POST | /api/outlet/{tenant_id}/kds/order/{order_id}/ready | Mark an order as ready. |
 | POST | /api/outlet/{tenant_id}/kds/order/{order_id}/serve | Mark an order as served. |
-| POST | /api/outlet/{tenant_id}/kds/order/{order_id}/picked | Mark a ready order as picked up. |
 | GET | /api/outlet/{tenant_id}/kds/expo | List ready tickets with aging and allergen badges. |
+| POST | /api/outlet/{tenant_id}/kds/expo/{order_id}/picked | Mark a ready order as picked up. |
 | GET | /api/outlet/{tenant_id}/kot/{order_id}.pdf | Printable KOT for an order (PDF/HTML). |
 | GET | /api/outlet/{tenant_id}/print/status | Printer agent heartbeat and retry queue length. |
 

--- a/pwa/src/pages/ExpoDashboard.jsx
+++ b/pwa/src/pages/ExpoDashboard.jsx
@@ -24,16 +24,22 @@ export default function ExpoDashboard() {
   }, [])
 
   const markPicked = (id) => {
-    apiFetch(`/kds/order/${id}/picked`, { method: 'POST' })
+    apiFetch(`/kds/expo/${id}/picked`, { method: 'POST' })
       .then(() => fetchOrders())
       .catch((err) => setError(err.message))
   }
 
   useEffect(() => {
     const handler = (e) => {
+      if (e.key === 'p' || e.key === 'P') {
+        if (orders.length > 0) {
+          markPicked(orders[orders.length - 1].order_id)
+        }
+        return
+      }
       const idx = parseInt(e.key, 10)
       if (!isNaN(idx) && idx > 0 && idx <= orders.length) {
-        markPicked(orders[idx - 1].id)
+        markPicked(orders[idx - 1].order_id)
       }
     }
     window.addEventListener('keydown', handler)
@@ -49,30 +55,23 @@ export default function ExpoDashboard() {
       {!loading && !error && (
         <ul className="space-y-4">
           {orders.map((o, idx) => (
-            <li key={o.id} className="border p-2 rounded">
+            <li key={o.order_id} className="border p-2 rounded">
               <div className="flex justify-between">
                 <span className="font-semibold">
-                  Table {o.table_code}
-                  {o.allergens.length > 0 && (
+                  Table {o.table}
+                  {o.allergen_badges.length > 0 && (
                     <span className="ml-2 rounded bg-red-100 px-1 text-red-800 text-xs">
                       Allergy
                     </span>
                   )}
                 </span>
                 <span className="text-sm text-gray-600">
-                  {Math.round(o.aging_secs / 60)}m
+                  {Math.round(o.age_s / 60)}m
                 </span>
               </div>
-              <ul className="mt-2 text-sm">
-                {o.items.map((it, i) => (
-                  <li key={i}>
-                    {it.qty} x {it.name}
-                  </li>
-                ))}
-              </ul>
               <button
                 className="mt-2 bg-blue-600 text-white px-2 py-1 rounded"
-                onClick={() => markPicked(o.id)}
+                onClick={() => markPicked(o.order_id)}
               >
                 Picked [{idx + 1}]
               </button>


### PR DESCRIPTION
## Summary
- add KDS expo endpoints for listing tickets with aging and marking picked orders
- wire expo routes into API and expose hotkey support in Expo dashboard
- document new routes and cover expo pick flow with tests

## Testing
- `pre-commit run --files api/tests/test_kds_expo.py api/app/routes_kds_expo.py api/app/routes_kds.py api/app/main.py pwa/src/pages/ExpoDashboard.jsx docs/kds_routes.md`
- `pytest api/tests/test_kds_expo.py`


------
https://chatgpt.com/codex/tasks/task_e_68adabf49760832a9bff9049c090edbb