### PR TITLE
chore(db): add core multi-tenant indexes with tests and docs

### DIFF
--- a/api/tests/test_indexes_explain.py
+++ b/api/tests/test_indexes_explain.py
@@ -1,0 +1,180 @@
+from datetime import datetime, timedelta
+
+import psycopg2
+from psycopg2.extras import Json
+
+DSN = "dbname=testdb user=postgres password=postgres host=localhost"
+
+
+def setup_module(module):
+    conn = psycopg2.connect(DSN)
+    conn.autocommit = True
+    cur = conn.cursor()
+
+    cur.execute(
+        """
+        DROP TABLE IF EXISTS orders, menu_items, webhook_events;
+        CREATE TABLE orders (
+            id SERIAL PRIMARY KEY,
+            tenant_id INT NOT NULL,
+            status TEXT,
+            created_at TIMESTAMPTZ NOT NULL,
+            deleted_at TIMESTAMPTZ,
+            table_id INT,
+            closed_at TIMESTAMPTZ,
+            total_amount NUMERIC
+        );
+        CREATE TABLE menu_items (
+            id SERIAL PRIMARY KEY,
+            tenant_id INT NOT NULL,
+            category_id INT,
+            sort_order INT,
+            is_active BOOL,
+            deleted_at TIMESTAMPTZ,
+            dietary JSONB
+        );
+        CREATE TABLE webhook_events (
+            id SERIAL PRIMARY KEY,
+            tenant_id INT NOT NULL,
+            next_attempt_at TIMESTAMPTZ,
+            state TEXT
+        );
+        """
+    )
+
+    cur.execute(
+        """
+        CREATE INDEX idx_orders_tenant_status_created
+            ON orders (tenant_id, status, created_at DESC)
+            INCLUDE (total_amount, table_id)
+            WHERE deleted_at IS NULL;
+        CREATE INDEX idx_orders_tenant_table_open
+            ON orders (tenant_id, table_id, created_at DESC)
+            WHERE closed_at IS NULL AND deleted_at IS NULL;
+        CREATE INDEX brin_orders_created
+            ON orders USING BRIN (created_at);
+        CREATE INDEX idx_menu_tenant_category_active
+            ON menu_items (tenant_id, category_id, sort_order)
+            WHERE is_active = TRUE AND deleted_at IS NULL;
+        CREATE INDEX gin_menu_dietary
+            ON menu_items USING GIN ((coalesce(dietary, '[]'::jsonb)));
+        CREATE INDEX idx_webhooks_tenant_due
+            ON webhook_events (tenant_id, next_attempt_at)
+            WHERE state = 'pending';
+        """
+    )
+
+    now = datetime.utcnow()
+    orders = [
+        (1, 'new', now - timedelta(minutes=i), None, 10, None, 100.0)
+        for i in range(50)
+    ]
+    orders.append((1, 'new', now, None, 20, None, 50.0))
+    cur.executemany(
+        "INSERT INTO orders (tenant_id, status, created_at, deleted_at, table_id, closed_at, total_amount) VALUES (%s,%s,%s,%s,%s,%s,%s)",
+        orders,
+    )
+
+    menu = [
+        (1, 5, i, True, None, Json(['vegan']))
+        for i in range(10)
+    ]
+    cur.executemany(
+        "INSERT INTO menu_items (tenant_id, category_id, sort_order, is_active, deleted_at, dietary) VALUES (%s,%s,%s,%s,%s,%s)",
+        menu,
+    )
+
+    webhooks = [
+        (1, now + timedelta(minutes=i), 'pending')
+        for i in range(5)
+    ]
+    cur.executemany(
+        "INSERT INTO webhook_events (tenant_id, next_attempt_at, state) VALUES (%s,%s,%s)",
+        webhooks,
+    )
+
+    cur.execute("ANALYZE")
+
+    cur.close()
+    conn.close()
+
+
+def _plan(sql, params=None):
+    conn = psycopg2.connect(DSN)
+    cur = conn.cursor()
+    cur.execute("SET enable_seqscan=off")
+    cur.execute(sql, params or ())
+    plan = "\n".join(row[0] for row in cur.fetchall())
+    cur.close()
+    conn.close()
+    return plan
+
+
+def test_open_orders_by_table():
+    plan = _plan(
+        "EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM orders WHERE tenant_id=1 AND table_id=10 AND closed_at IS NULL AND deleted_at IS NULL ORDER BY created_at DESC"
+    )
+    assert "Index Scan" in plan and "idx_orders_tenant_table_open" in plan
+
+
+def test_kds_status_window():
+    plan = _plan(
+        "EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM orders WHERE tenant_id=1 AND status='new' AND deleted_at IS NULL ORDER BY created_at DESC LIMIT 5"
+    )
+    assert "Bitmap Index Scan" in plan or "Index Scan" in plan
+    assert "idx_orders_tenant_status_created" in plan
+
+
+def test_menu_category_active():
+    plan = _plan(
+        "EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM menu_items WHERE tenant_id=1 AND category_id=5 AND is_active = TRUE AND deleted_at IS NULL ORDER BY sort_order"
+    )
+    assert "Index Scan" in plan and "idx_menu_tenant_category_active" in plan
+
+
+def test_dietary_filter():
+    plan = _plan(
+        "EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM menu_items WHERE tenant_id=1 AND coalesce(dietary, '[]'::jsonb) ? 'vegan'"
+    )
+    assert "Bitmap Index Scan" in plan or "Index Scan" in plan
+    assert "gin_menu_dietary" in plan
+
+
+def test_webhooks_due():
+    plan = _plan(
+        "EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM webhook_events WHERE tenant_id=1 AND state='pending' ORDER BY next_attempt_at LIMIT 1"
+    )
+    assert "Index Scan" in plan and "idx_webhooks_tenant_due" in plan
+
+
+def test_orders_date_range_brin():
+    conn = psycopg2.connect(DSN)
+    cur = conn.cursor()
+    cur.execute("SET enable_seqscan=off")
+    cur.execute(
+        "EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM orders WHERE created_at > now() - interval '1 hour'"
+    )
+    plan = "\n".join(r[0] for r in cur.fetchall())
+    cur.close()
+    conn.close()
+    assert "brin_orders_created" in plan
+
+
+def test_partial_index_skips_deleted():
+    conn = psycopg2.connect(DSN)
+    cur = conn.cursor()
+    cur.execute("INSERT INTO orders (tenant_id, status, created_at, deleted_at, table_id, closed_at, total_amount) VALUES (1,'new',now(),NULL,30,NULL,10.0) RETURNING id")
+    oid = cur.fetchone()[0]
+    conn.commit()
+    plan_live = _plan(
+        "EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM orders WHERE tenant_id=1 AND table_id=30 AND closed_at IS NULL AND deleted_at IS NULL"
+    )
+    assert "idx_orders_tenant_table_open" in plan_live
+    cur.execute("UPDATE orders SET deleted_at=now() WHERE id=%s", (oid,))
+    conn.commit()
+    plan_deleted = _plan(
+        "EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM orders WHERE tenant_id=1 AND table_id=30 AND closed_at IS NULL AND deleted_at IS NOT NULL"
+    )
+    assert "idx_orders_tenant_table_open" not in plan_deleted
+    cur.close()
+    conn.close()

--- a/db/migrations/2025-08-27_add_core_indexes.sql
+++ b/db/migrations/2025-08-27_add_core_indexes.sql
@@ -1,0 +1,88 @@
+-- ORDERS: KDS / open tabs / time filters
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_orders_tenant_status_created
+  ON orders (tenant_id, status, created_at DESC)
+  INCLUDE (total_amount, table_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_orders_tenant_table_open
+  ON orders (tenant_id, table_id, created_at DESC)
+  WHERE closed_at IS NULL AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ux_orders_tenant_idempotency
+  ON orders (tenant_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+-- For large date-range exports; BRIN is tiny and fast for append-only
+CREATE INDEX CONCURRENTLY IF NOT EXISTS brin_orders_created
+  ON orders USING BRIN (created_at) WITH (pages_per_range=64);
+
+-- ORDER_ITEMS: joins + analytics
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_order_items_order
+  ON order_items (order_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_order_items_tenant_menuitem
+  ON order_items (tenant_id, menu_item_id)
+  WHERE deleted_at IS NULL;
+
+-- PAYMENTS: settlement & UTR lookups
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_payments_tenant_order_status
+  ON payments (tenant_id, order_id, status)
+  WHERE deleted_at IS NULL;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ux_payments_tenant_utr
+  ON payments (tenant_id, utr)
+  WHERE utr IS NOT NULL;
+
+-- MENU: category listing, active menus, search, filters
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_menu_tenant_category_active
+  ON menu_items (tenant_id, category_id, sort_order)
+  WHERE is_active = TRUE AND deleted_at IS NULL;
+
+-- JSONB filters for dietary/allergens/tags (use ?/?| operators)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS gin_menu_dietary
+  ON menu_items USING GIN ((coalesce(dietary, '[]'::jsonb)));
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS gin_menu_allergens
+  ON menu_items USING GIN ((coalesce(allergens, '[]'::jsonb)));
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS gin_menu_tags
+  ON menu_items USING GIN ((coalesce(tags, '[]'::jsonb)));
+
+-- Full-text search
+CREATE INDEX CONCURRENTLY IF NOT EXISTS gin_menu_search
+  ON menu_items USING GIN (search_tsv);
+
+-- TABLES: fast occupancy/state lookups
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ux_tables_tenant_code_live
+  ON tables (tenant_id, table_code)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tables_tenant_state_updated
+  ON tables (tenant_id, state, updated_at DESC);
+
+-- WEBHOOK queue: next attempt scheduler
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_webhooks_tenant_due
+  ON webhook_events (tenant_id, next_attempt_at)
+  WHERE state = 'pending';
+
+-- EXPORT jobs listing by date
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_exports_tenant_created
+  ON exports (tenant_id, created_at DESC);
+
+-- AUDIT: huge, append-only; BRIN wins
+CREATE INDEX CONCURRENTLY IF NOT EXISTS brin_audit_created
+  ON audit_log USING BRIN (created_at);
+
+-- DEVICES: fingerprint uniqueness per-tenant
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ux_devices_tenant_fingerprint
+  ON devices (tenant_id, fingerprint)
+  WHERE deleted_at IS NULL;
+
+-- PROMOS: fast code resolve when active
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_promos_tenant_code_active
+  ON promos (tenant_id, code)
+  WHERE is_active = TRUE AND deleted_at IS NULL;
+
+-- RATE LIMIT: ip window lookups
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ratelimit_tenant_ip_window
+  ON rate_limits (tenant_id, ip, window_start);

--- a/docs/DB_INDEXING.md
+++ b/docs/DB_INDEXING.md
@@ -1,0 +1,43 @@
+# Core Indexing
+
+This project uses a set of targeted indexes to keep hot multi-tenant queries fast without over-indexing. Each index below lists the query pattern it accelerates.
+
+## Orders
+- `idx_orders_tenant_status_created` – fetch KDS/status windows by tenant and status ordered by creation time.
+- `idx_orders_tenant_table_open` – find open orders for a table.
+- `ux_orders_tenant_idempotency` – enforce idempotency per tenant.
+- `brin_orders_created` – speed large date range exports.
+
+## Order Items
+- `idx_order_items_order` – join items to an order.
+- `idx_order_items_tenant_menuitem` – tenant scoped menu item analytics excluding soft deletes.
+
+## Payments
+- `idx_payments_tenant_order_status` – settlement lookups per order.
+- `ux_payments_tenant_utr` – unique UTR per tenant.
+
+## Menu Items
+- `idx_menu_tenant_category_active` – list active menu items in a category.
+- `gin_menu_dietary`, `gin_menu_allergens`, `gin_menu_tags` – filter JSONB attributes with `?`/`?|`.
+- `gin_menu_search` – full-text search.
+
+## Tables
+- `ux_tables_tenant_code_live` – tenant unique table codes.
+- `idx_tables_tenant_state_updated` – poll table state changes.
+
+## Misc
+- `idx_webhooks_tenant_due` – schedule pending webhook retries.
+- `idx_exports_tenant_created` – list export jobs by date.
+- `brin_audit_created` – append-only audit log range scans.
+- `ux_devices_tenant_fingerprint` – deduplicate devices.
+- `idx_promos_tenant_code_active` – resolve active promo codes.
+- `idx_ratelimit_tenant_ip_window` – rate limit lookups.
+
+Partial indexes skip soft-deleted or closed records, keeping btrees small. BRIN is used for very large, append-only tables (`orders`, `audit_log`) where a tiny index can satisfy range scans. GIN accelerates JSONB and full-text searches. Covering indexes (`INCLUDE`) make common `orders` selects index-only.
+
+## Verification
+1. Load sample data via `scripts/seed_large_outlet.py`.
+2. Run `pytest api/tests/test_indexes_explain.py` and confirm the plans show `Index Scan` or `Bitmap Index Scan` on the expected index.
+3. Monitor `plan_guard.py` so P95 for hot queries improves or stays within 20% of baseline.
+
+Autovacuum should keep indexes healthy. Run `REINDEX CONCURRENTLY` only if bloat is observed and schedule `ANALYZE` after large imports.


### PR DESCRIPTION
## Summary
- add partial, covering, GIN, and BRIN indexes for hot paths
- document index targets and verification steps
- exercise new indexes with `EXPLAIN`-based tests

## Testing
- `pytest api/tests/test_indexes_explain.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb64bf4b0832aa9120bd61c94a4b3