### PR TITLE
Handle integration probe warnings and extend marketplace tests

### DIFF
--- a/api/app/routes_integrations_marketplace.py
+++ b/api/app/routes_integrations_marketplace.py
@@ -69,6 +69,17 @@ async def connect_integration(
     probe_report = None
     if payload.url:
         probe_report = await probe_webhook(str(payload.url))
+        warnings = set(probe_report.get("warnings", []))
+        if "tls_self_signed" in warnings:
+            raise HTTPException(
+                status_code=400,
+                detail="Webhook has self-signed TLS certificate",
+            )
+        if "slow" in warnings:
+            raise HTTPException(
+                status_code=400,
+                detail="Webhook responded too slowly",
+            )
     TENANT_INTEGRATIONS.setdefault(tenant, {})[payload.type] = {
         "url": str(payload.url) if payload.url else None,
         "key": payload.key,

--- a/api/tests/test_integrations_marketplace.py
+++ b/api/tests/test_integrations_marketplace.py
@@ -6,6 +6,7 @@ import types
 
 import fakeredis.aioredis
 from httpx import ASGITransport, AsyncClient
+import pytest
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
@@ -21,9 +22,13 @@ sys.modules.setdefault(
     "api.app.services.printer_watchdog", types.ModuleType("printer_watchdog")
 )
 
+from fastapi import FastAPI
+
 from api.app import routes_integrations_marketplace  # noqa: E402
 from api.app.auth import create_access_token  # noqa: E402
-from api.app.main import app  # noqa: E402
+
+app = FastAPI()
+app.include_router(routes_integrations_marketplace.router)
 
 app.state.redis = fakeredis.aioredis.FakeRedis()
 
@@ -47,7 +52,9 @@ def test_list_marketplace():
     assert {"google_sheets", "slack", "zoho_books"}.issubset(types_list)
 
 
-def test_connect_integration(monkeypatch):
+@pytest.mark.parametrize("integration_type", ["slack", "google_sheets", "zoho_books"])
+def test_connect_integration(monkeypatch, integration_type):
+    routes_integrations_marketplace.TENANT_INTEGRATIONS.clear()
     report = {"allowed": True}
 
     async def fake_probe(url: str):
@@ -63,7 +70,7 @@ def test_connect_integration(monkeypatch):
         ) as client:
             resp = await client.post(
                 "/api/outlet/t1/integrations/connect",
-                json={"type": "slack", "url": "https://example.com/hook"},
+                json={"type": integration_type, "url": "https://example.com/hook"},
                 headers={"Authorization": f"Bearer {token}"},
             )
         return resp
@@ -73,6 +80,76 @@ def test_connect_integration(monkeypatch):
     data = resp.json()["data"]
     assert data["probe"] == report
     assert (
-        routes_integrations_marketplace.TENANT_INTEGRATIONS["t1"]["slack"]["url"]
+        routes_integrations_marketplace.TENANT_INTEGRATIONS["t1"][integration_type]["url"]
         == "https://example.com/hook"
     )
+
+
+def test_connect_integration_tenant_isolation(monkeypatch):
+    routes_integrations_marketplace.TENANT_INTEGRATIONS.clear()
+    report = {"allowed": True}
+
+    async def fake_probe(url: str):
+        return report
+
+    monkeypatch.setattr(routes_integrations_marketplace, "probe_webhook", fake_probe)
+
+    token = create_access_token({"sub": "admin@example.com", "role": "super_admin"})
+
+    async def _run():
+        async with AsyncClient(
+            transport=ASGITransport(app), base_url="http://test"
+        ) as client:
+            await client.post(
+                "/api/outlet/t1/integrations/connect",
+                json={"type": "slack", "url": "https://example.com/one"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            await client.post(
+                "/api/outlet/t2/integrations/connect",
+                json={"type": "slack", "url": "https://example.com/two"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+    asyncio.run(_run())
+    assert (
+        routes_integrations_marketplace.TENANT_INTEGRATIONS["t1"]["slack"]["url"]
+        == "https://example.com/one"
+    )
+    assert (
+        routes_integrations_marketplace.TENANT_INTEGRATIONS["t2"]["slack"]["url"]
+        == "https://example.com/two"
+    )
+
+
+@pytest.mark.parametrize(
+    "warnings,detail",
+    [
+        (["tls_self_signed"], "Webhook has self-signed TLS certificate"),
+        (["slow"], "Webhook responded too slowly"),
+    ],
+)
+def test_connect_integration_with_warnings(monkeypatch, warnings, detail):
+    routes_integrations_marketplace.TENANT_INTEGRATIONS.clear()
+    report = {"allowed": True, "warnings": warnings}
+
+    async def fake_probe(url: str):
+        return report
+
+    monkeypatch.setattr(routes_integrations_marketplace, "probe_webhook", fake_probe)
+
+    token = create_access_token({"sub": "admin@example.com", "role": "super_admin"})
+
+    async def _run():
+        async with AsyncClient(
+            transport=ASGITransport(app), base_url="http://test"
+        ) as client:
+            return await client.post(
+                "/api/outlet/t1/integrations/connect",
+                json={"type": "slack", "url": "https://example.com/hook"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+    resp = asyncio.run(_run())
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == detail

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -1,0 +1,46 @@
+# Integration Setup Guide
+
+This document provides an overview of the integration marketplace, connection workflow, and troubleshooting tips for common integrations.
+
+## Marketplace Overview
+
+The marketplace exposes a curated list of integrations that can be connected per tenant. Each integration includes a sample payload to help validate webhook handling.
+
+## Connection Workflow
+
+1. List available integrations to discover supported services.
+2. Choose an integration and provide the destination URL or key.
+3. The system probes the webhook for reachability and performance.
+4. On success, the configuration is stored for the tenant.
+
+## Troubleshooting
+
+If connection fails, verify the following:
+
+- **Self-signed TLS**: Use a certificate from a trusted authority.
+- **Slow responses**: Ensure the endpoint responds within one second.
+
+## Slack
+
+1. Navigate to *Incoming Webhooks* in Slack and create a new webhook URL.
+2. Use the generated URL when connecting the integration.
+3. Confirm messages appear in the selected channel.
+
+![Slack setup](images/slack_setup.png)
+
+## Google Sheets
+
+1. Create a script endpoint that appends rows to a sheet.
+2. Publish the script as a web app and obtain the URL.
+3. Provide this URL during connection and test with sample payloads.
+
+![Google Sheets setup](images/google_sheets_setup.png)
+
+## Zoho Books
+
+1. Enable webhooks in Zoho Books and create a new rule.
+2. Enter the webhook URL provided by Neo.
+3. Verify invoices trigger the webhook on payment events.
+
+![Zoho Books setup](images/zoho_books_setup.png)
+

--- a/docs/integrations_marketplace.md
+++ b/docs/integrations_marketplace.md
@@ -21,3 +21,5 @@ POST /api/outlet/{tenant}/integrations/connect
 ```
 
 Validates the URL with a probe and stores the configuration for the tenant.
+
+For detailed setup instructions and troubleshooting, see [INTEGRATIONS.md](INTEGRATIONS.md).


### PR DESCRIPTION
## Summary
- Validate integration webhooks for self-signed TLS and slow responses, returning helpful hints
- Parameterize marketplace connection tests for Slack, Google Sheets, and Zoho Books with tenant isolation coverage
- Add integration setup documentation with troubleshooting tips and cross-link

## Testing
- `pytest api/tests/test_integrations_marketplace.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adba480a6c832aac31adb6e4dbf85c