### PR TITLE
feat: add root requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ database migrations for both the master schema and an example tenant, and run
 the test suite:
 
 ```bash
-pip install -r api/requirements.txt
+pip install -r requirements.txt
 python run_all.py --env --install
 alembic upgrade head
 pytest -q
@@ -471,11 +471,11 @@ Admins can pin tables on a floor plan and retrieve their states:
 Run migrations and launch the API with a single command once dependencies are installed:
 
 ```bash
-pip install -r api/requirements.txt python-dotenv
+pip install -r requirements.txt python-dotenv
 python start_app.py
 ```
 
-The script loads environment variables from `.env`, executes `alembic upgrade head` using `api/alembic.ini` via `python -m alembic`, and starts the application via `uvicorn api.app.main:app`. If Alembic is missing, it will prompt you to install dependencies with `pip install -r api/requirements.txt`.
+The script loads environment variables from `.env`, executes `alembic upgrade head` using `api/alembic.ini` via `python -m alembic`, and starts the application via `uvicorn api.app.main:app`. If Alembic is missing, it will prompt you to install dependencies with `pip install -r requirements.txt`.
 
 ### Notification Worker
 
@@ -803,7 +803,7 @@ Create a virtual environment and install development dependencies:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -r api/requirements.txt
+pip install -r requirements.txt
 pip install pre-commit pytest-cov
 ```
 Run linters and formatters:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,7 +8,7 @@ A Helm chart for Kubernetes deployments lives in [helm](helm/README.md).
 
 ## 1. Install dependencies
 - Python 3.12+
-- `uvicorn` and project requirements: `pip install -r api/requirements.txt`
+- `uvicorn` and project requirements: `pip install -r requirements.txt`
 - nginx and systemd (usually preinstalled on most distributions)
 
 ## 2. Set up the application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r api/requirements.txt

--- a/start_app.py
+++ b/start_app.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 import subprocess
 import sys
 
-from dotenv import load_dotenv
 import uvicorn
+from dotenv import load_dotenv
 
 import config
 
@@ -30,9 +30,7 @@ def main() -> None:
             check=True,
         )
     except FileNotFoundError:
-        print(
-            "Install dependencies first: pip install -r api/requirements.txt"
-        )
+        print("Install dependencies first: pip install -r requirements.txt")
         return
     uvicorn.run("api.app.main:app")
 


### PR DESCRIPTION
## Summary
- add root requirements.txt referencing api/requirements.txt
- update docs to use new root requirements
- adjust startup script message to reference root requirements file

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: import file mismatch errors)*


------
https://chatgpt.com/codex/tasks/task_e_68aef90d6790832aa89af3afc6a20cb9