### PR TITLE
feat: stream invoice csv exports

### DIFF
--- a/api/app/routes_exports.py
+++ b/api/app/routes_exports.py
@@ -6,7 +6,9 @@ import asyncio
 import csv
 import os
 from contextlib import asynccontextmanager
-from datetime import datetime, time, timezone
+from datetime import datetime, time, timedelta, timezone
+from io import BytesIO, StringIO, TextIOWrapper
+from zipfile import ZipFile
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, HTTPException, Request
@@ -16,9 +18,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from .db.replica import read_only
 from .db.tenant import get_engine
-from .models_tenant import Invoice
+from .models_tenant import Invoice, Payment
+from .pdf.render import render_invoice
+from .repos_sqlalchemy import invoices_repo_sql
 from .security import ratelimit
 from .utils import ratelimits
+from .utils.csv_stream import stream_csv
 from .utils.rate_limit import rate_limited
 from .utils.responses import err
 
@@ -55,6 +60,104 @@ def _iter_bytes(buffer: BytesIO):
     buffer.seek(0)
     while chunk := buffer.read(8192):
         yield chunk
+
+
+@router.get("/api/outlet/{tenant_id}/exports/invoices.csv")
+@read_only
+async def invoices_export(
+    tenant_id: str,
+    request: Request,
+    limit: int = DEFAULT_LIMIT,
+    cursor: int | None = None,
+    job: str | None = None,
+    chunk_size: int = 1000,
+) -> StreamingResponse:
+    """Stream invoice rows as CSV."""
+
+    limit, cap_hint = _cap_limit(limit)
+
+    redis = request.app.state.redis
+    ip = request.client.host if request.client else "unknown"
+    policy = ratelimits.exports()
+    allowed = await ratelimit.allow(
+        redis, ip, "exports", rate_per_min=policy.rate_per_min, burst=policy.burst
+    )
+    if not allowed:
+        retry_after = await redis.ttl(f"ratelimit:{ip}:exports")
+        return rate_limited(retry_after)
+    if job:
+        await redis.set(f"export:{job}:progress", 0)
+
+    async with _session(tenant_id) as session:
+
+        async def row_iter():
+            exported = 0
+            last_id = cursor or 0
+            while exported < limit:
+                chunk = min(SCAN_LIMIT, limit - exported)
+                stmt = (
+                    select(
+                        Invoice.id,
+                        Invoice.number,
+                        Invoice.total,
+                        Invoice.created_at,
+                    )
+                    .where(Invoice.id > last_id)
+                    .order_by(Invoice.id)
+                    .limit(chunk)
+                )
+                rows = (await session.execute(stmt)).all()
+                if not rows:
+                    break
+                for inv_id, number, total_amt, created_at in rows:
+                    exported += 1
+                    if job and exported % 1000 == 0:
+                        await redis.set(f"export:{job}:progress", exported)
+                    yield [
+                        inv_id,
+                        number,
+                        float(total_amt),
+                        created_at.isoformat(),
+                    ]
+                    last_id = inv_id
+                    if exported >= limit:
+                        break
+            if cap_hint:
+                yield ["", "", "", "cap hit"]
+
+        headers = ["id", "number", "total", "created_at"]
+        iterator = stream_csv(headers, row_iter(), chunk_size=chunk_size)
+    return StreamingResponse(iterator, media_type="text/csv")
+
+
+@router.get(
+    "/api/outlet/{tenant_id}/exports/invoices/progress/{job}",
+    response_class=StreamingResponse,
+    responses={200: {"content": {"text/event-stream": {}}}},
+)
+async def invoices_export_progress(
+    tenant_id: str, job: str, request: Request
+) -> StreamingResponse:
+    """Emit invoice export progress via SSE."""
+
+    redis = request.app.state.redis
+
+    async def event_gen():
+        last = 0
+        while True:
+            val = await redis.get(f"export:{job}:progress")
+            if val is None:
+                if last:
+                    break
+                await asyncio.sleep(0.1)
+                continue
+            count = int(val)
+            if count > last:
+                yield f'event: progress\ndata: {{"count": {count}}}\n\n'
+                last = count
+            await asyncio.sleep(0.1)
+
+    return StreamingResponse(event_gen(), media_type="text/event-stream")
 
 
 @router.get("/api/outlet/{tenant_id}/exports/daily")
@@ -254,7 +357,6 @@ async def daily_export(
 
         headers = {"Content-Disposition": "attachment; filename=export.zip"}
         more = await session.scalar(
-
             select(Invoice.id)
             .where(
                 Invoice.created_at >= start_dt,
@@ -277,60 +379,6 @@ async def daily_export(
                 .limit(1)
             )
 
-        async def row_iter():
-            exported = 0
-            last = cursor
-            header = ["id", "no", "date", "subtotal", "tax", "tip", "total", "settled"]
-            yield ",".join(header) + "\n"
-            while exported < limit:
-                chunk = min(SCAN_LIMIT, limit - exported)
-                conditions = [
-                    Invoice.created_at >= start_dt,
-                    Invoice.created_at <= end_dt,
-                    Invoice.id > last,
-                ]
-                if last_id is not None:
-                    conditions.append(Invoice.id <= last_id)
-                stmt = (
-                    select(
-                        Invoice.id,
-                        Invoice.number,
-                        Invoice.bill_json,
-                        Invoice.tip,
-                        Invoice.total,
-                        Invoice.settled,
-                        Invoice.created_at,
-                    )
-                    .where(*conditions)
-                    .order_by(Invoice.id)
-                    .limit(chunk)
-                )
-                rows = (await session.execute(stmt)).all()
-                if not rows:
-                    break
-                for (
-                    inv_id,
-                    number,
-                    bill,
-                    tip,
-                    total_amt,
-                    settled,
-                    created_at,
-                ) in rows:
-                    inv_date = created_at.astimezone(tzinfo).date().isoformat()
-                    subtotal = bill.get("subtotal", 0)
-                    tax = sum(bill.get("tax_breakup", {}).values())
-                    line = f"{inv_id},{number},{inv_date},{subtotal},{tax},{float(tip or 0)},{float(total_amt)},{settled}\n"
-                    yield line
-                    exported += 1
-                    last = inv_id
-                    if progress:
-                        request.app.state.export_progress[progress] = exported
-                if len(rows) < chunk or (last_id and last >= last_id):
-                    break
-            if progress:
-                request.app.state.export_progress.pop(progress, None)
-
         headers = {"Content-Disposition": "attachment; filename=invoices.csv"}
         if more is not None:
             headers["Next-Cursor"] = str(last_id)
@@ -338,7 +386,9 @@ async def daily_export(
             headers["X-Row-Limit"] = str(HARD_LIMIT)
         if job:
             await redis.delete(f"export:{job}:progress")
-        return StreamingResponse(_iter_bytes(bundle), media_type="application/zip", headers=headers)
+        return StreamingResponse(
+            _iter_bytes(bundle), media_type="application/zip", headers=headers
+        )
 
 
 @router.get(
@@ -346,7 +396,9 @@ async def daily_export(
     response_class=StreamingResponse,
     responses={200: {"content": {"text/event-stream": {}}}},
 )
-async def daily_export_progress(tenant_id: str, job: str, request: Request) -> StreamingResponse:
+async def daily_export_progress(
+    tenant_id: str, job: str, request: Request
+) -> StreamingResponse:
     """Stream export progress via SSE."""
 
     redis = request.app.state.redis

--- a/api/app/utils/csv_stream.py
+++ b/api/app/utils/csv_stream.py
@@ -1,0 +1,64 @@
+"""Utilities for streaming CSV responses."""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+from typing import Any, AsyncIterable, AsyncIterator, Iterable
+
+
+class CSVStream:
+    """Asynchronous iterator producing CSV byte chunks."""
+
+    def __init__(
+        self, rows_iterable: AsyncIterable[Iterable[Any]], flush_size: int = 1000
+    ):
+        self.rows_iterable = rows_iterable
+        self.flush_size = flush_size
+        self.buffer = io.StringIO()
+        self.writer = csv.writer(self.buffer)
+        self.rows_written = 0
+
+    def write_row(self, row: Iterable[Any]) -> bytes | None:
+        """Append a row and return bytes if a flush occurred."""
+        self.writer.writerow(row)
+        self.rows_written += 1
+        if self.rows_written >= self.flush_size:
+            data = self.buffer.getvalue().encode("utf-8")
+            self.buffer.seek(0)
+            self.buffer.truncate(0)
+            self.rows_written = 0
+            return data
+        return None
+
+    async def _gen(self) -> AsyncIterator[bytes]:
+        async for row in self.rows_iterable:
+            chunk = self.write_row(row)
+            if chunk:
+                yield chunk
+                await asyncio.sleep(0)
+        tail = self.buffer.getvalue().encode("utf-8")
+        if tail:
+            yield tail
+
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        return self._gen()
+
+
+def csv_stream(
+    rows_iterable: AsyncIterable[Iterable[Any]], flush_size: int = 1000
+) -> CSVStream:
+    """Create a :class:`CSVStream` for the given rows."""
+    return CSVStream(rows_iterable, flush_size)
+
+
+def stream_csv(
+    headers: Iterable[Any],
+    row_iter: AsyncIterable[Iterable[Any]],
+    chunk_size: int = 1000,
+) -> CSVStream:
+    """Return a CSV stream with ``headers`` prepended."""
+    iterator = csv_stream(row_iter, flush_size=chunk_size)
+    iterator.write_row(headers)
+    return iterator

--- a/api/tests/test_exports_stream.py
+++ b/api/tests/test_exports_stream.py
@@ -1,0 +1,144 @@
+"""Tests streaming CSV export and SSE progress."""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+import json
+import os
+import pathlib
+import sys
+
+import fakeredis.aioredis
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from api.app import db as app_db  # noqa: E402
+
+sys.modules.setdefault("db", app_db)  # noqa: E402
+from api.app import models_tenant, routes_exports  # noqa: E402
+from api.app.db.tenant import get_engine  # noqa: E402
+from api.app.models_tenant import Invoice  # noqa: E402
+
+os.environ.setdefault(
+    "POSTGRES_TENANT_DSN_TEMPLATE", "sqlite+aiosqlite:///./tenant_{tenant_id}.db"
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+async def tenant_session() -> AsyncSession:
+    tenant_id = "demo"
+    engine = get_engine(tenant_id)
+    async with engine.begin() as conn:
+        await conn.run_sync(models_tenant.Base.metadata.create_all)
+    sessionmaker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        if engine.url.get_backend_name().startswith("sqlite"):
+            await engine.dispose()
+            db_path = engine.url.database
+            if db_path and db_path != ":memory:" and os.path.exists(db_path):
+                os.remove(db_path)
+        else:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE'))
+            await engine.dispose()
+
+
+app = FastAPI()
+app.include_router(routes_exports.router)
+app.state.redis = fakeredis.aioredis.FakeRedis()
+
+
+@pytest.fixture
+async def seeded_session(tenant_session):
+    invoices = [
+        Invoice(
+            order_group_id=i,
+            number=f"INV{i}",
+            bill_json={"subtotal": 0, "tax_breakup": {}, "total": 0},
+            tip=0,
+            total=0,
+        )
+        for i in range(3000)
+    ]
+    tenant_session.add_all(invoices)
+    await tenant_session.commit()
+    return tenant_session
+
+
+@pytest.mark.anyio
+async def test_stream_chunks(seeded_session, monkeypatch):
+    monkeypatch.setattr(routes_exports, "DEFAULT_LIMIT", 5000)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with client.stream(
+            "GET", "/api/outlet/demo/exports/invoices.csv?limit=2500&chunk_size=500"
+        ) as resp:
+            assert resp.status_code == 200
+            await resp.aread()
+        data = await client.get(
+            "/api/outlet/demo/exports/invoices.csv?limit=2500&chunk_size=500"
+        )
+        rows = list(csv.reader(io.StringIO(data.text)))
+    assert len(rows) - 1 == 2500
+
+
+@pytest.mark.anyio
+async def test_cap_hint(seeded_session, monkeypatch):
+    monkeypatch.setattr(routes_exports, "ABSOLUTE_MAX_ROWS", 100)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with client.stream(
+            "GET", "/api/outlet/demo/exports/invoices.csv?limit=200"
+        ) as resp:
+            chunks = [chunk async for chunk in resp.aiter_bytes()]
+    data = b"".join(chunks).decode().splitlines()
+    assert len(data) == 102  # header + 100 rows + hint
+    assert data[-1].endswith("cap hit")
+
+
+@pytest.mark.anyio
+async def test_sse_progress():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+
+        async def produce():
+            await app.state.redis.set("export:job1:progress", 0)
+            await asyncio.sleep(0.05)
+            await app.state.redis.set("export:job1:progress", 1000)
+            await asyncio.sleep(0.05)
+            await app.state.redis.set("export:job1:progress", 2000)
+            await asyncio.sleep(0.2)
+            await app.state.redis.delete("export:job1:progress")
+
+        async def consume():
+            async with client.stream(
+                "GET", "/api/outlet/demo/exports/invoices/progress/job1"
+            ) as sse_resp:
+                events = []
+                async for line in sse_resp.aiter_lines():
+                    if line.startswith("data:"):
+                        events.append(json.loads(line[5:]))
+                        if len(events) == 2:
+                            break
+                return events
+
+        prod = asyncio.create_task(produce())
+        events = await consume()
+        await prod
+    assert events == [{"count": 1000}, {"count": 2000}]


### PR DESCRIPTION
## Summary
- stream CSV data via reusable `CSVStream` iterator
- add invoices export with server-sent progress events
- cover export streaming, hard caps and progress SSE

## Testing
- `pre-commit run --files api/app/utils/csv_stream.py api/app/routes_exports.py api/tests/test_exports_stream.py`
- `pytest api/tests/test_exports_stream.py`

------
https://chatgpt.com/codex/tasks/task_e_68adace5d0c4832a83036d885e484e17