### PR TITLE
Stream export completion and docs

### DIFF
--- a/docs/EXPORTS.md
+++ b/docs/EXPORTS.md
@@ -1,10 +1,8 @@
 # Exports
 
 Big export endpoints support cursor-based pagination so interrupted downloads can resume.
-Each request is capped at **100 000 rows**; when the cap is hit the response includes an
-`X-Row-Limit` header and a `Next-Cursor` value to continue from.
-
-Each request caps output to **100k rows**; if hit, the `X-Export-Hint` header advises clients to refine the range and resume with the provided cursor.
+Each request is capped at **100 000 rows**. When the cap is hit the CSV ends with a `cap hit`
+row and the response includes `X-Row-Limit` and `Next-Cursor` headers to continue from.
 
 Export downloads are provided via tenant-scoped, signed URLs to ensure isolation.
 
@@ -69,15 +67,6 @@ with open("daily.csv", "ab") as fh:
             break
 ```
 
-### Progress via SSE
-
-Provide a `progress` query parameter to the export request and listen on:
-
-```
-GET /api/outlet/demo/exports/progress/{progress}
-```
-
-Each event reports rows exported so far.
 
 ## Helper CLI
 
@@ -107,8 +96,7 @@ corresponding progress stream:
 curl -N http://localhost:8000/api/outlet/demo/exports/daily/progress/abc
 ```
 
-The stream emits `progress` events with the number of rows exported and ends
-with a `complete` event.
+The stream emits `progress` events every 1 000 rows and ends with a `complete` event.
 ## Accounting exports
 
 Lightweight CSVs allow hand-off to ledger software without a full integration.


### PR DESCRIPTION
## Summary
- delete invoice export progress key once streaming is done and send a final `complete` SSE event
- document CSV truncation headers and progress completion signal
- ensure daily ZIP exports keep `export.zip` filename and compute next cursor once

## Testing
- `python -m pytest api/tests/test_exports_stream.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68adbab23204832aae46c089c4c319d0