### PR TITLE
Fix print test script import path

### DIFF
--- a/scripts/save_print_test_png.py
+++ b/scripts/save_print_test_png.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import pathlib
+import sys
 
 import fakeredis.aioredis
 import requests
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
 
 from api.app.render_text_image import render_text_image
 from api.app.routes_print_test import router


### PR DESCRIPTION
## Summary
- allow `save_print_test_png.py` to import API modules when run directly by adding repository root to `sys.path`

## Testing
- `pre-commit run --files scripts/save_print_test_png.py`
- `PYTHONPATH=tests pytest` *(fails: import file mismatch in several test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68aef6058ea4832a920cd4c91aac8f9e