### PR TITLE
chore: harden worker image and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Security
+
+- Pin ``ecdsa`` dependency to ``>=0.19.2`` to address upstream vulnerability.
+- Pin worker image to a digest-based Python base, upgrade ``setuptools`` during build, and run as non-root ``app`` user.
+
 ## v1.0.0 - 2025-08-26
 
 ### Fixed

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,11 +1,15 @@
-FROM python:3.11-slim
+FROM python@sha256:1d6131b5d479888b43200645e03a78443c7157efbdb730e6b48129740727c312
 
 WORKDIR /app
 
 COPY api/requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
+    && pip install --no-cache-dir --upgrade setuptools
 
 COPY api /app/api
 COPY scripts /app/scripts
+
+RUN useradd -m app && chown -R app /app
+USER app
 
 CMD ["python", "scripts/notify_worker.py"]

--- a/api/app/routes_support_bundle.py
+++ b/api/app/routes_support_bundle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from io import BytesIO
 from typing import Iterator
@@ -18,6 +19,8 @@ from .models_master import Tenant
 from .routes_ready import ready
 from .routes_version import version
 from .utils.responses import ok
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -50,7 +53,6 @@ async def support_bundle(
                 "enable_hotel": bool(tenant.enable_hotel),
                 "enable_counter": bool(tenant.enable_counter),
                 "enable_gateway": bool(getattr(tenant, "enable_gateway", False)),
-
                 "sla_sound_alert": bool(tenant.sla_sound_alert),
                 "sla_color_alert": bool(tenant.sla_color_alert),
             },
@@ -77,7 +79,8 @@ async def support_bundle(
             with open(log_file, "r", encoding="utf-8") as fh:
                 lines = fh.readlines()[-200:]
             log_content = "".join(lines)
-        except Exception:  # pragma: no cover - best effort
+        except OSError as exc:  # pragma: no cover - best effort
+            logger.warning("Failed to read log file %s: %s", log_file, exc)
             log_content = None
 
     def build_zip() -> Iterator[bytes]:

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,6 +8,7 @@ requests
 
 argon2-cffi
 python-jose[cryptography]
+ecdsa>=0.19.2
 pydantic-settings
 python-dotenv
 openpyxl

--- a/docs/DEPLOY_DOCKER.md
+++ b/docs/DEPLOY_DOCKER.md
@@ -2,6 +2,8 @@
 
 This repository provides Docker images for the API service and the background worker. The images share the same base but expose different commands.
 
+Worker images pin the Python base image by digest, upgrade ``setuptools`` during build, and run as a non-root ``app`` user.
+
 ## Build images
 
 ```bash


### PR DESCRIPTION
## Summary
- pin ecdsa to >=0.19.2
- harden worker image with digest-based Python, setuptools upgrade, and non-root user
- replace broad exceptions with targeted ones and log unexpected errors

## Testing
- `pre-commit run --files api/requirements.txt Dockerfile.worker docs/DEPLOY_DOCKER.md CHANGELOG.md scripts/notify_worker.py api/app/analytics/posthog.py api/app/routes_support_bundle.py`
- `pytest api/tests/test_retention.py`
- `docker build -f Dockerfile.worker .` *(fails: command not found)*
- `trivy fs --security-checks vuln --exit-code 1 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af011cf140832a9fcdfd29f4d7afad