### PR TITLE
chore(ci): nightly Parquet dump workflow

### DIFF
--- a/.github/workflows/dwh_parquet.yml
+++ b/.github/workflows/dwh_parquet.yml
@@ -1,0 +1,44 @@
+name: Nightly DWH Parquet dump
+
+on:
+  schedule:
+    - cron: '0 20 * * *' # 20:00 IST
+  workflow_dispatch:
+
+jobs:
+  dump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyarrow boto3 sqlalchemy
+      - name: Export nightly dump
+        env:
+          DWH_DB_DSN: ${{ secrets.STAGING_URL }}
+          DWH_S3_URL: ${{ secrets.DWH_S3_URL }}
+          DWH_S3_KEY: ${{ secrets.DWH_S3_KEY }}
+          DWH_S3_SECRET: ${{ secrets.DWH_S3_SECRET }}
+          DWH_S3_BUCKET: ${{ secrets.DWH_S3_BUCKET }}
+          DWH_TMP_DIR: dump
+        run: |
+          python - <<'PY'
+          import json
+          from datetime import date, timedelta
+          from scripts.dwh_parquet_dump import main
+          day = date.today() - timedelta(days=1)
+          manifest = main(day)
+          with open('dump/manifest.json', 'w') as fh:
+              json.dump(manifest, fh)
+          PY
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dwh-parquet
+          path: |
+            dump/manifest.json
+            dump/*/orders.parquet

--- a/docs/dwh_dumps.md
+++ b/docs/dwh_dumps.md
@@ -19,3 +19,9 @@ Set the following environment variables:
 
 Each run uploads files under `<prefix><dataset>/dt=<YYYY-MM-DD>/` and writes a
 manifest to `<prefix>manifest/<YYYY-MM-DD>.json` listing the generated keys.
+
+## CI
+
+A nightly workflow [dwh_parquet.yml](../.github/workflows/dwh_parquet.yml) runs the export
+against the staging environment and uploads the manifest along with a sample
+Parquet file as artifacts.


### PR DESCRIPTION
## Summary
- schedule nightly Parquet export to run at 20:00 IST and upload manifest plus sample dataset
- document the new nightly export workflow

## Testing
- `python -m pre_commit run --files .github/workflows/dwh_parquet.yml docs/dwh_dumps.md`
- `pytest -q` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aea8a1a5bc832a85fa50dec4996a08