### PR TITLE
Stream analytics outlets CSV export

### DIFF
--- a/docs/owner_analytics.md
+++ b/docs/owner_analytics.md
@@ -50,5 +50,14 @@ A sample payload:
 }
 ```
 
-Appending ``format=csv`` returns a CSV export with per‑outlet rows, including
-the ``voids_pct`` column.
+Appending ``export=csv`` streams a CSV export with per‑outlet rows, including
+the ``voids_pct`` column. The response yields the header followed by one line
+per outlet so large exports do not need to be buffered in memory.
+
+Example request:
+
+```bash
+curl "https://example.com/api/analytics/outlets?ids=t1,t2&from=2024-01-01&to=2024-01-03&export=csv" \
+  -H "x-tenant-ids: t1,t2"
+```
+


### PR DESCRIPTION
## Summary
- switch outlets analytics query parameter to `export` and stream CSV responses
- document `export=csv` usage and streaming behavior
- adjust tests for streaming CSV and verify tenant scope/date boundaries

## Testing
- `pytest api/tests/test_analytics_outlets.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68adba74cea4832aa80d904b80acf6fc