### PR TITLE
chore: tidy imports for ruff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Update GitHub Actions workflows to use `actions/upload-artifact@v4`.
+- Clean up redundant imports and outdated ``noqa`` comment to satisfy ``ruff``.
 
 ### Added
 

--- a/api/app/kds/printer_watchdog.py
+++ b/api/app/kds/printer_watchdog.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 """Printer agent heartbeat and retry queue metrics for KDS."""
 
 
-import json
-
 import logging
 from datetime import datetime, timezone
 from typing import Tuple

--- a/api/app/routes_metrics.py
+++ b/api/app/routes_metrics.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from fastapi import APIRouter, Request, Response
 from datetime import datetime, timezone
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, generate_latest
-from datetime import datetime, timezone
 
 # Counters
 http_requests_total = Counter(

--- a/api/app/routes_ready.py
+++ b/api/app/routes_ready.py
@@ -20,7 +20,7 @@ async def ready() -> dict:
         with SessionLocal() as session:
             session.execute(text("SELECT 1"))
         # Import lazily to avoid circular import with main.py
-        from .main import redis_client  # noqa: WPS433 (import within function)
+        from .main import redis_client
 
         if redis_client is not None:
             await redis_client.ping()


### PR DESCRIPTION
## Summary
- remove unused json import in printer watchdog
- deduplicate datetime import in metrics route
- drop obsolete WPS433 noqa in readiness route

## Testing
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'api.app.routes_admin_pilot')*

------
https://chatgpt.com/codex/tasks/task_e_68adb5dc1f4c832a9fb4cc60ece40f96