### PR TITLE
chore(ci): refine gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -9,11 +9,11 @@ permissions:
 
 jobs:
   scan:
+    permissions: {contents: read, pull-requests: read}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: gitleaks/gitleaks-action@v2
-        with:
-          config: .gitleaks.toml
-          fail: true
-          args: --redact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ARGS: "--no-banner --redact"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Update GitHub Actions workflows to use `actions/upload-artifact@v4`.
 - Clean up redundant imports and outdated ``noqa`` comment to satisfy ``ruff``.
 - Point GHCR workflow to the API Dockerfile so image builds succeed.
+- Configure gitleaks workflow with env vars and job-level permissions.
 
 ### Added
 


### PR DESCRIPTION
## Summary
- remove explicit gitleaks action `with` config and rely on env vars
- add job level permissions for read-only access
- document gitleaks workflow change in changelog

## Testing
- `pre-commit run --files .github/workflows/gitleaks.yml CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68aeab3f19b8832a8241020db603d2e4