### PR TITLE
chore(ci): weekly rollback dry-run workflow

### DIFF
--- a/.github/workflows/rollback_dryrun.yml
+++ b/.github/workflows/rollback_dryrun.yml
@@ -1,0 +1,15 @@
+name: rollback-dryrun
+
+on:
+  schedule: [{ cron: "0 9 * * 1" }]  # Mon 09:00 IST
+  workflow_dispatch:
+
+jobs:
+  dryrun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dry-run rollback on staging
+        run: |
+          python scripts/rollback_blue_green.py --env=staging --to=$(python scripts/release_tag.py --prev)
+          echo "✅ rollback dry-run completed"

--- a/docs/ROLLBACK_DRILL.md
+++ b/docs/ROLLBACK_DRILL.md
@@ -16,4 +16,5 @@ A quick exercise to keep rollback muscle memory fresh.
    - Hit critical endpoints or run smoke tests to confirm the old version works.
 
 A GitHub Actions workflow performs a weekly dry-run against staging so the team
-practises these steps regularly.
+practises these steps regularly. It runs every Monday at 09:00 IST and rolls back
+to the previous release tag.


### PR DESCRIPTION
## Summary
- add scheduled rollback dry-run workflow to exercise staging rollbacks weekly
- document weekly rollback drill schedule and target

## Testing
- `pytest api/tests/test_invoice_pdf_route.py -q -W ignore` (fails: ModuleNotFoundError: No module named 'pypdf')
- `pytest tests/test_anonymize_pii.py -q -W ignore`

------
https://chatgpt.com/codex/tasks/task_e_68aed5c95fec832a8281d0fd1e9ebead