### PR TITLE
test(analytics): owner aggregate CSV + scoping

### DIFF
--- a/api/tests/test_owner_aggregate_csv.py
+++ b/api/tests/test_owner_aggregate_csv.py
@@ -1,0 +1,169 @@
+import pathlib
+import sys
+from datetime import datetime, timedelta, timezone
+from contextlib import asynccontextmanager
+
+import fakeredis
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from api.app import models_tenant
+from api.app.models_tenant import Invoice, Order, OrderItem, OrderStatus, Payment
+from api.app import routes_analytics_outlets
+
+
+async def _seed(amount: float, prep: int) -> tuple[AsyncSession, any]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(models_tenant.Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    session = Session()
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    for i in range(3):
+        placed = base + timedelta(days=i)
+        order = Order(
+            table_id=1,
+            status=OrderStatus.NEW,
+            placed_at=placed,
+            accepted_at=placed,
+            ready_at=placed + timedelta(seconds=prep),
+        )
+        session.add(order)
+        await session.flush()
+        session.add(
+            OrderItem(
+                order_id=order.id,
+                item_id=1,
+                name_snapshot="Item",
+                qty=1,
+                price_snapshot=amount - 5,
+                status="served",
+            )
+        )
+        bill = {"subtotal": amount - 5, "tax_breakup": {5: 5}, "total": amount}
+        invoice = Invoice(
+            order_group_id=order.id,
+            number=f"INV{i}",
+            bill_json=bill,
+            gst_breakup=bill["tax_breakup"],
+            total=amount,
+            created_at=placed,
+        )
+        session.add(invoice)
+        await session.flush()
+        session.add(
+            Payment(
+                invoice_id=invoice.id,
+                mode="cash",
+                amount=amount,
+                created_at=placed,
+            )
+        )
+    await session.commit()
+    return session, engine
+
+
+@pytest.fixture
+async def seeded_sessions():
+    s1, e1 = await _seed(100, 600)
+    s2, e2 = await _seed(200, 1200)
+    yield {"t1": s1, "t2": s2}
+    await s1.close()
+    await s2.close()
+    await e1.dispose()
+    await e2.dispose()
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(routes_analytics_outlets.router)
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    return app
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_csv_header_and_first_row(app, seeded_sessions, monkeypatch):
+    @asynccontextmanager
+    async def fake_session(tid: str):
+        yield seeded_sessions[tid]
+
+    async def fake_info(ids):
+        return {tid: {"tz": "UTC"} for tid in ids}
+
+    monkeypatch.setattr(routes_analytics_outlets, "_session", fake_session)
+    monkeypatch.setattr(routes_analytics_outlets, "_get_tenants_info", fake_info)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/analytics/outlets",
+            params={
+                "ids": "t1,t2",
+                "from": "2024-01-01",
+                "to": "2024-01-03",
+                "export": "csv",
+            },
+            headers={"x-tenant-ids": "t1,t2"},
+        )
+    assert resp.headers["content-type"].startswith("text/csv")
+    lines = resp.text.splitlines()
+    assert lines[0] == "outlet_id,orders,sales,aov,median_prep,voids_pct"
+    assert lines[1] == "t1,3,300.00,100.00,600.00,0.00"
+
+
+@pytest.mark.anyio
+async def test_cross_tenant_forbidden(app, seeded_sessions, monkeypatch):
+    @asynccontextmanager
+    async def fake_session(tid: str):
+        yield seeded_sessions[tid]
+
+    async def fake_info(ids):
+        return {tid: {"tz": "UTC"} for tid in ids}
+
+    monkeypatch.setattr(routes_analytics_outlets, "_session", fake_session)
+    monkeypatch.setattr(routes_analytics_outlets, "_get_tenants_info", fake_info)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/analytics/outlets",
+            params={"ids": "t1,t2", "from": "2024-01-01", "to": "2024-01-01"},
+            headers={"x-tenant-ids": "t1"},
+        )
+    assert resp.status_code in (403, 404)
+
+
+@pytest.mark.anyio
+async def test_boundary_dates(app, seeded_sessions, monkeypatch):
+    @asynccontextmanager
+    async def fake_session(tid: str):
+        yield seeded_sessions[tid]
+
+    async def fake_info(ids):
+        return {tid: {"tz": "UTC"} for tid in ids}
+
+    monkeypatch.setattr(routes_analytics_outlets, "_session", fake_session)
+    monkeypatch.setattr(routes_analytics_outlets, "_get_tenants_info", fake_info)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/analytics/outlets",
+            params={"ids": "t1,t2", "from": "2024-01-02", "to": "2024-01-02"},
+            headers={"x-tenant-ids": "t1,t2"},
+        )
+    data = resp.json()
+    assert data["orders"] == 2
+    assert data["sales"] == 300.0
+    assert data["aov"] == 150.0
+    assert data["median_prep"] == 900.0

--- a/docs/owner_analytics.md
+++ b/docs/owner_analytics.md
@@ -37,6 +37,10 @@ The response includes combined orders, sales, average order value, top items,
 median preparation time (prep SLA) and a ``voids_pct`` representing the
 percentage of orders cancelled during the period.
 
+The ``x-tenant-ids`` header defines the tenant scope. All ``ids`` in the query
+string must be within this scope or a ``403`` will be returned. The ``from`` and
+``to`` dates are inclusive.
+
 A sample payload:
 
 ```json


### PR DESCRIPTION
## Summary
- cover CSV export for multi-outlet owner aggregate analytics
- ensure cross-tenant scope enforcement
- document tenant scoping and inclusive date range

## Testing
- `pytest api/tests/test_owner_aggregate_csv.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aea8f28610832ab510f26313dd0993