### PR TITLE
fix(ux): checkout page with legal links + refund confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Configure gitleaks workflow with env vars and job-level permissions.
 - Ensure pa11y workflow waits for Postgres and migrates before tests.
 - Add checkout footer links and confirm refund flow with idempotency key note in admin.
+- Show checkout totals with optional tip, legal links, and confirmation before idempotent refunds.
 
 ### Added
 

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Checkout</title>
+  </head>
+  <body>
+    <p>Total: {{ total }}</p>
+    {% if tip_enabled %}
+    <p>Tip: {{ tip }}</p>
+    {% endif %}
+
+    <div id="payment-methods">
+      {% for method in payment_methods %}
+      <button class="pay" data-method="{{ method }}">{{ method }}</button>
+      {% endfor %}
+    </div>
+
+    <button id="refund-btn" data-payment-id="{{ payment_id }}">Refund</button>
+    <p style="font-size: 10px">
+      <a href="/legal/terms">Terms</a> |
+      <a href="/legal/refund">Refunds</a> |
+      <a href="/legal/contact">Contact</a>
+    </p>
+    <script>
+      const btn = document.getElementById('refund-btn');
+      if (btn) {
+        btn.addEventListener('click', async () => {
+          if (!confirm('Are you sure?')) return;
+          const key = self.crypto?.randomUUID?.() || Date.now().toString();
+          const id = btn.dataset.paymentId;
+          await fetch(`/payments/${id}/refund`, {
+            method: 'POST',
+            headers: { 'Idempotency-Key': key }
+          });
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/tests/test_checkout_template.py
+++ b/tests/test_checkout_template.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_checkout_refund_flow():
+    html = Path("templates/checkout.html").read_text(encoding="utf-8")
+    # legal links are covered elsewhere; here we check refund behaviour
+    assert "Are you sure?" in html
+    assert "confirm(" in html
+    assert "Idempotency-Key" in html
+    assert "/payments/" in html and "/refund" in html

--- a/tests/test_legal_pages.py
+++ b/tests/test_legal_pages.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from fastapi.testclient import TestClient
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from api.app.routes_legal import router as legal_router
 
@@ -27,7 +27,11 @@ def test_legal_pages_served():
 
 def test_invoice_templates_link_legal_pages():
     root = Path(__file__).resolve().parents[1]
-    templates = ["templates/invoice_a4.html", "templates/invoice_80mm.html"]
+    templates = [
+        "templates/invoice_a4.html",
+        "templates/invoice_80mm.html",
+        "templates/checkout.html",
+    ]
     for template in templates:
         html = (root / template).read_text(encoding="utf-8")
         for path in ["terms", "refund", "contact"]:


### PR DESCRIPTION
## Summary
- add checkout page template with totals, optional tips, legal links, and idempotent refund flow
- cover checkout legal links in existing tests
- document checkout refund confirmation and legal links in changelog

## Testing
- `pre-commit run --files CHANGELOG.md templates/checkout.html tests/test_legal_pages.py tests/test_checkout_template.py`
- `pytest tests/test_legal_pages.py tests/test_checkout_template.py api/tests/test_refunds.py`

------
https://chatgpt.com/codex/tasks/task_e_68aed5ce1128832a8e3795c239557d92