### PR TITLE
chore(ops): Makefile targets (release-rc, pilot, release-ga, prod)

### DIFF
--- a/GO_LIVE_CHECKLIST.md
+++ b/GO_LIVE_CHECKLIST.md
@@ -4,8 +4,9 @@
 - [ ] Verify service health and metrics
 - [ ] Announce release to stakeholders
 - [ ] Run pilot rollout
-    - `python scripts/release_tag.py --rc`
-    - `python scripts/deploy_blue_green.py --env=staging`
-    - `python scripts/weighted_canary_ramp.py --env=staging`
-    - `python scripts/canary_probe.py --env=staging`
+    - `make pilot`
     - enable telemetry/NPS flags
+- [ ] Tag GA release
+    - `make release-ga`
+- [ ] Run production rollout
+    - `make prod`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: release-rc stage pilot release-ga prod
+
+release-rc:
+	python scripts/release_tag.py --rc
+
+stage:
+	python scripts/deploy_blue_green.py --env=staging
+	python scripts/canary_probe.py --env=staging
+	python scripts/weighted_canary_ramp.py --env=staging --steps "5,25,50,100"
+
+pilot: release-rc stage
+	python scripts/emit_test_alert.py --env=staging
+	pytest -q
+	npx playwright test
+	python scripts/pdf_smoke.py --env=staging
+	bash scripts/backup_smoke.sh --env=staging
+
+release-ga:
+	python scripts/release_tag.py --ga
+
+prod:
+	python scripts/deploy_blue_green.py --env=prod
+	python scripts/weighted_canary_ramp.py --env=prod --steps "5,25,50,100"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains three main services:
 Monitoring tools such as UptimeRobot should poll the `/status.json` endpoint for platform health. Status is persisted in Redis with `status.json` on disk as a fallback. Administrators can override it via `POST /admin/status` or the helper script in `ops/scripts/status_page.py` during incidents.
 Invoices support optional FSSAI license details when provided.
 QR pack generation events are audited and can be exported via admin APIs. See
-[`docs/qrpack_audit.md`](docs/qrpack_audit.md) for details.
+[`docs/qrpack_audit.md`](docs/qrpack_audit.md) for details. For manual rollouts, `make stage` deploys to staging, `make pilot` runs the staging smoke suite, and `make prod` promotes to production.
 Per-tenant product analytics can be enabled with tenant consent. See
 [`docs/analytics.md`](docs/analytics.md) for setup instructions.
 
@@ -851,8 +851,8 @@ supplied.
 
 ## Release
 
-Run `python scripts/release_tag.py` to generate a changelog entry and tag a new version. The helper queries merged pull requests since the last tag and groups entries by label. A `release` workflow is available for manual triggering via the GitHub UI.
+Run `python scripts/release_tag.py` to generate a changelog entry and tag a new version. Use `make release-rc` for a release candidate or `make release-ga` for a GA tag. The helper queries merged pull requests since the last tag and groups entries by label. A `release` workflow is available for manual triggering via the GitHub UI.
 
 ## Deployment
 
-A `deploy` GitHub Actions workflow builds Docker images, verifies staging with preflight, smoke, canary, and accessibility gates, then waits for manual approval before a blue/green production rollout with automatic rollback on failure. See `docs/CI_CD.md` for details.
+A `deploy` GitHub Actions workflow builds Docker images, verifies staging with preflight, smoke, canary, and accessibility gates, then waits for manual approval before a blue/green production rollout with automatic rollback on failure. See `docs/CI_CD.md` for details. For manual rollouts, `make stage` deploys to staging, `make pilot` runs the staging smoke suite, and `make prod` promotes to production.


### PR DESCRIPTION
## Summary
- add Makefile shortcuts for release and deploy flows
- document new make targets for pilot and production rollouts

## Testing
- `pre-commit run --files Makefile README.md GO_LIVE_CHECKLIST.md`
- `pytest -q tests` *(fails: cannot import name 'stream_rows' from 'api.app.utils.csv_stream')*


------
https://chatgpt.com/codex/tasks/task_e_68aeb3fd0e70832aa19796832e845fd8