### PR TITLE
feat: add status page endpoint and incident scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repository contains three main services:
 
 - `api/` – FastAPI application with `/health`, `/ready` and `/time/skew` endpoints, Alembic migrations, and service helpers such as EMA-based ETA utilities with per-tenant persistence.
 - `pwa/` – React + Tailwind front end with a placeholder home page and installable PWA manifest.
-- `ops/` – Docker Compose for local development.
--
+ - `ops/` – Docker Compose for local development.
+Monitoring tools such as UptimeRobot should poll the `/status.json` endpoint for platform health. Ops scripts in `ops/scripts/status_page.py` maintain this file during incidents.
 Invoices support optional FSSAI license details when provided.
 QR pack generation events are audited and can be exported via admin APIs. See
 [`docs/qrpack_audit.md`](docs/qrpack_audit.md) for details.

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -31,7 +31,7 @@ from fastapi import (
     WebSocketDisconnect,
     status,
 )
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
@@ -231,6 +231,14 @@ app = FastAPI(
 )
 static_dir = Path(__file__).resolve().parent.parent.parent / "static"
 app.mount("/static", SWStaticFiles(directory=static_dir), name="static")
+
+
+@app.get("/status.json")
+async def status_json():
+    return FileResponse(
+        Path(__file__).resolve().parent.parent.parent / "status.json",
+        media_type="application/json",
+    )
 init_tracing(app)
 asyncio.set_event_loop(asyncio.new_event_loop())
 app.state.redis = from_url(settings.redis_url, decode_responses=True)

--- a/docs/INCIDENT_RUNBOOK.md
+++ b/docs/INCIDENT_RUNBOOK.md
@@ -33,3 +33,20 @@ Contact: {incident commander}
 
 ## Testing
 Use `scripts/emit_test_alert.py` to trigger a synthetic alert during drills.
+
+## Status Page Maintenance
+
+The status page is served from `/status.json` and indicates overall platform health.
+Update it during incidents with:
+
+```
+python ops/scripts/status_page.py start "<title>" "<details>"
+```
+
+Resolve an incident when service is restored:
+
+```
+python ops/scripts/status_page.py resolve "<title>"
+```
+
+The `state` field should be `operational` when no incidents remain and `degraded` while any are active.

--- a/docs/INCIDENT_TEMPLATES.md
+++ b/docs/INCIDENT_TEMPLATES.md
@@ -35,3 +35,16 @@ Ops
 ---
 
 During a SEV, the `/status.json` file is automatically updated to reflect the current `state` and any active `incidents` so external systems can track progress.
+Valid values for `state` include `operational`, `degraded`, and `down`.
+
+Start an incident and mark the status page as degraded:
+
+```
+python ops/scripts/status_page.py start "<title>" "<details>"
+```
+
+Resolve an incident and restore the status page when all issues are cleared:
+
+```
+python ops/scripts/status_page.py resolve "<title>"
+```

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,5 +1,15 @@
 # Operations
 
+## Status Endpoint
+
+External monitors can poll `GET /status.json` to observe platform health. The file contains a top-level `state` (`operational` or `degraded`) and a list of active `incidents`.
+Use the helper script to start or resolve incidents:
+
+```
+python ops/scripts/status_page.py start "<title>" "<details>"
+python ops/scripts/status_page.py resolve "<title>"
+```
+
 ## Data Purge
 
 The `scripts/purge_data.py` helper removes expired customer PII and delivered

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down
+.PHONY: up down incident-start incident-resolve
 
 # Start the local development stack
 up:
@@ -7,3 +7,9 @@ up:
 # Stop and remove containers, networks and volumes
 down:
 	docker-compose down --volumes --remove-orphans
+
+incident-start:
+	python scripts/status_page.py start "$(TITLE)" "$(DETAILS)"
+
+incident-resolve:
+	python scripts/status_page.py resolve "$(TITLE)"

--- a/ops/scripts/status_page.py
+++ b/ops/scripts/status_page.py
@@ -1,0 +1,62 @@
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Any
+
+STATUS_FILE = Path(__file__).resolve().parents[2] / "status.json"
+
+
+def _read_status() -> Dict[str, Any]:
+    with STATUS_FILE.open() as f:
+        return json.load(f)
+
+
+def _write_status(data: Dict[str, Any]) -> None:
+    with STATUS_FILE.open("w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def start_incident(title: str, details: str) -> None:
+    data = _read_status()
+    data["state"] = "degraded"
+    incidents = data.setdefault("incidents", [])
+    incidents.append(
+        {
+            "title": title,
+            "details": details,
+            "started_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        }
+    )
+    _write_status(data)
+
+
+def resolve_incident(title: str) -> None:
+    data = _read_status()
+    incidents = [i for i in data.get("incidents", []) if i.get("title") != title]
+    data["incidents"] = incidents
+    data["state"] = "degraded" if incidents else "operational"
+    _write_status(data)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage status.json incidents")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    start = sub.add_parser("start", help="start an incident")
+    start.add_argument("title")
+    start.add_argument("details")
+
+    resolve = sub.add_parser("resolve", help="resolve an incident")
+    resolve.add_argument("title")
+
+    args = parser.parse_args()
+    if args.cmd == "start":
+        start_incident(args.title, args.details)
+    else:
+        resolve_incident(args.title)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_status_page.py
+++ b/tests/test_status_page.py
@@ -1,0 +1,24 @@
+import json
+from ops.scripts import status_page
+
+
+def test_status_page_toggle(tmp_path, monkeypatch):
+    status_file = tmp_path / "status.json"
+    status_file.write_text(json.dumps({"state": "operational", "incidents": []}))
+    monkeypatch.setattr(status_page, "STATUS_FILE", status_file)
+
+    status_page.start_incident("db", "down")
+    status_page.start_incident("api", "slow")
+    data = json.loads(status_file.read_text())
+    assert data["state"] == "degraded"
+    assert len(data["incidents"]) == 2
+
+    status_page.resolve_incident("db")
+    data = json.loads(status_file.read_text())
+    assert data["state"] == "degraded"
+    assert len(data["incidents"]) == 1
+
+    status_page.resolve_incident("api")
+    data = json.loads(status_file.read_text())
+    assert data["state"] == "operational"
+    assert data["incidents"] == []

--- a/tests/test_status_route.py
+++ b/tests/test_status_route.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from api.app.main import app
+
+
+def test_status_route_serves_json():
+    client = TestClient(app)
+    resp = client.get("/status.json")
+    assert resp.status_code == 200
+    status_path = Path(__file__).resolve().parent.parent / "status.json"
+    with status_path.open() as f:
+        expected = json.load(f)
+    assert resp.json() == expected
+    assert resp.headers["content-type"].startswith("application/json")


### PR DESCRIPTION
## Summary
- serve `/status.json` through FastAPI and expose incident state
- add status page helpers for starting and resolving incidents
- document status workflow and add tests

## Testing
- `pytest tests/test_status_route.py tests/test_status_page.py`

------
https://chatgpt.com/codex/tasks/task_e_68adadb70a74832ab968991639599ce3