### PR TITLE
perf(ci): Lighthouse budgets + reports

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,55 @@
+name: lighthouse-ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: neo
+          POSTGRES_PASSWORD: neo
+          POSTGRES_DB: neo
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U neo" --health-interval=10s --health-timeout=5s --health-retries=5
+    env:
+      DATABASE_URL: postgresql+asyncpg://neo:neo@localhost:5432/neo
+      SYNC_DATABASE_URL: postgresql://neo:neo@localhost:5432/neo
+      SQLALCHEMY_DATABASE_URI: postgresql://neo:neo@localhost:5432/neo
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install Python dependencies
+        run: pip install -r api/requirements.txt
+      - name: Install Lighthouse CI
+        run: npm install -g @lhci/cli
+      - name: Wait for Postgres
+        run: |
+          until pg_isready -h localhost -U neo; do
+            echo "Waiting for Postgres..."
+            sleep 1
+          done
+      - name: Run migrations
+        run: |
+          python -m alembic -c api/alembic.ini upgrade head -x db_url=$SYNC_DATABASE_URL
+      - name: Run Lighthouse CI
+        run: |
+          python start_app.py &
+          sleep 5
+          lhci autorun --config=lighthouserc.json
+      - name: Upload Lighthouse reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: lighthouse

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository contains three main services:
 - `api/` – FastAPI application with `/health`, `/ready` and `/time/skew` endpoints, Alembic migrations, and service helpers such as EMA-based ETA utilities with per-tenant persistence.
 - `pwa/` – React + Tailwind front end with a placeholder home page and installable PWA manifest.
  - `ops/` – Docker Compose for local development.
+
+A Lighthouse CI workflow enforces performance budgets for the guest, admin, and KDS routes.
 Monitoring tools such as UptimeRobot should poll the `/status.json` endpoint for platform health. Status is persisted in Redis with `status.json` on disk as a fallback. Administrators can override it via `POST /admin/status` or the helper script in `ops/scripts/status_page.py` during incidents.
 Invoices support optional FSSAI license details when provided.
 QR pack generation events are audited and can be exported via admin APIs. See

--- a/budgets.json
+++ b/budgets.json
@@ -1,0 +1,35 @@
+[
+  {
+    "path": "/guest",
+    "resourceSizes": [
+      { "resourceType": "total", "budget": 300 },
+      { "resourceType": "script", "budget": 150 }
+    ],
+    "timings": [
+      { "metric": "largest-contentful-paint", "budget": 3000 },
+      { "metric": "interaction-to-next-paint", "budget": 200 }
+    ]
+  },
+  {
+    "path": "/admin",
+    "resourceSizes": [
+      { "resourceType": "total", "budget": 300 },
+      { "resourceType": "script", "budget": 150 }
+    ],
+    "timings": [
+      { "metric": "largest-contentful-paint", "budget": 3000 },
+      { "metric": "interaction-to-next-paint", "budget": 200 }
+    ]
+  },
+  {
+    "path": "/kds",
+    "resourceSizes": [
+      { "resourceType": "total", "budget": 300 },
+      { "resourceType": "script", "budget": 150 }
+    ],
+    "timings": [
+      { "metric": "largest-contentful-paint", "budget": 3000 },
+      { "metric": "interaction-to-next-paint", "budget": 200 }
+    ]
+  }
+]

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -10,6 +10,8 @@ A `trivy` workflow builds the API and worker images and fails if any HIGH or CRI
 
 A nightly `pdf-smoke` workflow renders sample invoice and KOT PDFs for the demo tenant, asserting 200 responses within two seconds and uploading the outputs as build artifacts.
 
+A `lighthouse-ci` workflow audits /guest, /admin, and /kds against LCP, INP, transfer size, and script size budgets, uploading HTML reports and failing the build if limits are exceeded.
+
 1. **build-and-push** – builds the API image and pushes it to GitHub Container Registry (GHCR) tagged as `neo-api:latest`.
 2. **deploy-staging** – upgrades the staging environment via Helm, scrubs restored data to purge real PII (fakes names, phones, and emails; clears payment UTRs; rotates table/room/counter QR tokens), audits environment examples, runs `/api/admin/preflight`, smoke and canary probes, `pa11y-ci`, and Playwright smoke tests.
 3. **manual-approval** – requires a human reviewer before production rollout.

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,24 @@
+{
+  "ci": {
+    "collect": {
+      "url": [
+        "http://localhost:8000/guest",
+        "http://localhost:8000/admin",
+        "http://localhost:8000/kds"
+      ],
+      "numberOfRuns": 1,
+      "output": ["html"],
+      "reportFilenamePattern": "%%PATHNAME%%-lighthouse.%%EXTENSION%%",
+      "settings": {
+        "budgetsPath": "budgets.json"
+      }
+    },
+    "assert": {
+      "budgetsFile": "budgets.json"
+    },
+    "upload": {
+      "target": "filesystem",
+      "outputDir": "./lighthouse"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Lighthouse performance budgets for guest, admin, and KDS routes
- check budgets in CI and upload HTML reports
- document new Lighthouse CI workflow and budgets

## Testing
- `pre-commit run --files budgets.json lighthouserc.json .github/workflows/lighthouse.yml docs/CI_CD.md README.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pypdf'; AssertionError: 'server_time' in response)*
- `pytest tests/test_alert_templates.py`


------
https://chatgpt.com/codex/tasks/task_e_68aebcea2c88832aab3b9cc0b2643f44