### PR TITLE
feat(ux): owner onboarding wizard (guided steps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ A minimal onboarding flow captures tenant details:
 - `POST /api/onboarding/{id}/payments` – configure payment modes and VPA.
 - `POST /api/onboarding/{id}/finish` – finalize and activate the tenant.
 
+Admins can also use the `/admin/onboarding` web wizard for a guided setup. The
+wizard saves progress locally so owners can return and complete steps later.
+
 ### QR Pack
 
 - `GET /api/outlet/{tenant}/qrpack.pdf?size=A4&per_page=12&show_logo=true&label_fmt=Table%20{n}` – generate a printable sheet of table labels with QR codes and the outlet logo.

--- a/pwa/src/App.jsx
+++ b/pwa/src/App.jsx
@@ -6,6 +6,7 @@ import KitchenDashboard from './pages/KitchenDashboard'
 import CleanerDashboard from './pages/CleanerDashboard'
 import Billing from './pages/Billing'
 import ExpoDashboard from './pages/ExpoDashboard'
+import OwnerOnboardingWizard from './pages/OwnerOnboardingWizard'
 import RequireRole from './components/RequireRole'
 import ConsentBanner from './components/ConsentBanner'
 import { useAuth } from './contexts/AuthContext'
@@ -59,6 +60,14 @@ export default function App() {
           element={
             <RequireRole roles={['admin']}>
               <AdminDashboard />
+            </RequireRole>
+          }
+        />
+        <Route
+          path="/admin/onboarding"
+          element={
+            <RequireRole roles={['admin']}>
+              <OwnerOnboardingWizard />
             </RequireRole>
           }
         />

--- a/pwa/src/pages/AdminDashboard.jsx
+++ b/pwa/src/pages/AdminDashboard.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useTheme } from '../contexts/ThemeContext'
 import { apiFetch } from '../api'
 import LimitsUsageWidget from '../components/LimitsUsageWidget'
@@ -26,6 +27,12 @@ export default function AdminDashboard() {
     <div className="p-4">
       {logo && <img src={logo} alt="Logo" className="h-16 mb-4" />}
       <h2 className="text-xl font-bold mb-4">Admin Dashboard</h2>
+      <Link
+        to="/admin/onboarding"
+        className="text-blue-600 underline mb-4 inline-block"
+      >
+        Start Onboarding Wizard
+      </Link>
       <LimitsUsageWidget />
       <OpsWidget />
       <PilotTelemetryWidget />

--- a/pwa/src/pages/OwnerOnboardingWizard.jsx
+++ b/pwa/src/pages/OwnerOnboardingWizard.jsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react'
+
+const STEPS = [
+  { id: 'brand', title: 'Brand & Logo' },
+  { id: 'tables', title: 'Tables Count' },
+  { id: 'menu', title: 'Menu Import' },
+  { id: 'printer', title: 'Printer Test' },
+  { id: 'payments', title: 'Payment Mode' },
+  { id: 'alerts', title: 'Alerts Rules' },
+]
+
+const STORAGE_KEY = 'owner_onboarding_progress'
+
+export default function OwnerOnboardingWizard() {
+  const [step, setStep] = useState(0)
+  const [data, setData] = useState({})
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved)
+        setStep(parsed.step || 0)
+        setData(parsed.data || {})
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [])
+
+  function persist(nextStep, nextData) {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ step: nextStep, data: nextData })
+    )
+  }
+
+  const current = STEPS[step]
+
+  function handleNext(e) {
+    e.preventDefault()
+    const formData = new FormData(e.target)
+    const currentData = {}
+    formData.forEach((value, key) => {
+      currentData[key] = value
+    })
+    const nextData = { ...data, [current.id]: currentData }
+    const nextStep = step + 1
+    if (nextStep >= STEPS.length) {
+      localStorage.removeItem(STORAGE_KEY)
+    } else {
+      persist(nextStep, nextData)
+    }
+    setData(nextData)
+    setStep(nextStep)
+  }
+
+  if (step >= STEPS.length) {
+    return (
+      <div className="p-4">
+        <h2 className="text-xl font-bold mb-4">Onboarding Complete</h2>
+        <p className="mb-4">You're ready to go live.</p>
+      </div>
+    )
+  }
+
+  function renderStep() {
+    switch (current.id) {
+      case 'brand':
+        return (
+          <>
+            <label className="block mb-2">
+              Brand Name
+              <input name="name" className="border ml-2" />
+            </label>
+            <label className="block mb-4">
+              Logo URL
+              <input name="logo" className="border ml-2" />
+            </label>
+          </>
+        )
+      case 'tables':
+        return (
+          <label className="block mb-4">
+            Number of Tables
+            <input name="count" type="number" min="1" className="border ml-2" />
+          </label>
+        )
+      case 'menu':
+        return (
+          <label className="block mb-4">
+            Import Menu
+            <input name="file" type="file" className="border ml-2" />
+          </label>
+        )
+      case 'printer':
+        return (
+          <p className="mb-4">
+            Send a test print from your browser and verify the receipt before
+            proceeding.
+          </p>
+        )
+      case 'payments':
+        return (
+          <label className="block mb-4">
+            Payment Mode
+            <select name="mode" className="border ml-2">
+              <option value="upi">UPI</option>
+              <option value="cash">Cash</option>
+            </select>
+          </label>
+        )
+      case 'alerts':
+        return (
+          <label className="block mb-4">
+            Alert Rules
+            <textarea name="rules" className="border ml-2" />
+          </label>
+        )
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-4">
+        Step {step + 1} of {STEPS.length}: {current.title}
+      </h2>
+      <form onSubmit={handleNext}>
+        {renderStep()}
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+          Next
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/pwa/src/pages/__tests__/OwnerOnboardingWizard.test.jsx
+++ b/pwa/src/pages/__tests__/OwnerOnboardingWizard.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import OwnerOnboardingWizard from '../OwnerOnboardingWizard'
+
+describe('OwnerOnboardingWizard', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('persists progress and resumes later', () => {
+    const { unmount } = render(<OwnerOnboardingWizard />)
+    fireEvent.change(screen.getByLabelText(/Brand Name/i), {
+      target: { value: 'Cafe' },
+    })
+    fireEvent.click(screen.getByText(/Next/i))
+    unmount()
+    render(<OwnerOnboardingWizard />)
+    expect(screen.getByText(/Step 2 of 6/i)).toBeInTheDocument()
+    expect(screen.getByText(/Tables Count/i)).toBeInTheDocument()
+  })
+})

--- a/static/help/owner_onboarding.html
+++ b/static/help/owner_onboarding.html
@@ -10,6 +10,7 @@
 </head>
 <body>
 <h1>Owner Onboarding</h1>
+<p>Visit <code>/admin/onboarding</code> for a guided setup wizard. Progress is saved in your browser so you can return later.</p>
 <h2>QR Setup</h2>
 <p>Generate QR codes in the dashboard, place them on tables and test scanning.</p>
 <h2>Table Map</h2>


### PR DESCRIPTION
## Summary
- add owner onboarding wizard with progress saved locally
- link admin dashboard to the wizard route
- document the onboarding wizard and add persistence test

## Testing
- `pytest api/tests/test_onboarding_e2e.py`
- `cd pwa && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aebcefd5c4832a8e626fbca267e460