### PR TITLE
chore: configure postgres for pa11y workflow

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -11,13 +11,13 @@ jobs:
       postgres:
         image: postgres:16
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: neo
+          POSTGRES_PASSWORD: neo
           POSTGRES_DB: master
         ports:
           - 5432:5432
         options: >-
-          --health-cmd="pg_isready -U postgres"
+          --health-cmd="pg_isready -U neo"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
@@ -31,8 +31,8 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     env:
-      POSTGRES_MASTER_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/master
-      POSTGRES_TENANT_DSN_TEMPLATE: postgresql+asyncpg://postgres:postgres@postgres:5432/tenant_{tenant_id}
+      POSTGRES_MASTER_URL: postgresql+asyncpg://neo:neo@postgres:5432/master
+      POSTGRES_TENANT_DSN_TEMPLATE: postgresql+asyncpg://neo:neo@postgres:5432/tenant_{tenant_id}
       REDIS_URL: redis://localhost:6379/0
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +46,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r api/requirements.txt pillow
+      - name: Wait for DB
+        run: |
+          until pg_isready -h postgres -U neo; do
+            echo "Waiting for Postgres..."
+            sleep 1
+          done
       - name: Migrate and seed demo data
         run: |
           PYTHONPATH=. python scripts/tenant_migrate.py --tenant demo


### PR DESCRIPTION
## Summary
- ensure pa11y workflow uses Postgres 16 service with neo credentials
- provide master and tenant DSN environment variables
- wait for PostgreSQL before running migrations

## Testing
- `pre-commit run --files .github/workflows/a11y.yml`


------
https://chatgpt.com/codex/tasks/task_e_68aebdba5b7c832a9dc26186097c7da0