### PR TITLE
Add A/B testing allocator and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ Request bodies and query parameters are scrubbed of sensitive keys such as
 JSON logger further redacts phone numbers, email addresses, and UTR values in
 log messages using regex filters.
 
+## A/B testing
+
+The API includes a deterministic allocator that maps device IDs into weighted
+experiment variants. Clients can query their assignment via
+`GET /api/ab/{experiment}` by providing a `device-id` header or `device_id`
+query parameter. Set `FLAG_AB_TESTS=0` to globally disable experiments and
+force the `"control"` variant.
+
+Prometheus metrics capture experiment outcomes:
+
+* `ab_exposures_total` – incremented when a variant is served.
+* `ab_conversions_total` – helper counter for recording conversions.
+
+Example:
+
+```bash
+curl -H 'device-id: 123' http://localhost:8000/api/ab/sample
+{"variant": "control"}
+```
+
 Media files can be persisted using either the local filesystem or S3. Configure
 storage with:
 

--- a/api/app/exp/__init__.py
+++ b/api/app/exp/__init__.py
@@ -1,0 +1,3 @@
+from .ab_allocator import allocate, get_variant
+
+__all__ = ["allocate", "get_variant"]

--- a/api/app/exp/ab_allocator.py
+++ b/api/app/exp/ab_allocator.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Dict
+
+from config import get_settings
+
+from .. import flags
+
+
+def allocate(device_id: str, experiment: str, variants: Dict[str, int]) -> str:
+    """Deterministically assign ``device_id`` to a variant.
+
+    Parameters
+    ----------
+    device_id:
+        Identifier for the device/user.
+    experiment:
+        Experiment name (included in the hash for stability across experiments).
+    variants:
+        Mapping of variant name to integer weight.
+    """
+    total = sum(variants.values())
+    if total <= 0:
+        return "control"
+    key = f"{experiment}:{device_id}".encode()
+    bucket = int(hashlib.md5(key).hexdigest(), 16) % total
+    cumulative = 0
+    for name, weight in variants.items():
+        cumulative += weight
+        if bucket < cumulative:
+            return name
+    return "control"
+
+
+def get_variant(device_id: str, experiment: str, tenant: object | None = None) -> str:
+    """Return variant for ``device_id`` under ``experiment``.
+
+    Respects the ``ab_tests`` feature flag and falls back to ``control`` when
+    disabled or when the experiment is undefined.
+    """
+    if not flags.get("ab_tests", tenant):
+        return "control"
+    settings = get_settings()
+    experiments = getattr(settings, "ab_tests", {})
+    variants = experiments.get(experiment)
+    if not variants:
+        return "control"
+    return allocate(device_id, experiment, variants)

--- a/api/app/flags.py
+++ b/api/app/flags.py
@@ -2,7 +2,7 @@
 
 Flags support a three-level precedence order:
 
-1. Environment variable override: ``FLAG_<NAME>``
+1. Environment variable override: ``FLAG_<NAME>`` (e.g., ``FLAG_AB_TESTS``)
 2. Per-tenant override via model attributes or ``tenant.features`` mapping
 3. Default defined in :data:`REGISTRY`
 """
@@ -22,6 +22,7 @@ REGISTRY: Dict[str, Dict[str, Any]] = {
     "wa_enabled": {"default": False},
     "happy_hour": {"default": False},
     "analytics": {"default": False},
+    "ab_tests": {"default": True},
 
 }
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -154,6 +154,7 @@ from .routes_media import router as media_router
 from .routes_menu_import import router as menu_import_router
 from .routes_metrics import router as metrics_router
 from .routes_metrics import ws_messages_total
+from .routes_ab_tests import router as ab_tests_router
 from .routes_onboarding import router as onboarding_router
 from .routes_order_void import router as order_void_router
 from .routes_orders_batch import router as orders_batch_router
@@ -904,6 +905,7 @@ app.include_router(orders_batch_router)
 app.include_router(housekeeping_router)
 app.include_router(hotel_hk_router)
 app.include_router(metrics_router)
+app.include_router(ab_tests_router)
 app.include_router(rum_router)
 app.include_router(owner_analytics_router)
 app.include_router(owner_sla_router)

--- a/api/app/routes_ab_tests.py
+++ b/api/app/routes_ab_tests.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Header, Query
+
+from .auth import User, authenticate_user
+from .exp.ab_allocator import get_variant
+from .routes_metrics import ab_exposures_total
+
+router = APIRouter()
+
+
+@router.get("/api/ab/{experiment}")
+async def fetch_variant(
+    experiment: str,
+    device_id_header: str | None = Header(None, alias="device-id"),
+    device_id_query: str | None = Query(None, alias="device_id"),
+    user: User = Depends(authenticate_user),
+) -> dict:
+    """Return assigned variant for ``experiment`` and ``device_id``.
+
+    ``device_id`` may be supplied via the ``device-id`` header or
+    ``device_id`` query parameter.
+    """
+    device_id = device_id_header or device_id_query or ""
+    variant = get_variant(device_id, experiment)
+    ab_exposures_total.labels(experiment=experiment, variant=variant).inc()
+    return {"variant": variant}

--- a/api/app/routes_metrics.py
+++ b/api/app/routes_metrics.py
@@ -67,6 +67,16 @@ notifications_outbox_failed_total = Counter(
 )
 notifications_outbox_failed_total.inc(0)
 
+ab_exposures_total = Counter(
+    "ab_exposures_total", "Experiment exposures", ["experiment", "variant"]
+)
+ab_exposures_total.labels(experiment="sample", variant="control").inc(0)
+
+ab_conversions_total = Counter(
+    "ab_conversions_total", "Experiment conversions", ["experiment", "variant"]
+)
+ab_conversions_total.labels(experiment="sample", variant="control").inc(0)
+
 webhook_attempts_total = Counter(
     "webhook_attempts_total", "Total webhook delivery attempts", ["destination"]
 )
@@ -128,6 +138,11 @@ kot_delay_alerts_total = Counter(
     "kot_delay_alerts_total", "Total KOT delay alerts"
 )
 kot_delay_alerts_total.inc(0)
+
+
+def record_ab_conversion(experiment: str, variant: str) -> None:
+    """Increment conversion counter for an experiment variant."""
+    ab_conversions_total.labels(experiment=experiment, variant=variant).inc()
 
 router = APIRouter()
 

--- a/api/tests/test_ab_allocator.py
+++ b/api/tests/test_ab_allocator.py
@@ -1,0 +1,24 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from api.app.exp import ab_allocator
+
+
+def test_allocation_is_stable():
+    variants = {"control": 1, "treat": 1}
+    did = "device-123"
+    first = ab_allocator.allocate(did, "exp", variants)
+    second = ab_allocator.allocate(did, "exp", variants)
+    assert first == second
+
+
+def test_weighted_distribution():
+    variants = {"control": 1, "treat": 3}
+    counts = {"control": 0, "treat": 0}
+    for i in range(1000):
+        v = ab_allocator.allocate(f"id-{i}", "exp", variants)
+        counts[v] += 1
+    ratio = counts["treat"] / counts["control"]
+    assert 2.0 < ratio < 4.0

--- a/api/tests/test_routes_ab_tests.py
+++ b/api/tests/test_routes_ab_tests.py
@@ -1,0 +1,45 @@
+import os
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("ALLOWED_ORIGINS", "http://example.com")
+os.environ.setdefault("DB_URL", "postgresql://localhost/db")
+os.environ.setdefault("REDIS_URL", "redis://localhost/0")
+os.environ.setdefault("SECRET_KEY", "x" * 32)
+
+from fastapi.testclient import TestClient
+import fakeredis.aioredis
+
+from api.app.main import app
+from api.app import flags as flags_module
+from api.app.exp import ab_allocator
+from api.app.auth import authenticate_user
+
+
+def _client(monkeypatch, flag_value: bool, variants: dict | None = None) -> TestClient:
+    monkeypatch.setattr(flags_module, "get", lambda name, tenant=None: flag_value)
+    if variants is not None:
+        class Dummy:
+            ab_tests = variants
+        monkeypatch.setattr(ab_allocator, "get_settings", lambda: Dummy())
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    app.dependency_overrides[authenticate_user] = lambda: None
+    return TestClient(app)
+
+
+def test_returns_control_when_flag_disabled(monkeypatch):
+    client = _client(monkeypatch, False)
+    resp = client.get("/api/ab/sample?device_id=abc")
+    assert resp.status_code == 200
+    assert resp.json() == {"variant": "control"}
+
+
+def test_deterministic_variant_when_enabled(monkeypatch):
+    variants = {"sample": {"control": 1, "treat": 1}}
+    client = _client(monkeypatch, True, variants)
+    expected = ab_allocator.allocate("abc", "sample", variants["sample"])
+    resp = client.get("/api/ab/sample?device_id=abc")
+    assert resp.status_code == 200
+    assert resp.json() == {"variant": expected}


### PR DESCRIPTION
## Summary
- add weighted A/B allocation helper and flag-aware variant resolver
- expose `/api/ab/{experiment}` endpoint that records exposure metrics
- track experiment exposures and conversions via new Prometheus counters and docs

## Testing
- `pytest api/tests/test_ab_allocator.py api/tests/test_routes_ab_tests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68adadebb2dc832abf58e1c56a6af357