### PR TITLE
feat(db): monthly partitions for audit_log + retention script

### DIFF
--- a/docs/DB_INDEXING.md
+++ b/docs/DB_INDEXING.md
@@ -52,6 +52,8 @@ This project relies on a focused set of indexes to keep multi-tenant queries fas
 | --- | --- | --- | --- |
 | `brin_audit_created` | Audit exports ([`scripts/audit_dump.py`](../scripts/audit_dump.py)) | `created_at BETWEEN ? AND ?` | BRIN is tiny and ideal for append-only logs |
 
+Monthly partitions (`audit_log_yYYYYmMM`) keep the table lean. Remove old partitions with `scripts/audit_partition_retention.py` (run with `--keep-months` to control retention).
+
 ## Devices
 | Index | Route/Repo benefiting | WHERE clause shape | Notes |
 | --- | --- | --- | --- |

--- a/migrations/versions/20250830_0000_audit_log_partitions.py
+++ b/migrations/versions/20250830_0000_audit_log_partitions.py
@@ -1,0 +1,76 @@
+"""monthly partitions for audit_log
+
+Revision ID: 20250830_0000_audit_log_partitions
+Revises: 20250829_0000_customer_consent_flags
+Create Date: 2025-08-30
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20250830_0000_audit_log_partitions"
+down_revision = "20250829_0000_customer_consent_flags"
+branch_labels = None
+depends_on = None
+
+_CREATE_PARTITIONS = """
+CREATE TABLE IF NOT EXISTS audit_log_y2025m08
+    PARTITION OF audit_log FOR VALUES FROM ('2025-08-01') TO ('2025-09-01');
+CREATE TABLE IF NOT EXISTS audit_log_default
+    PARTITION OF audit_log DEFAULT;
+"""
+
+_CREATE_TRIGGER = """
+CREATE OR REPLACE FUNCTION audit_log_insert_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+    _part text := 'audit_log_y' || to_char(NEW.created_at, 'YYYY') || 'm' || to_char(NEW.created_at, 'MM');
+BEGIN
+    EXECUTE format('INSERT INTO %I VALUES ($1.*)', _part) USING NEW;
+    RETURN NULL;
+EXCEPTION WHEN undefined_table THEN
+    INSERT INTO audit_log_default VALUES (NEW.*);
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS audit_log_insert_router ON audit_log;
+CREATE TRIGGER audit_log_insert_router
+    BEFORE INSERT ON audit_log
+    FOR EACH ROW EXECUTE FUNCTION audit_log_insert_trigger();
+"""
+
+_CREATE_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_audit_log_y2025m08_tenant_id
+    ON audit_log_y2025m08 (tenant_id);
+"""
+
+_DROP_INDEX = "DROP INDEX IF EXISTS idx_audit_log_y2025m08_tenant_id;"
+_DROP_TRIGGER = """
+DROP TRIGGER IF EXISTS audit_log_insert_router ON audit_log;
+DROP FUNCTION IF EXISTS audit_log_insert_trigger();
+"""
+_DROP_PARTITIONS = """
+DROP TABLE IF EXISTS audit_log_y2025m08;
+DROP TABLE IF EXISTS audit_log_default;
+"""
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    with op.get_context().autocommit_block():
+        conn.execute(sa.text(_CREATE_PARTITIONS))
+        conn.execute(sa.text(_CREATE_TRIGGER))
+        conn.execute(sa.text(_CREATE_INDEX))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    with op.get_context().autocommit_block():
+        conn.execute(sa.text(_DROP_INDEX))
+        conn.execute(sa.text(_DROP_TRIGGER))
+        conn.execute(sa.text(_DROP_PARTITIONS))

--- a/scripts/audit_partition_retention.py
+++ b/scripts/audit_partition_retention.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Detach and drop old ``audit_log`` partitions."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from datetime import datetime
+
+from sqlalchemy import text
+
+from api.app.db import SessionLocal
+
+PARTITION_RE = re.compile(r"audit_log_y(\d{4})m(\d{2})")
+
+
+def drop_old_partitions(keep_months: int = 6) -> None:
+    """Remove ``audit_log`` partitions older than ``keep_months`` months."""
+
+    now = datetime.utcnow().replace(day=1)
+    year, month = now.year, now.month - keep_months
+    while month <= 0:
+        month += 12
+        year -= 1
+    keep_from = datetime(year, month, 1)
+
+    with SessionLocal() as session:
+        res = session.execute(
+            text(
+                "SELECT inhrelid::regclass::text FROM pg_inherits "
+                "JOIN pg_class parent ON parent.oid = inhparent "
+                "WHERE parent.relname = 'audit_log'"
+            )
+        )
+        for (name,) in res:
+            match = PARTITION_RE.match(name)
+            if not match:
+                continue
+            part_date = datetime(int(match.group(1)), int(match.group(2)), 1)
+            if part_date < keep_from:
+                session.execute(
+                    text(f"ALTER TABLE audit_log DETACH PARTITION {name}")
+                )  # nosec B608
+                session.execute(text(f"DROP TABLE IF EXISTS {name}"))  # nosec B608
+        session.commit()
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="Drop old audit_log partitions")
+    parser.add_argument(
+        "--keep-months",
+        type=int,
+        default=6,
+        help="How many months of partitions to keep (default: 6)",
+    )
+    args = parser.parse_args()
+    drop_old_partitions(args.keep_months)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    _cli()


### PR DESCRIPTION
## Summary
- partition audit_log table monthly and route inserts
- add script to prune old audit_log partitions
- document audit partitioning and retention

## Testing
- `pre-commit run --files docs/DB_INDEXING.md migrations/versions/20250830_0000_audit_log_partitions.py scripts/audit_partition_retention.py`
- `pytest tests/test_audit_log.py api/tests/test_audit.py api/tests/test_admin_kds_audit.py api/tests/test_pagination.py` (fails: assert 500 == 200)


------
https://chatgpt.com/codex/tasks/task_e_68aebc7b4498832aab473507a0e49fde