### PR TITLE
chore(print): print-test PNG artifacts in CI

### DIFF
--- a/.github/workflows/print_test_artifact.yml
+++ b/.github/workflows/print_test_artifact.yml
@@ -1,0 +1,40 @@
+name: Print test artifact
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  print-test:
+    runs-on: ubuntu-latest
+    env:
+      STAGING_URL: ${{ secrets.PRINT_TEST_STAGING_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install fastapi fakeredis pillow requests
+          pip install -r api/requirements.txt
+      - name: Generate print-test PNGs (mock)
+        run: |
+          python scripts/save_print_test_png.py --printer 58mm --output mock-58mm.png
+          python scripts/save_print_test_png.py --printer 80mm --output mock-80mm.png
+      - name: Generate print-test PNGs (staging)
+        if: env.STAGING_URL != ''
+        run: |
+          python scripts/save_print_test_png.py --url "$STAGING_URL" --printer 58mm --output staging-58mm.png
+          python scripts/save_print_test_png.py --url "$STAGING_URL" --printer 80mm --output staging-80mm.png
+      - name: Upload print-test PNGs
+        uses: actions/upload-artifact@v4
+        with:
+          name: print-test
+          path: |
+            mock-58mm.png
+            mock-80mm.png
+            staging-58mm.png
+            staging-80mm.png
+          if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- chore(print): print-test PNG artifact in CI.
+- chore(print): print-test PNG artifacts in CI for 58/80mm printers.
 - feat(analytics): multi-outlet summary with CSV export and voids percentage.
 - Flagged server-side menu A/B testing with deterministic bucketing and exposure tracking.
 - L1 support console for tenant/table/order lookup with safe actions (resend invoice, reprint KOT, replay webhook, unlock PIN) and audit logging.

--- a/scripts/save_print_test_png.py
+++ b/scripts/save_print_test_png.py
@@ -1,26 +1,41 @@
 from __future__ import annotations
 
-import base64
+import argparse
 
 import fakeredis.aioredis
+import requests
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from api.app.render_text_image import render_text_image
 from api.app.routes_print_test import router
 
 
 def main() -> None:
-    fake = fakeredis.aioredis.FakeRedis()
-    app = FastAPI()
-    app.include_router(router)
-    app.state.redis = fake
-    client = TestClient(app)
-
-    resp = client.post("/admin/print/test", json={"printer": "80mm"})
+    parser = argparse.ArgumentParser(description="Save print-test preview as PNG")
+    parser.add_argument(
+        "--printer", choices=["58mm", "80mm"], default="80mm", help="Printer width"
+    )
+    parser.add_argument("--output", default="print-test.png", help="Output PNG path")
+    parser.add_argument("--url", default="", help="Base URL for remote API")
+    args = parser.parse_args()
+    if args.url:
+        resp = requests.post(
+            f"{args.url.rstrip('/')}/admin/print/test",
+            json={"printer": args.printer},
+            timeout=10,
+        )
+    else:
+        fake = fakeredis.aioredis.FakeRedis()
+        app = FastAPI()
+        app.include_router(router)
+        app.state.redis = fake
+        client = TestClient(app)
+        resp = client.post("/admin/print/test", json={"printer": args.printer})
     resp.raise_for_status()
-    data = resp.json()
-    image_bytes = base64.b64decode(data["image"])
-    with open("print-test.png", "wb") as fh:
+    preview = resp.json()["preview"]
+    image_bytes = render_text_image(preview)
+    with open(args.output, "wb") as fh:
         fh.write(image_bytes)
 
 


### PR DESCRIPTION
## Summary
- Add workflow generating 58/80mm print-test PNG artifacts with optional staging requests
- Allow save_print_test_png to render preview text locally or via remote API
- Document print-test artifact workflow in changelog

## Testing
- `pre-commit run --files scripts/save_print_test_png.py .github/workflows/print_test_artifact.yml CHANGELOG.md`
- `PYTHONPATH=. pytest api/tests/test_print_test_route.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea90fee1c832a848fcf5d10a99746