### PR TITLE
feat: add outlets analytics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- feat(analytics): multi-outlet summary with CSV export and voids percentage.
 - Flagged server-side menu A/B testing with deterministic bucketing and exposure tracking.
 - L1 support console for tenant/table/order lookup with safe actions (resend invoice, reprint KOT, replay webhook, unlock PIN) and audit logging.
 - Cache last 50 invoice PDFs per outlet for offline review.

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -31,7 +31,7 @@ from fastapi import (
     WebSocketDisconnect,
     status,
 )
-from fastapi.responses import JSONResponse, FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
@@ -101,14 +101,10 @@ from .models_tenant import Table
 from .obs import capture_exception, init_sentry
 from .obs.logging import configure_logging
 from .otel import init_tracing
-from .routes_accounting_exports import router as accounting_exports_router
-
+from .routes_ab_tests import router as ab_tests_router
 from .routes_accounting import router as accounting_router
+from .routes_accounting_exports import router as accounting_exports_router
 from .routes_admin_devices import router as admin_devices_router
-from .routes_admin_menu import router as admin_menu_router
-from .routes_admin_ops import router as admin_ops_router
-from .routes_admin_pilot import router as admin_pilot_router
-
 from .routes_admin_menu import router as admin_menu_router
 from .routes_admin_ops import router as admin_ops_router
 from .routes_admin_pilot import router as admin_pilot_router
@@ -119,12 +115,8 @@ from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
 from .routes_admin_support_console import router as admin_support_console_router
 from .routes_admin_webhooks import router as admin_webhooks_router
-
-
-from .routes_admin_devices import router as admin_devices_router
-from .routes_print_test import router as print_test_router
-from .routes_integrations import router as integrations_router
 from .routes_alerts import router as alerts_router
+from .routes_analytics_outlets import router as analytics_outlets_router
 from .routes_api_keys import router as api_keys_router
 from .routes_auth_2fa import router as auth_2fa_router
 from .routes_auth_magic import router as auth_magic_router
@@ -153,7 +145,6 @@ from .routes_hotel_guest import router as hotel_guest_router
 from .routes_hotel_housekeeping import router as hotel_hk_router
 from .routes_housekeeping import router as housekeeping_router
 from .routes_integrations import router as integrations_router
-
 from .routes_integrations_marketplace import router as integrations_marketplace_router
 from .routes_invoice_pdf import router as invoice_pdf_router
 from .routes_jobs_status import router as jobs_status_router
@@ -165,7 +156,6 @@ from .routes_media import router as media_router
 from .routes_menu_import import router as menu_import_router
 from .routes_metrics import router as metrics_router
 from .routes_metrics import ws_messages_total
-from .routes_ab_tests import router as ab_tests_router
 from .routes_onboarding import router as onboarding_router
 from .routes_order_void import router as order_void_router
 from .routes_orders_batch import router as orders_batch_router
@@ -255,6 +245,8 @@ async def status_json():
         Path(__file__).resolve().parent.parent.parent / "status.json",
         media_type="application/json",
     )
+
+
 init_tracing(app)
 asyncio.set_event_loop(asyncio.new_event_loop())
 app.state.redis = from_url(settings.redis_url, decode_responses=True)
@@ -932,6 +924,7 @@ app.include_router(hotel_hk_router)
 app.include_router(metrics_router)
 app.include_router(ab_tests_router)
 app.include_router(rum_router)
+app.include_router(analytics_outlets_router)
 app.include_router(owner_analytics_router)
 app.include_router(owner_sla_router)
 app.include_router(dashboard_router)

--- a/api/app/models_tenant.py
+++ b/api/app/models_tenant.py
@@ -96,6 +96,7 @@ class OrderStatus(enum.Enum):
     PREPARING = "preparing"
     READY = "ready"
     SERVED = "served"
+    CANCELLED = "cancelled"
 
 
 class Table(Base):

--- a/api/app/routes_analytics_outlets.py
+++ b/api/app/routes_analytics_outlets.py
@@ -1,0 +1,192 @@
+"""Owner multi-outlet analytics summary routes."""
+
+from __future__ import annotations
+
+import csv
+import statistics
+from contextlib import asynccontextmanager
+from datetime import datetime, time, timezone
+from io import StringIO
+from typing import Iterable
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .db.replica import read_only, replica_session
+from .db.tenant import get_engine
+from .models_master import Tenant
+from .models_tenant import Invoice, Order, OrderItem, OrderStatus
+
+router = APIRouter()
+
+
+@asynccontextmanager
+async def _session(tenant_id: str):
+    engine = get_engine(tenant_id)
+    sessionmaker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        await engine.dispose()
+
+
+async def _get_tenants_info(tenant_ids: Iterable[str]) -> dict[str, dict]:
+    async with replica_session() as session:
+        result = await session.execute(
+            select(Tenant.id, Tenant.name, Tenant.timezone).where(
+                Tenant.id.in_(tenant_ids)
+            )
+        )
+        rows = result.all()
+    info: dict[str, dict] = {}
+    for tid, name, tz in rows:
+        info[tid] = {"name": name, "tz": tz or "UTC"}
+    return info
+
+
+def _parse_scope(request: Request) -> list[str]:
+    header = request.headers.get("x-tenant-ids")
+    if not header:
+        raise HTTPException(status_code=403, detail="forbidden")
+    return [h.strip() for h in header.split(",") if h.strip()]
+
+
+@router.get("/api/analytics/outlets")
+@read_only
+async def analytics_outlets(
+    request: Request,
+    ids: str,
+    from_: str = Query(..., alias="from"),
+    to: str = Query(...),
+    format: str | None = None,
+):
+    tenant_scope = set(_parse_scope(request))
+    requested = [tid.strip() for tid in ids.split(",") if tid.strip()]
+    if not requested:
+        raise HTTPException(status_code=400, detail="ids required")
+    if not set(requested).issubset(tenant_scope):
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    start_date = datetime.strptime(from_, "%Y-%m-%d").date()
+    end_date = datetime.strptime(to, "%Y-%m-%d").date()
+    if start_date > end_date:
+        raise HTTPException(status_code=400, detail="invalid range")
+
+    info = await _get_tenants_info(requested)
+    total_orders = 0
+    total_sales = 0.0
+    total_cancelled = 0
+    top: dict[str, int] = {}
+    durations: list[float] = []
+    per_outlet: list[dict] = []
+
+    for tid in requested:
+        tz = info.get(tid, {}).get("tz", "UTC")
+        tzinfo = ZoneInfo(tz)
+        start_dt = datetime.combine(start_date, time.min, tzinfo).astimezone(
+            timezone.utc
+        )
+        end_dt = datetime.combine(end_date, time.max, tzinfo).astimezone(timezone.utc)
+        async with _session(tid) as session:
+            orders = await session.scalar(
+                select(func.count())
+                .select_from(Order)
+                .where(Order.placed_at >= start_dt, Order.placed_at <= end_dt)
+            )
+            cancelled = await session.scalar(
+                select(func.count())
+                .select_from(Order)
+                .where(
+                    Order.placed_at >= start_dt,
+                    Order.placed_at <= end_dt,
+                    Order.status == OrderStatus.CANCELLED,
+                )
+            )
+            sales = await session.scalar(
+                select(func.coalesce(func.sum(Invoice.total), 0)).where(
+                    Invoice.created_at >= start_dt, Invoice.created_at <= end_dt
+                )
+            )
+            result = await session.execute(
+                select(OrderItem.name_snapshot, func.sum(OrderItem.qty).label("qty"))
+                .join(Order, Order.id == OrderItem.order_id)
+                .where(Order.placed_at >= start_dt, Order.placed_at <= end_dt)
+                .group_by(OrderItem.name_snapshot)
+                .order_by(desc("qty"))
+                .limit(5)
+            )
+            items = [(n, int(q)) for n, q in result.all()]
+            rows = await session.execute(
+                select(Order.accepted_at, Order.ready_at).where(
+                    Order.accepted_at.is_not(None),
+                    Order.ready_at.is_not(None),
+                    Order.accepted_at >= start_dt,
+                    Order.ready_at <= end_dt,
+                )
+            )
+            durs = [
+                (ready - accepted).total_seconds()
+                for accepted, ready in rows.all()
+                if accepted and ready
+            ]
+
+        o = int(orders or 0)
+        c = int(cancelled or 0)
+        s = float(sales or 0.0)
+        total_orders += o
+        total_sales += s
+        total_cancelled += c
+        for name, qty in items:
+            top[name] = top.get(name, 0) + qty
+        durations.extend(durs)
+        per_outlet.append(
+            {
+                "id": tid,
+                "orders": o,
+                "sales": s,
+                "aov": float(s / o) if o else 0.0,
+                "median_prep": statistics.median(durs) if durs else 0.0,
+                "voids_pct": float(c / o * 100) if o else 0.0,
+            }
+        )
+
+    aov = float(total_sales / total_orders) if total_orders else 0.0
+    top_items = sorted(top.items(), key=lambda x: x[1], reverse=True)[:5]
+    median_prep = statistics.median(durations) if durations else 0.0
+    voids_pct = float(total_cancelled / total_orders * 100) if total_orders else 0.0
+    data = {
+        "orders": total_orders,
+        "sales": total_sales,
+        "aov": aov,
+        "top_items": [{"name": n, "qty": q} for n, q in top_items],
+        "median_prep": median_prep,
+        "voids_pct": voids_pct,
+    }
+
+    if format == "csv":
+        output = StringIO()
+        writer = csv.writer(output)
+        writer.writerow(
+            ["outlet_id", "orders", "sales", "aov", "median_prep", "voids_pct"]
+        )
+        for row in per_outlet:
+            writer.writerow(
+                [
+                    row["id"],
+                    row["orders"],
+                    f"{row['sales']:.2f}",
+                    f"{row['aov']:.2f}",
+                    f"{row['median_prep']:.2f}",
+                    f"{row['voids_pct']:.2f}",
+                ]
+            )
+        resp = Response(content=output.getvalue(), media_type="text/csv")
+        resp.headers["Content-Disposition"] = "attachment; filename=outlets.csv"
+        return resp
+
+    return data

--- a/api/app/routes_owner_aggregate.py
+++ b/api/app/routes_owner_aggregate.py
@@ -4,21 +4,16 @@ from __future__ import annotations
 
 import json
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta, time, timezone
-from io import StringIO
-from zoneinfo import ZoneInfo
-import csv
-import statistics
+from datetime import datetime, timedelta
 from typing import Iterable
 
-from fastapi import APIRouter, HTTPException, Query, Request, Response
-from sqlalchemy import desc, func, select
+from fastapi import APIRouter, HTTPException, Request, Response
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from .db.replica import read_only, replica_session
 from .db.tenant import get_engine
 from .models_master import Tenant
-from .models_tenant import Invoice, Order, OrderItem
 from .pdf.render import render_template
 from .repos_sqlalchemy import dashboard_repo_sql, invoices_repo_sql
 
@@ -58,121 +53,6 @@ def _parse_scope(request: Request) -> list[str]:
         raise HTTPException(status_code=403, detail="forbidden")
     return [h.strip() for h in header.split(",") if h.strip()]
 
-
-@router.get("/api/analytics/outlets")
-@read_only
-async def analytics_outlets(
-    request: Request,
-    ids: str,
-    from_: str = Query(..., alias="from"),
-    to: str = Query(...),
-    format: str | None = None,
-):
-    tenant_scope = set(_parse_scope(request))
-    requested = [tid.strip() for tid in ids.split(",") if tid.strip()]
-    if not requested:
-        raise HTTPException(status_code=400, detail="ids required")
-    if not set(requested).issubset(tenant_scope):
-        raise HTTPException(status_code=403, detail="forbidden")
-
-    start_date = datetime.strptime(from_, "%Y-%m-%d").date()
-    end_date = datetime.strptime(to, "%Y-%m-%d").date()
-    if start_date > end_date:
-        raise HTTPException(status_code=400, detail="invalid range")
-
-    info = await _get_tenants_info(requested)
-    total_orders = 0
-    total_sales = 0.0
-    top: dict[str, int] = {}
-    durations: list[float] = []
-    per_outlet: list[dict] = []
-
-    for tid in requested:
-        tz = info.get(tid, {}).get("tz", "UTC")
-        tzinfo = ZoneInfo(tz)
-        start_dt = datetime.combine(start_date, time.min, tzinfo).astimezone(timezone.utc)
-        end_dt = datetime.combine(end_date, time.max, tzinfo).astimezone(timezone.utc)
-        async with _session(tid) as session:
-            orders = await session.scalar(
-                select(func.count())
-                .select_from(Order)
-                .where(Order.placed_at >= start_dt, Order.placed_at <= end_dt)
-            )
-            sales = await session.scalar(
-                select(func.coalesce(func.sum(Invoice.total), 0)).where(
-                    Invoice.created_at >= start_dt, Invoice.created_at <= end_dt
-                )
-            )
-            result = await session.execute(
-                select(OrderItem.name_snapshot, func.sum(OrderItem.qty).label("qty"))
-                .join(Order, Order.id == OrderItem.order_id)
-                .where(Order.placed_at >= start_dt, Order.placed_at <= end_dt)
-                .group_by(OrderItem.name_snapshot)
-                .order_by(desc("qty"))
-                .limit(5)
-            )
-            items = [(n, int(q)) for n, q in result.all()]
-            rows = await session.execute(
-                select(Order.accepted_at, Order.ready_at).where(
-                    Order.accepted_at.is_not(None),
-                    Order.ready_at.is_not(None),
-                    Order.accepted_at >= start_dt,
-                    Order.ready_at <= end_dt,
-                )
-            )
-            durs = [
-                (ready - accepted).total_seconds()
-                for accepted, ready in rows.all()
-                if accepted and ready
-            ]
-
-        o = int(orders or 0)
-        s = float(sales or 0.0)
-        total_orders += o
-        total_sales += s
-        for name, qty in items:
-            top[name] = top.get(name, 0) + qty
-        durations.extend(durs)
-        per_outlet.append(
-            {
-                "id": tid,
-                "orders": o,
-                "sales": s,
-                "aov": float(s / o) if o else 0.0,
-                "median_prep": statistics.median(durs) if durs else 0.0,
-            }
-        )
-
-    aov = float(total_sales / total_orders) if total_orders else 0.0
-    top_items = sorted(top.items(), key=lambda x: x[1], reverse=True)[:5]
-    median_prep = statistics.median(durations) if durations else 0.0
-    data = {
-        "orders": total_orders,
-        "sales": total_sales,
-        "aov": aov,
-        "top_items": [{"name": n, "qty": q} for n, q in top_items],
-        "median_prep": median_prep,
-    }
-
-    if format == "csv":
-        output = StringIO()
-        writer = csv.writer(output)
-        writer.writerow(["outlet_id", "orders", "sales", "aov", "median_prep"])
-        for row in per_outlet:
-            writer.writerow(
-                [
-                    row["id"],
-                    row["orders"],
-                    f"{row['sales']:.2f}",
-                    f"{row['aov']:.2f}",
-                    f"{row['median_prep']:.2f}",
-                ]
-            )
-        resp = Response(content=output.getvalue(), media_type="text/csv")
-        resp.headers["Content-Disposition"] = "attachment; filename=outlets.csv"
-        return resp
-
-    return data
 
 @router.get("/api/owner/{owner_id}/dashboard/charts")
 @read_only

--- a/docs/owner_analytics.md
+++ b/docs/owner_analytics.md
@@ -33,6 +33,22 @@ Owners may aggregate performance across specific outlets:
 GET /api/analytics/outlets?ids=t1,t2&from=YYYY-MM-DD&to=YYYY-MM-DD
 ```
 
-The response includes combined orders, sales, average order value, top items
-and median preparation time for the selected outlets. Adding ``format=csv``
-returns a CSV export with per‑outlet metrics.
+The response includes combined orders, sales, average order value, top items,
+median preparation time (prep SLA) and a ``voids_pct`` representing the
+percentage of orders cancelled during the period.
+
+A sample payload:
+
+```json
+{
+  "orders": 42,
+  "sales": 1234.0,
+  "aov": 29.38,
+  "top_items": [{"name": "Veg Item", "qty": 10}],
+  "median_prep": 300.0,
+  "voids_pct": 5.0
+}
+```
+
+Appending ``format=csv`` returns a CSV export with per‑outlet rows, including
+the ``voids_pct`` column.

--- a/tests/test_analytics_outlets.py
+++ b/tests/test_analytics_outlets.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from prometheus_client import registry
+
+import api.app.routes_analytics_outlets as routes_analytics_outlets
+
+sys.modules.setdefault("api.app.routes_admin_pilot", types.SimpleNamespace(router=None))
+sys.modules.setdefault("api.app.routes_admin_print", types.SimpleNamespace(router=None))
+
+os.environ.setdefault(
+    "POSTGRES_TENANT_DSN_TEMPLATE", "sqlite+aiosqlite:///./tenant_{tenant_id}.db"
+)
+os.environ.setdefault("DEFAULT_TZ", "UTC")
+
+from api.app.main import app
+
+
+class FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class FakeSession:
+    async def scalar(self, stmt):
+        text = str(stmt).lower()
+        if "status" in text:
+            return 1  # cancelled orders per tenant
+        if "count" in text:
+            return 2  # total orders per tenant
+        if "sum" in text:
+            return 100.0  # sales per tenant
+        return None
+
+    async def execute(self, stmt):
+        text = str(stmt).lower()
+        if "name_snapshot" in text:
+            return FakeResult([("Veg Item", 2)])
+        # accepted and ready times
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 1, 1, 0, 5, tzinfo=timezone.utc)
+        return FakeResult([(start, end)])
+
+
+@asynccontextmanager
+async def fake_session(tid):
+    yield FakeSession()
+
+
+@pytest.fixture(autouse=True)
+def patch_deps(monkeypatch):
+    registry.REGISTRY = registry.CollectorRegistry()
+    monkeypatch.setattr(routes_analytics_outlets, "_session", fake_session)
+
+    async def _get(ids):
+        return {tid: {"name": tid, "tz": "UTC"} for tid in ids}
+
+    monkeypatch.setattr(routes_analytics_outlets, "_get_tenants_info", _get)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_valid_range_returns_metrics(client):
+    ids = "t1,t2"
+    resp = client.get(
+        "/api/analytics/outlets",
+        params={"ids": ids, "from": "2024-01-01", "to": "2024-01-02"},
+        headers={"x-tenant-ids": ids},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["orders"] == 4
+    assert data["sales"] == 200.0
+    assert data["voids_pct"] == 50.0
+
+
+def test_invalid_range(client):
+    ids = "t1,t2"
+    resp = client.get(
+        "/api/analytics/outlets",
+        params={"ids": ids, "from": "2024-01-02", "to": "2024-01-01"},
+        headers={"x-tenant-ids": ids},
+    )
+    assert resp.status_code == 400
+
+
+def test_ids_outside_scope(client):
+    resp = client.get(
+        "/api/analytics/outlets",
+        params={"ids": "t1,x", "from": "2024-01-01", "to": "2024-01-02"},
+        headers={"x-tenant-ids": "t1"},
+    )
+    assert resp.status_code == 403
+
+
+def test_csv_format(client):
+    ids = "t1,t2"
+    resp = client.get(
+        "/api/analytics/outlets",
+        params={"ids": ids, "from": "2024-01-01", "to": "2024-01-02", "format": "csv"},
+        headers={"x-tenant-ids": ids},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    lines = resp.text.strip().splitlines()
+    assert lines[0].split(",") == [
+        "outlet_id",
+        "orders",
+        "sales",
+        "aov",
+        "median_prep",
+        "voids_pct",
+    ]
+    assert len(lines) == 3


### PR DESCRIPTION
## Summary
- split analytics outlets endpoint into dedicated router
- compute voids percentage using cancelled orders
- document multi-outlet summary and changelog entry

## Testing
- `pre-commit run --files CHANGELOG.md api/app/main.py api/app/models_tenant.py api/app/routes_owner_aggregate.py api/app/routes_analytics_outlets.py docs/owner_analytics.md tests/test_analytics_outlets.py`
- `pytest tests/test_analytics_outlets.py -q` *(fails: Internal Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_68adb13af08c832a9f66f01bd4edfea0