### PR TITLE
Add CLS/INP RUM tests and dashboard

### DIFF
--- a/api/tests/test_rum_vitals.py
+++ b/api/tests/test_rum_vitals.py
@@ -7,40 +7,96 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 import api.app.routes_rum_vitals as routes_rum_vitals
-from api.app.routes_rum_vitals import router, lcp_hist
+from api.app.routes_rum_vitals import cls_hist, inp_hist, lcp_hist, router
 
 app = FastAPI()
 app.include_router(router)
 client = TestClient(app)
 
 
-def _metric_sum(route: str = "/home") -> float:
-    return lcp_hist.labels(route=route)._sum.get()
+def _metric_sum(hist, route: str = "/admin") -> float:
+    return hist.labels(route=route)._sum.get()
 
 
 def test_requires_flag_and_consent(monkeypatch):
-    before = _metric_sum()
+    before = _metric_sum(lcp_hist)
 
     monkeypatch.setattr(routes_rum_vitals, "get_flag", lambda name, tenant=None: False)
     client.post(
         "/rum/vitals",
-        json={"lcp": 1.2, "consent": True, "route": "/home"},
+        json={"lcp": 1.2, "consent": True, "route": "/admin"},
         headers={"X-Tenant-ID": "demo"},
     )
-    assert _metric_sum("/home") == before
+    assert _metric_sum(lcp_hist, "/admin") == before
 
     monkeypatch.setattr(routes_rum_vitals, "get_flag", lambda name, tenant=None: True)
     client.post(
         "/rum/vitals",
-        json={"lcp": 1.2, "consent": False, "route": "/home"},
+        json={"lcp": 1.2, "consent": False, "route": "/admin"},
         headers={"X-Tenant-ID": "demo"},
     )
-    assert _metric_sum("/home") == before
+    assert _metric_sum(lcp_hist, "/admin") == before
 
     client.post(
         "/rum/vitals",
-        json={"lcp": 1.2, "consent": True, "route": "/home"},
+        json={"lcp": 1.2, "consent": True, "route": "/admin"},
         headers={"X-Tenant-ID": "demo"},
     )
-    assert _metric_sum("/home") == before + 1.2
-    assert _metric_sum("/other") == 0
+    assert _metric_sum(lcp_hist, "/admin") == before + 1.2
+    assert _metric_sum(lcp_hist, "/other") == 0
+
+
+def test_cls_requires_flag_and_consent(monkeypatch):
+    before = _metric_sum(cls_hist)
+
+    monkeypatch.setattr(routes_rum_vitals, "get_flag", lambda name, tenant=None: False)
+    client.post(
+        "/rum/vitals",
+        json={"cls": 0.5, "consent": True, "route": "/admin"},
+        headers={"X-Tenant-ID": "demo"},
+    )
+    assert _metric_sum(cls_hist, "/admin") == before
+
+    monkeypatch.setattr(routes_rum_vitals, "get_flag", lambda name, tenant=None: True)
+    client.post(
+        "/rum/vitals",
+        json={"cls": 0.5, "consent": False, "route": "/admin"},
+        headers={"X-Tenant-ID": "demo"},
+    )
+    assert _metric_sum(cls_hist, "/admin") == before
+
+    client.post(
+        "/rum/vitals",
+        json={"cls": 0.5, "consent": True, "route": "/admin"},
+        headers={"X-Tenant-ID": "demo"},
+    )
+    assert _metric_sum(cls_hist, "/admin") == before + 0.5
+    assert _metric_sum(cls_hist, "/other") == 0
+
+
+def test_inp_requires_flag_and_consent(monkeypatch):
+    before = _metric_sum(inp_hist)
+
+    monkeypatch.setattr(routes_rum_vitals, "get_flag", lambda name, tenant=None: False)
+    client.post(
+        "/rum/vitals",
+        json={"inp": 1.0, "consent": True, "route": "/admin"},
+        headers={"X-Tenant-ID": "demo"},
+    )
+    assert _metric_sum(inp_hist, "/admin") == before
+
+    monkeypatch.setattr(routes_rum_vitals, "get_flag", lambda name, tenant=None: True)
+    client.post(
+        "/rum/vitals",
+        json={"inp": 1.0, "consent": False, "route": "/admin"},
+        headers={"X-Tenant-ID": "demo"},
+    )
+    assert _metric_sum(inp_hist, "/admin") == before
+
+    client.post(
+        "/rum/vitals",
+        json={"inp": 1.0, "consent": True, "route": "/admin"},
+        headers={"X-Tenant-ID": "demo"},
+    )
+    assert _metric_sum(inp_hist, "/admin") == before + 1.0
+    assert _metric_sum(inp_hist, "/other") == 0

--- a/deploy/dashboards/rum.json
+++ b/deploy/dashboards/rum.json
@@ -1,0 +1,71 @@
+{
+  "id": null,
+  "uid": "rum",
+  "title": "Web Vitals RUM",
+  "timezone": "",
+  "schemaVersion": 36,
+  "version": 1,
+  "refresh": "5m",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "LCP by route",
+      "datasource": "prometheus",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(web_vitals_lcp_seconds_bucket[5m])) by (le, route))",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.75, sum(rate(web_vitals_lcp_seconds_bucket[5m])) by (le, route))",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(web_vitals_lcp_seconds_bucket[5m])) by (le, route))",
+          "refId": "C"
+        }
+      ],
+      "id": 1
+    },
+    {
+      "type": "graph",
+      "title": "CLS by route",
+      "datasource": "prometheus",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(web_vitals_cls_bucket[5m])) by (le, route))",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.75, sum(rate(web_vitals_cls_bucket[5m])) by (le, route))",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(web_vitals_cls_bucket[5m])) by (le, route))",
+          "refId": "C"
+        }
+      ],
+      "id": 2
+    },
+    {
+      "type": "graph",
+      "title": "INP by route",
+      "datasource": "prometheus",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(web_vitals_inp_seconds_bucket[5m])) by (le, route))",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.75, sum(rate(web_vitals_inp_seconds_bucket[5m])) by (le, route))",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(web_vitals_inp_seconds_bucket[5m])) by (le, route))",
+          "refId": "C"
+        }
+      ],
+      "id": 3
+    }
+  ]
+}

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -52,3 +52,26 @@ VITE_TENANT_ID=<tenant> npm run build
 The value will be sent as `X-Tenant-ID` in all API calls including the RUM
 endpoint.
 
+### Grafana dashboard
+
+`deploy/dashboards/rum.json` defines a Grafana dashboard with panels for
+Largest Contentful Paint (LCP), Cumulative Layout Shift (CLS) and Interaction to
+Next Paint (INP). Each panel charts the p50, p75 and p95 percentiles per route
+using the Prometheus histograms. Import the JSON through Grafana's **Dashboards →
+Import** page to load it.
+
+The percentile panels help interpret performance: p50 is the median, p75 shows
+upper-quartile latencies and p95 highlights worst-case routes.
+
+### Sample PromQL
+
+Percentiles can be queried directly with `histogram_quantile`:
+
+```promql
+histogram_quantile(0.95, sum(rate(web_vitals_lcp_seconds_bucket{route="/"}[5m])) by (le))
+histogram_quantile(0.95, sum(rate(web_vitals_cls_bucket{route="/"}[5m])) by (le))
+histogram_quantile(0.95, sum(rate(web_vitals_inp_seconds_bucket{route="/"}[5m])) by (le))
+```
+
+Replace `0.95` with `0.50` or `0.75` for other percentiles.
+


### PR DESCRIPTION
## Summary
- extend RUM vitals tests to cover CLS and INP metrics gated by consent and feature flag
- add Grafana dashboard for Web Vitals with p50/p75/p95 per route
- document dashboard import and PromQL histogram quantile examples

## Testing
- `pre-commit run --files api/tests/test_rum_vitals.py deploy/dashboards/rum.json docs/analytics.md`
- `pytest api/tests/test_rum_vitals.py`
- `pytest tests/test_rum_vitals.py` *(fails: ModuleNotFoundError: No module named 'api.app.routes_admin_pilot')*


------
https://chatgpt.com/codex/tasks/task_e_68adb9cad138832ab316e9f255577632