### PR TITLE
feat(sec): abuse cooldown metric + hint payload

### DIFF
--- a/api/app/routes_metrics.py
+++ b/api/app/routes_metrics.py
@@ -4,8 +4,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Request, Response
 from datetime import datetime, timezone
+
+from fastapi import APIRouter, Request, Response
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, generate_latest
 
 # Counters
@@ -39,6 +40,11 @@ room_locked_denied_total = Counter(
     "room_locked_denied_total", "Total requests denied due to locked rooms"
 )
 room_locked_denied_total.inc(0)
+
+abuse_ip_cooldown = Gauge(
+    "abuse_ip_cooldown", "Remaining cooldown seconds for abusive IP", ["ip"]
+)
+abuse_ip_cooldown.labels(ip="sample").set(0)
 
 http_errors_total = Counter("http_errors_total", "Total HTTP errors", ["status"])
 http_errors_total.labels(status="0").inc(0)
@@ -115,14 +121,11 @@ rollup_runs_total.inc(0)
 rollup_failures_total = Counter("rollup_failures_total", "Total rollup failures")
 rollup_failures_total.inc(0)
 
-printer_retry_queue = Gauge(
-    "printer_retry_queue", "Queued print jobs awaiting retry"
-)
+printer_retry_queue = Gauge("printer_retry_queue", "Queued print jobs awaiting retry")
 printer_retry_queue.set(0)
 printer_retry_queue_age = Gauge(
     "printer_retry_queue_age",
     "Age in seconds of the oldest job awaiting retry",
-
 )
 printer_retry_queue_age.set(0)
 
@@ -133,15 +136,14 @@ kds_oldest_kot_seconds = Gauge(
 )
 kds_oldest_kot_seconds.labels(tenant="sample").set(0)
 
-kot_delay_alerts_total = Counter(
-    "kot_delay_alerts_total", "Total KOT delay alerts"
-)
+kot_delay_alerts_total = Counter("kot_delay_alerts_total", "Total KOT delay alerts")
 kot_delay_alerts_total.inc(0)
 
 
 def record_ab_conversion(experiment: str, variant: str) -> None:
     """Increment conversion counter for an experiment variant."""
     ab_conversions_total.labels(experiment=experiment, variant=variant).inc()
+
 
 router = APIRouter()
 

--- a/api/app/security/blocklist.py
+++ b/api/app/security/blocklist.py
@@ -26,6 +26,12 @@ async def is_blocked(redis: Redis, tenant: str, ip: str) -> bool:
     return bool(await redis.exists(BLOCK_KEY.format(tenant=tenant, ip=ip)))
 
 
+async def block_ttl(redis: Redis, tenant: str, ip: str) -> int:
+    """Return remaining block TTL for ``ip`` within ``tenant`` in seconds."""
+    ttl = await redis.ttl(BLOCK_KEY.format(tenant=tenant, ip=ip))
+    return max(ttl, 0)
+
+
 async def block_ip(redis: Redis, tenant: str, ip: str, ttl: int = 86400) -> None:
     """Block ``ip`` for ``tenant`` for the given ``ttl`` (default 1 day)."""
     await redis.set(BLOCK_KEY.format(tenant=tenant, ip=ip), 1, ex=ttl)

--- a/api/tests/test_abuse_guard.py
+++ b/api/tests/test_abuse_guard.py
@@ -9,6 +9,8 @@ from fastapi.testclient import TestClient
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 from api.app.hooks import order_rejection
+from api.app.routes_metrics import abuse_ip_cooldown
+from api.app.security import blocklist
 from api.app.security.abuse_guard import guard
 
 app = FastAPI()
@@ -38,3 +40,24 @@ def test_cooldown_then_release():
     time.sleep(1.2)
     resp2 = client.post("/g/order")
     assert resp2.status_code == 200
+
+
+def test_abuse_metric_and_hint():
+    redis = fakeredis.aioredis.FakeRedis()
+    app.state.redis = redis
+    client = TestClient(app)
+
+    async def _prepare():
+        await blocklist.block_ip(redis, "demo", "testclient", ttl=5)
+
+    asyncio.run(_prepare())
+
+    resp = client.post("/g/order")
+    assert resp.status_code == 429
+    data = resp.json()["detail"]["error"]
+    assert data["code"] == "ABUSE_COOLDOWN"
+    secs = int(data["hint"].split()[3][:-1])
+    ttl = asyncio.run(blocklist.block_ttl(redis, "demo", "testclient"))
+    assert abs(secs - ttl) <= 1
+    metric = abuse_ip_cooldown._metrics[("testclient",)]._value.get()  # type: ignore[attr-defined]
+    assert abs(metric - ttl) <= 1

--- a/api/tests/test_guest_block.py
+++ b/api/tests/test_guest_block.py
@@ -11,7 +11,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 from api.app.hooks import order_rejection
 from api.app.middlewares.guest_block import GuestBlockMiddleware
 from api.app.security import ip_reputation
-from api.app.security.blocklist import add_rejection, is_blocked, block_ip, clear_ip
+from api.app.security.blocklist import add_rejection, block_ip, clear_ip, is_blocked
 
 app = FastAPI()
 app.add_middleware(GuestBlockMiddleware)
@@ -55,7 +55,9 @@ def test_block_after_three_manual_rejections():
 
     resp = client.post("/g/echo", headers={"X-Tenant-ID": "demo"})
     assert resp.status_code == 429
-    assert resp.json()["error"]["code"] == "IP_BLOCKED"
+    data = resp.json()["error"]
+    assert data["code"] == "ABUSE_COOLDOWN"
+    assert data["hint"].startswith("Try again in ")
 
 
 def test_user_agent_denylist():

--- a/docs/Pack_B_Ops_Security/Rate_Limit_Blocklist_Policy.md
+++ b/docs/Pack_B_Ops_Security/Rate_Limit_Blocklist_Policy.md
@@ -1,7 +1,7 @@
 # Rate Limit & Blocklist Policy
 
 - Guest APIs: 60 req/min/IP (burst 100).
-- After 3 **rejected** orders within 24h from the same IP for a tenant → blocklist for 24h (configurable) and further requests receive `IP_BLOCKED` (HTTP 429) from the `GuestBlockMiddleware`.
+- After 3 **rejected** orders within 24h from the same IP for a tenant → blocklist for 24h (configurable) and further requests receive `ABUSE_COOLDOWN` (HTTP 429) with hint `Try again in Xs` from the `GuestBlockMiddleware`.
 - Allow unblock by Super-Admin via `POST /api/outlet/{tenant}/security/unblock_ip`.
 - Implementation uses a Redis-backed token bucket (INCR + EXPIRE) to enforce
   burst and sustained rates.

--- a/docs/abuse_guard.md
+++ b/docs/abuse_guard.md
@@ -4,7 +4,9 @@
 traffic.
 
 - **IP cooldown**: After three rejected orders from the same IP within a day the
-  address is cooled down for fifteen minutes.
+  address is cooled down for fifteen minutes. Cooldowns emit a Prometheus
+  metric `abuse_ip_cooldown{ip="1.2.3.4"}` with the remaining TTL and the API
+  responds with an `ABUSE_COOLDOWN` error hinting `Try again in Xs`.
 - **User-Agent denylist**: Requests from known bad agents such as `curl` and
   `wget` are rejected.
 - **Geo sanity hint**: If the reported `X-Geo-City` header does not match the

--- a/docs/order_rejection_hook.md
+++ b/docs/order_rejection_hook.md
@@ -9,5 +9,7 @@ should be blocked.
 
 After three rejected orders from the same IP within 24 hours for a tenant the
 address is cooled down for fifteen minutes and further guest `POST /g/*`
-requests return an `IP_BLOCKED` (HTTP 429) envelope. Admins may clear an
-address with `POST /api/outlet/{tenant}/security/unblock_ip`.
+requests return an `ABUSE_COOLDOWN` (HTTP 429) envelope with a hint like
+`Try again in 900s`. A Prometheus metric `abuse_ip_cooldown{ip}` captures the
+remaining TTL. Admins may clear an address with
+`POST /api/outlet/{tenant}/security/unblock_ip`.


### PR DESCRIPTION
## Summary
- track remaining IP cooldown in `abuse_ip_cooldown{ip}` gauge and expose TTL in hint
- add block TTL helper and surface `ABUSE_COOLDOWN` responses in abuse guard and guest middleware
- document new cooldown metric and response semantics

## Testing
- `pre-commit run --files api/app/security/blocklist.py api/app/security/abuse_guard.py api/app/middlewares/guest_block.py api/app/routes_metrics.py api/tests/test_abuse_guard.py api/tests/test_guest_block.py docs/abuse_guard.md docs/order_rejection_hook.md docs/Pack_B_Ops_Security/Rate_Limit_Blocklist_Policy.md`
- `pytest api/tests/test_abuse_guard.py api/tests/test_guest_block.py`


------
https://chatgpt.com/codex/tasks/task_e_68adb845d4b0832aa3bfe000bc407897