### PR TITLE
feat(print): add preview PNG to print test route

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -56,4 +56,11 @@ jobs:
         run: pre-commit run --hook-stage manual i18n-lint --all-files
       - name: Test
         run: pytest --cov --cov-report=term --cov-fail-under=80 -q
+      - name: Save print-test PNG
+        run: python scripts/save_print_test_png.py
+      - name: Upload print-test PNG
+        uses: actions/upload-artifact@v4
+        with:
+          name: print-test-${{ matrix.db }}
+          path: print-test.png
 

--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,4 @@ static/fonts/*.ttf
 # Downloaded PWA icons
 static/icons/neo-qr-192.png
 static/icons/neo-qr-512.png
+print-test.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- chore(print): print-test PNG artifact in CI.
 - feat(analytics): multi-outlet summary with CSV export and voids percentage.
 - Flagged server-side menu A/B testing with deterministic bucketing and exposure tracking.
 - L1 support console for tenant/table/order lookup with safe actions (resend invoice, reprint KOT, replay webhook, unlock PIN) and audit logging.

--- a/api/app/render_text_image.py
+++ b/api/app/render_text_image.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import io
+from typing import List
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+def render_text_image(text: str) -> bytes:
+    """Render ``text`` to a PNG image and return raw bytes."""
+    try:
+        font = ImageFont.truetype("DejaVuSansMono.ttf", 14)
+    except OSError:
+        font = ImageFont.load_default()
+
+    lines: List[str] = text.splitlines() or [""]
+    bbox_a = font.getbbox("A")
+    line_height = bbox_a[3] - bbox_a[1]
+    max_width = 0
+    for line in lines:
+        bbox = font.getbbox(line)
+        line_width = bbox[2] - bbox[0]
+        if line_width > max_width:
+            max_width = line_width
+    width = max_width + 10
+    height = line_height * len(lines) + 10
+
+    image = Image.new("RGB", (width, height), "white")
+    draw = ImageDraw.Draw(image)
+    y = 5
+    for line in lines:
+        draw.text((5, y), line, font=font, fill="black")
+        y += line_height
+
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    return buf.getvalue()

--- a/api/app/routes_print_test.py
+++ b/api/app/routes_print_test.py
@@ -1,12 +1,14 @@
 """Admin test route for printers."""
 from __future__ import annotations
 
+import base64
 from datetime import datetime, timezone
 from typing import Literal
 
 from fastapi import APIRouter, Request
-from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
+
+from .render_text_image import render_text_image
 
 router = APIRouter()
 
@@ -15,15 +17,22 @@ class PrintTestPayload(BaseModel):
     printer: Literal["58mm", "80mm"]
 
 
-@router.post("/admin/print/test")
+class PrintTestResponse(BaseModel):
+    preview: str
+    image: str
+
+
+@router.post("/admin/print/test", response_model=PrintTestResponse)
 async def admin_print_test(
     payload: PrintTestPayload, request: Request
-) -> PlainTextResponse:
+) -> PrintTestResponse:
     """Return preview text and publish a test print event."""
     timestamp = datetime.now(timezone.utc).isoformat()
     outlet = "demo"
     title = request.app.title
     preview = f"outlet: {outlet}\ntitle: {title}\ntimestamp: {timestamp}\n"
+    png_bytes = render_text_image(preview)
+    image_b64 = base64.b64encode(png_bytes).decode()
     redis = request.app.state.redis
     await redis.publish(f"print:test:{payload.printer}", preview)
-    return PlainTextResponse(preview)
+    return PrintTestResponse(preview=preview, image=image_b64)

--- a/api/tests/test_print_test_route.py
+++ b/api/tests/test_print_test_route.py
@@ -1,3 +1,4 @@
+import base64
 from datetime import datetime
 
 import fakeredis.aioredis
@@ -24,11 +25,16 @@ def test_admin_print_test_previews_and_publishes():
 
     resp = client.post("/admin/print/test", json={"printer": "80mm"})
     assert resp.status_code == 200
-    body = resp.text
-    assert "outlet" in body
-    assert "title" in body
-    assert "timestamp" in body
-    ts_line = next(line for line in body.splitlines() if line.startswith("timestamp:"))
+    body = resp.json()
+    preview = body["preview"]
+    assert "outlet" in preview
+    assert "title" in preview
+    assert "timestamp" in preview
+    ts_line = next(
+        line for line in preview.splitlines() if line.startswith("timestamp:")
+    )
     datetime.fromisoformat(ts_line.split("timestamp: ", 1)[1])
+    img = base64.b64decode(body["image"])
+    assert img.startswith(b"\x89PNG\r\n\x1a\n")
     assert calls["count"] == 1
     assert calls["channel"] == "print:test:80mm"

--- a/docs/PRINTING.md
+++ b/docs/PRINTING.md
@@ -29,10 +29,10 @@ browser before sending it to hardware.
 
 ## Admin test route
 
-POST `/admin/print/test` accepts `{"printer": "58mm"|"80mm"}` and returns
-preview text containing the outlet name, a title, and a current ISO timestamp
-while also publishing a message for connected print agents. This helps verify
-printer connectivity from the dashboard.
+POST `/admin/print/test` accepts `{"printer": "58mm"|"80mm"}` and returns a
+JSON object containing the preview text along with a base64-encoded PNG for
+visual confirmation. It also publishes a message for connected print agents to
+help verify printer connectivity from the dashboard.
 
 ## Security
 

--- a/scripts/save_print_test_png.py
+++ b/scripts/save_print_test_png.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import base64
+
+import fakeredis.aioredis
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.app.routes_print_test import router
+
+
+def main() -> None:
+    fake = fakeredis.aioredis.FakeRedis()
+    app = FastAPI()
+    app.include_router(router)
+    app.state.redis = fake
+    client = TestClient(app)
+
+    resp = client.post("/admin/print/test", json={"printer": "80mm"})
+    resp.raise_for_status()
+    data = resp.json()
+    image_bytes = base64.b64decode(data["image"])
+    with open("print-test.png", "wb") as fh:
+        fh.write(image_bytes)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- return preview text and base64 PNG from /admin/print/test
- capture PNG artifact in CI
- document print-test response and artifact

## Testing
- `pre-commit run --files .github/workflows/python-tests.yml .gitignore CHANGELOG.md api/app/render_text_image.py api/app/routes_print_test.py api/tests/test_print_test_route.py scripts/save_print_test_png.py docs/PRINTING.md`
- `PYTHONPATH=. pytest api/tests/test_print_test_route.py -q`
- `PYTHONPATH=. python scripts/save_print_test_png.py && ls print-test.png`

------
https://chatgpt.com/codex/tasks/task_e_68adb8d6d2e4832ab7d2c484efb274b9