### PR TITLE
fix: mark non-security md5 and enable autoescape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Mark non-security MD5 usage in A/B bucketing and tests with ``usedforsecurity=False``.
+- Enable Jinja ``select_autoescape`` for ESC/POS presets to avoid unsafe rendering.
 - Update GitHub Actions workflows to use `actions/upload-artifact@v4`.
 - Clean up redundant imports and outdated ``noqa`` comment to satisfy ``ruff``.
 - Point GHCR workflow to the API Dockerfile so image builds succeed.

--- a/api/app/exp/ab_allocator.py
+++ b/api/app/exp/ab_allocator.py
@@ -24,7 +24,7 @@ def allocate(device_id: str, experiment: str, variants: Dict[str, int]) -> str:
     if total <= 0:
         return "control"
     key = f"{experiment}:{device_id}".encode()
-    bucket = int(hashlib.md5(key).hexdigest(), 16) % total
+    bucket = int(hashlib.md5(key, usedforsecurity=False).hexdigest(), 16) % total
     cumulative = 0
     for name, weight in variants.items():
         cumulative += weight

--- a/api/app/printing/escpos_presets.py
+++ b/api/app/printing/escpos_presets.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Any
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 TEMPLATE_DIR = Path(__file__).resolve().parents[3] / "templates" / "escpos"
-_env = Environment(loader=FileSystemLoader(TEMPLATE_DIR), autoescape=False)
+_env = Environment(
+    loader=FileSystemLoader(TEMPLATE_DIR),
+    autoescape=select_autoescape(["html", "xml"]),
+)
 
 TEMPLATE_MAP: Dict[str, str] = {
     "58mm": "58mm.txt",

--- a/api/app/routes_guest_menu.py
+++ b/api/app/routes_guest_menu.py
@@ -80,7 +80,9 @@ async def fetch_menu(
     if settings.ab_tests_enabled:
         variant = request.cookies.get("ab_menu")
         if variant not in {"A", "B"}:
-            bucket = int(hashlib.md5(table_token.encode()).hexdigest(), 16) % 2
+            bucket = int(
+                hashlib.md5(table_token.encode(), usedforsecurity=False).hexdigest(), 16
+            ) % 2
             variant = "B" if bucket else "A"
             response.set_cookie("ab_menu", variant, path="/")
         resp_data["ab_variant"] = variant

--- a/api/tests/test_menu_ab.py
+++ b/api/tests/test_menu_ab.py
@@ -61,7 +61,7 @@ def test_menu_ab_allocation_and_exposure(monkeypatch):
     assert resp.status_code == 200
     body = resp.json()
     variant = body["data"]["ab_variant"]
-    expected = "B" if int(hashlib.md5(b"T1").hexdigest(), 16) % 2 else "A"
+    expected = "B" if int(hashlib.md5(b"T1", usedforsecurity=False).hexdigest(), 16) % 2 else "A"
     assert variant == expected
     assert resp.cookies.get("ab_menu") == expected
     assert captured["url"].endswith("/analytics/ab")


### PR DESCRIPTION
## Summary
- mark md5 uses in A/B allocator and menu route as non-security hashing
- enable Jinja select_autoescape for ESC/POS printing presets
- document hashing and autoescape changes in changelog

## Testing
- `pytest api/tests/test_menu_ab.py`
- `bandit -r api/app api/tests`


------
https://chatgpt.com/codex/tasks/task_e_68adc130a174832aa6a8e9eed9f91d88