### PR TITLE
fix: point ghcr workflow to api dockerfile

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           push: true
           context: .
-          file: ./Dockerfile
+          file: ./Dockerfile.api
           tags: ghcr.io/${{ github.repository_owner }}/neo-api:latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 - Update GitHub Actions workflows to use `actions/upload-artifact@v4`.
 - Clean up redundant imports and outdated ``noqa`` comment to satisfy ``ruff``.
+- Point GHCR workflow to the API Dockerfile so image builds succeed.
 
 ### Added
 


### PR DESCRIPTION
## Summary
- fix GHCR workflow to build from Dockerfile.api
- document GHCR workflow fix

## Testing
- `git pull --rebase`
- `pre-commit run --files .github/workflows/ghcr.yml CHANGELOG.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'api.app.routes_admin_pilot')*

------
https://chatgpt.com/codex/tasks/task_e_68adb7839748832abf728169b46b887e