### PR TITLE
feat: add dynamic status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains three main services:
 - `api/` – FastAPI application with `/health`, `/ready` and `/time/skew` endpoints, Alembic migrations, and service helpers such as EMA-based ETA utilities with per-tenant persistence.
 - `pwa/` – React + Tailwind front end with a placeholder home page and installable PWA manifest.
  - `ops/` – Docker Compose for local development.
-Monitoring tools such as UptimeRobot should poll the `/status.json` endpoint for platform health. Ops scripts in `ops/scripts/status_page.py` maintain this file during incidents.
+Monitoring tools such as UptimeRobot should poll the `/status.json` endpoint for platform health. Status is persisted in Redis with `status.json` on disk as a fallback. Administrators can override it via `POST /admin/status` or the helper script in `ops/scripts/status_page.py` during incidents.
 Invoices support optional FSSAI license details when provided.
 QR pack generation events are audited and can be exported via admin APIs. See
 [`docs/qrpack_audit.md`](docs/qrpack_audit.md) for details.

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -185,6 +185,7 @@ from .routes_slo import router as slo_router
 from .routes_staff import router as staff_router
 from .routes_support import router as support_router
 from .routes_support_bundle import router as support_bundle_router
+from .routes_status_json import router as status_json_router
 from .routes_tables_map import router as tables_map_router
 from .routes_tables_qr_rotate import router as tables_qr_rotate_router
 from .routes_tables_sse import router as tables_sse_router
@@ -238,14 +239,6 @@ app = FastAPI(
 )
 static_dir = Path(__file__).resolve().parent.parent.parent / "static"
 app.mount("/static", SWStaticFiles(directory=static_dir), name="static")
-
-
-@app.get("/status.json")
-async def status_json():
-    return FileResponse(
-        Path(__file__).resolve().parent.parent.parent / "status.json",
-        media_type="application/json",
-    )
 
 
 init_tracing(app)
@@ -938,6 +931,7 @@ app.include_router(tables_qr_rotate_router)
 app.include_router(tables_sse_router)
 app.include_router(time_skew_router)
 app.include_router(pwa_version_router)
+app.include_router(status_json_router)
 app.include_router(version_router)
 app.include_router(ready_router)
 app.include_router(troubleshoot_router)

--- a/api/app/routes_status_json.py
+++ b/api/app/routes_status_json.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Literal
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from redis.asyncio import Redis
+
+from .auth import role_required
+from .utils.responses import ok
+
+router = APIRouter()
+
+STATUS_KEY = "status_json"
+STATUS_FILE = Path(__file__).resolve().parent.parent.parent / "status.json"
+
+
+class StatusPayload(BaseModel):
+    state: Literal["ok", "degraded", "outage"]
+    message: str | None = None
+    components: List[str] = Field(default_factory=list)
+
+    class Config:
+        extra = "allow"
+
+
+@router.get("/status.json")
+async def get_status(request: Request):
+    data = None
+    redis: Redis | None = getattr(request.app.state, "redis", None)
+    if redis:
+        try:
+            raw = await redis.get(STATUS_KEY)
+            if raw:
+                data = json.loads(raw)
+        except Exception:
+            data = None
+    if not data:
+        try:
+            with STATUS_FILE.open() as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            data = {"state": "outage", "message": None, "components": []}
+    return JSONResponse(data)
+
+
+@router.post("/admin/status", dependencies=[Depends(role_required("super_admin"))])
+async def set_status(payload: StatusPayload, request: Request):
+    data = payload.dict()
+    redis: Redis | None = getattr(request.app.state, "redis", None)
+    if redis:
+        await redis.set(STATUS_KEY, json.dumps(data))
+    with STATUS_FILE.open("w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+    return ok(data)

--- a/api/tests/test_status_json.py
+++ b/api/tests/test_status_json.py
@@ -1,0 +1,39 @@
+import asyncio
+import json
+import pathlib
+import sys
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from api.app.auth import create_access_token
+from api.app.main import app
+from api.app.routes_status_json import STATUS_KEY
+import api.app.routes_status_json as routes_status_json
+
+
+def test_get_status_json(tmp_path, monkeypatch):
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    status_file = tmp_path / 'status.json'
+    status_file.write_text(json.dumps({'state': 'ok', 'message': '', 'components': []}))
+    monkeypatch.setattr(routes_status_json, 'STATUS_FILE', status_file)
+    client = TestClient(app)
+    resp = client.get('/status.json')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert {'state', 'message', 'components'} <= data.keys()
+
+
+def test_post_status_updates_redis_and_file(tmp_path, monkeypatch):
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    status_file = tmp_path / 'status.json'
+    monkeypatch.setattr(routes_status_json, 'STATUS_FILE', status_file)
+    client = TestClient(app)
+    token = create_access_token({'sub': 'admin@example.com', 'role': 'super_admin'})
+    payload = {'state': 'degraded', 'message': 'db down', 'components': ['db']}
+    resp = client.post('/admin/status', json=payload, headers={'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 200
+    stored = json.loads(asyncio.run(app.state.redis.get(STATUS_KEY)))
+    assert stored == payload
+    assert json.loads(status_file.read_text()) == payload

--- a/docs/INCIDENT_RUNBOOK.md
+++ b/docs/INCIDENT_RUNBOOK.md
@@ -36,8 +36,8 @@ Use `scripts/emit_test_alert.py` to trigger a synthetic alert during drills.
 
 ## Status Page Maintenance
 
-The status page is served from `/status.json` and indicates overall platform health.
-Update it during incidents with:
+The status page is served from `/status.json`, which is stored in Redis with a file fallback.
+Use the helper script to update it during incidents:
 
 ```
 python ops/scripts/status_page.py start "<title>" "<details>"
@@ -49,4 +49,4 @@ Resolve an incident when service is restored:
 python ops/scripts/status_page.py resolve "<title>"
 ```
 
-The `state` field should be `operational` when no incidents remain and `degraded` while any are active.
+These commands invoke `POST /admin/status` and keep the fallback file updated. The `state` field should be `ok` when no incidents remain and `degraded` while any are active.

--- a/docs/INCIDENT_TEMPLATES.md
+++ b/docs/INCIDENT_TEMPLATES.md
@@ -34,8 +34,8 @@ Ops
 
 ---
 
-During a SEV, the `/status.json` file is automatically updated to reflect the current `state` and any active `incidents` so external systems can track progress.
-Valid values for `state` include `operational`, `degraded`, and `down`.
+During a SEV, `/status.json` is backed by Redis and reflects the current `state` and any active incidents so external systems can track progress.
+Valid values for `state` include `ok`, `degraded`, and `outage`.
 
 Start an incident and mark the status page as degraded:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -2,8 +2,16 @@
 
 ## Status Endpoint
 
-External monitors can poll `GET /status.json` to observe platform health. The file contains a top-level `state` (`operational` or `degraded`) and a list of active `incidents`.
-Use the helper script to start or resolve incidents:
+External monitors can poll `GET /status.json` to observe platform health. The status is primarily stored in Redis with `status.json` on disk as a fallback.
+Administrators can override it via `POST /admin/status`:
+
+```
+curl -X POST "$API_URL/admin/status" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"state":"degraded","message":"db","components":[]}'
+```
+
+Use the helper script to start or resolve incidents (which calls the endpoint and updates the fallback file):
 
 ```
 python ops/scripts/status_page.py start "<title>" "<details>"

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -10,9 +10,11 @@ down:
 	docker-compose down --volumes --remove-orphans
 
 incident-start:
-	python scripts/status_page.py start "$(TITLE)" "$(DETAILS)"
+        STATUS_API_URL=$(STATUS_API_URL) STATUS_API_TOKEN=$(STATUS_API_TOKEN) \
+        python scripts/status_page.py start "$(TITLE)" "$(DETAILS)"
 
 incident-resolve:
+        STATUS_API_URL=$(STATUS_API_URL) STATUS_API_TOKEN=$(STATUS_API_TOKEN) \
         python scripts/status_page.py resolve "$(TITLE)"
 
 # Deploy pilot stack, ramp traffic, and enable telemetry.

--- a/pwa/src/components/StatusPill.jsx
+++ b/pwa/src/components/StatusPill.jsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+export default function StatusPill() {
+  const [state, setState] = useState(null)
+
+  useEffect(() => {
+    fetch('/status.json')
+      .then((res) => res.json())
+      .then((json) => setState(json.state))
+      .catch(() => {})
+  }, [])
+
+  const color =
+    state === 'ok'
+      ? 'bg-green-500'
+      : state === 'degraded'
+      ? 'bg-amber-500'
+      : state === 'outage'
+      ? 'bg-red-500'
+      : 'bg-gray-400'
+
+  return <span data-testid="status-pill" className={`inline-block w-3 h-3 rounded-full ${color}`}></span>
+}

--- a/pwa/src/components/__tests__/StatusPill.test.jsx
+++ b/pwa/src/components/__tests__/StatusPill.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import StatusPill from '../StatusPill'
+
+describe('StatusPill', () => {
+  const mockFetch = (state) => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ state }),
+    })
+  }
+
+  it.each([
+    ['ok', 'bg-green-500'],
+    ['degraded', 'bg-amber-500'],
+    ['outage', 'bg-red-500'],
+  ])('renders %s color', async (status, cls) => {
+    mockFetch(status)
+    render(<StatusPill />)
+    const pill = await screen.findByTestId('status-pill')
+    await waitFor(() => expect(pill.className).toContain(cls))
+  })
+})

--- a/pwa/src/pages/AdminDashboard.jsx
+++ b/pwa/src/pages/AdminDashboard.jsx
@@ -6,6 +6,7 @@ import OpsWidget from '../components/OpsWidget'
 import PilotTelemetryWidget from '../components/PilotTelemetryWidget'
 import OwnerSlaWidget from '../components/OwnerSlaWidget'
 import Integrations from '../components/Integrations'
+import StatusPill from '../components/StatusPill'
 
 export default function AdminDashboard() {
   const { logo } = useTheme()
@@ -51,7 +52,8 @@ export default function AdminDashboard() {
           </tbody>
         </table>
       )}
-      <footer className="mt-8 text-sm text-gray-600">
+      <footer className="mt-8 text-sm text-gray-600 flex items-center space-x-2">
+        <StatusPill />
         <a
           href="/legal/subprocessors"
           className="mx-2 hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"

--- a/pwa/src/pages/GuestOrder.jsx
+++ b/pwa/src/pages/GuestOrder.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTheme } from '../contexts/ThemeContext'
 import { useOrderStatus } from '../hooks/useOrderStatus'
 import { apiFetch } from '../api'
+import StatusPill from '../components/StatusPill'
 
 export default function GuestOrder() {
   const { logo } = useTheme()
@@ -74,7 +75,8 @@ export default function GuestOrder() {
           </li>
         ))}
       </ul>
-      <footer className="mt-8 text-sm text-gray-600">
+      <footer className="mt-8 text-sm text-gray-600 flex items-center space-x-2">
+        <StatusPill />
         <a
           href="/legal/privacy"
           className="mx-2 hover:underline focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"

--- a/status.json
+++ b/status.json
@@ -1,4 +1,6 @@
 {
-  "state": "operational",
+  "state": "ok",
+  "message": null,
+  "components": [],
   "incidents": []
 }

--- a/tests/test_status_page.py
+++ b/tests/test_status_page.py
@@ -4,8 +4,9 @@ from ops.scripts import status_page
 
 def test_status_page_toggle(tmp_path, monkeypatch):
     status_file = tmp_path / "status.json"
-    status_file.write_text(json.dumps({"state": "operational", "incidents": []}))
+    status_file.write_text(json.dumps({"state": "ok", "message": None, "components": [], "incidents": []}))
     monkeypatch.setattr(status_page, "STATUS_FILE", status_file)
+    monkeypatch.setattr(status_page, "_post_status", lambda data: None)
 
     status_page.start_incident("db", "down")
     status_page.start_incident("api", "slow")
@@ -20,5 +21,5 @@ def test_status_page_toggle(tmp_path, monkeypatch):
 
     status_page.resolve_incident("api")
     data = json.loads(status_file.read_text())
-    assert data["state"] == "operational"
+    assert data["state"] == "ok"
     assert data["incidents"] == []

--- a/tests/test_status_route.py
+++ b/tests/test_status_route.py
@@ -1,17 +1,20 @@
 import json
-from pathlib import Path
 
+import fakeredis.aioredis
 from fastapi.testclient import TestClient
 
 from api.app.main import app
+import api.app.routes_status_json as routes_status_json
 
 
-def test_status_route_serves_json():
+def test_status_route_serves_json(tmp_path, monkeypatch):
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    status_file = tmp_path / "status.json"
+    status_file.write_text(json.dumps({"state": "ok", "message": "", "components": []}))
+    monkeypatch.setattr(routes_status_json, "STATUS_FILE", status_file)
     client = TestClient(app)
     resp = client.get("/status.json")
     assert resp.status_code == 200
-    status_path = Path(__file__).resolve().parent.parent / "status.json"
-    with status_path.open() as f:
-        expected = json.load(f)
+    expected = json.loads(status_file.read_text())
     assert resp.json() == expected
     assert resp.headers["content-type"].startswith("application/json")


### PR DESCRIPTION
## Summary
- add Redis-backed /status.json endpoint with admin override
- surface status pill in PWA
- document status management workflow

## Testing
- `pytest api/tests/test_status_json.py tests/test_status_route.py tests/test_status_page.py`
- `cd pwa && npm test -- src/components/__tests__/StatusPill.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68adbaff0e14832a8b07021aac679807