### PR TITLE
Improve release tagging and pilot deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## v1.0.0-rc1 - 2025-08-25
-
-
 ## Unreleased
 
 ### Fixed
@@ -64,7 +61,7 @@ All notable changes to this project will be documented in this file.
 - Idempotent payment refunds via `/payments/{id}/refund` endpoint.
 - Extra tenant isolation and signed media tests to enforce cross-tenant boundaries.
 - Per-coupon usage caps (per day/guest/outlet) with valid-from/to windows and
-  usage auditing, returning helpful hints when limits are exceeded.>>>>>>> main
+  usage auditing, returning helpful hints when limits are exceeded.
 
 - Opt-in owner digest with richer stats (top 10 items, comps %, voids, tips,
   prep SLA hit rate) and after-hours throttling.
@@ -114,7 +111,9 @@ All notable changes to this project will be documented in this file.
 - Bundle Noto Sans fonts for printable invoices and KOTs, covering the ₹ sign and Gujarati/Hindi glyphs.
 - Handle per-item GST/HSN display with IGST support, outlet-wide ₹0.01 rounding and composition invoices without GST lines.
 
+## v1.0.0-rc1 - 2025-08-25
 
+- Second release candidate.
 
 ## v1.0.0-rc - 2025-08-25
 

--- a/docs/GO_LIVE_CHECKLIST.md
+++ b/docs/GO_LIVE_CHECKLIST.md
@@ -11,6 +11,7 @@
 - Pilot smoke: menu→order→bill path OK
 - Printing agent OK; fonts verified
 - Licensing plan + grace flows verified
+- Telemetry and NPS capture enabled ([pilot survey](PILOT_SURVEY.md))
 
 ## General availability
 
@@ -20,3 +21,5 @@
 - Blue/green switch rehearsed
 - Rollback path documented and tested
 - Alert routing to on-call channels confirmed
+- Telemetry dashboards verified ([analytics](analytics.md))
+- Rollback status documented with reference to [status.json](../status.json)

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -1,4 +1,5 @@
 .PHONY: up down incident-start incident-resolve
+.PHONY: pilot
 
 # Start the local development stack
 up:
@@ -12,4 +13,11 @@ incident-start:
 	python scripts/status_page.py start "$(TITLE)" "$(DETAILS)"
 
 incident-resolve:
-	python scripts/status_page.py resolve "$(TITLE)"
+        python scripts/status_page.py resolve "$(TITLE)"
+
+# Deploy pilot stack, ramp traffic, and enable telemetry.
+# Requires TELEMETRY_API_URL and TELEMETRY_API_TOKEN.
+pilot:
+	python scripts/deploy_blue_green.py --env=pilot
+	python scripts/weighted_canary_ramp.py --env=pilot
+	curl -X POST "$${TELEMETRY_API_URL}/enable?env=pilot" -H "Authorization: Bearer $${TELEMETRY_API_TOKEN}"

--- a/scripts/release_tag.py
+++ b/scripts/release_tag.py
@@ -104,14 +104,20 @@ def build_groups(prs: Dict[int, Tuple[str, List[str]]]) -> str:
 
 
 def next_tag(current: str | None, final: bool) -> str:
+    """Return the next tag.
+
+    The first pre-release returns ``<base>-rc`` without a numeric suffix. Subsequent
+    release candidates are suffixed with an incrementing number (``-rc1``, ``-rc2`` ...).
+    """
+
     if final:
         return BASE_VERSION
-    if current and current.startswith(f"{BASE_VERSION}-rc"):
-        try:
-            n = int(current.split("-rc")[1])
-        except ValueError:
-            n = 0
-    else:
+    if not current or not current.startswith(f"{BASE_VERSION}-rc"):
+        return f"{BASE_VERSION}-rc"
+    suffix = current.split(f"{BASE_VERSION}-rc", 1)[1]
+    try:
+        n = int(suffix) if suffix else 0
+    except ValueError:
         n = 0
     return f"{BASE_VERSION}-rc{n + 1}"
 
@@ -130,7 +136,9 @@ def create_tag(tag: str) -> None:
 
 
 def main(argv: Iterable[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Tag a release")
+    parser = argparse.ArgumentParser(
+        description="Tag a release; first RC is '-rc' then '-rc1', '-rc2', etc."
+    )
     parser.add_argument("--final", action="store_true", help="create final release tag")
     args = parser.parse_args(list(argv) if argv is not None else None)
 


### PR DESCRIPTION
## Summary
- Teach release_tag.py to emit `<base>-rc` for first pre-release and clarify CLI help.
- Expand go-live checklist with telemetry/NPS steps and rollback references.
- Add `pilot` Makefile target to deploy and enable telemetry.
- Fix merge marker in changelog and keep Unreleased at top.

## Testing
- `pre-commit run --files scripts/release_tag.py docs/GO_LIVE_CHECKLIST.md ops/Makefile CHANGELOG.md`
- `pytest` *(fails: 74 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adba28bc40832abd0edd61d1013cb9