### PR TITLE
ci: update artifact actions to v4

### DIFF
--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Generate Postman collection
         run: python scripts/gen_postman.py openapi.json docs/postman_collection.json
       - name: Upload collection artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: postman-collection
           path: docs/postman_collection.json

--- a/.github/workflows/purge-soft-deleted.yml
+++ b/.github/workflows/purge-soft-deleted.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python scripts/purge_soft_deleted.py --tenant demo --dry-run | tee purge-report.txt
       - name: Upload report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: purge-soft-deleted-report
           path: purge-report.txt

--- a/.github/workflows/purge_dry_run.yml
+++ b/.github/workflows/purge_dry_run.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python scripts/purge_soft_deleted.py --days ${PURGE_DAYS:-90} --dry-run | tee purge-report.txt
       - name: Upload report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: purge-dry-run-report
           path: purge-report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Update GitHub Actions workflows to use `actions/upload-artifact@v4`.
+
 ### Added
 
 - Flagged server-side menu A/B testing with deterministic bucketing and exposure tracking.


### PR DESCRIPTION
## Summary
- fix GitHub Actions upload-artifact deprecation by updating to v4
- document workflow update in changelog

## Testing
- `python -m pre_commit run --files CHANGELOG.md .github/workflows/purge_dry_run.yml .github/workflows/purge-soft-deleted.yml .github/workflows/postman.yml`
- `pytest` *(fails: Interrupted with 73 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adb3a3a3cc832a826dc331a0357b4b