### PR TITLE
fix: order alembic db_url flag in workflows

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Migrate and seed demo data
         run: |
-          python -m alembic -c api/alembic.ini upgrade head -x db_url=$SYNC_DATABASE_URL
+          python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
           PYTHONPATH=. python scripts/tenant_migrate.py --tenant demo
           PYTHONPATH=. python scripts/demo_seed.py --tenant demo --reset
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -42,7 +42,7 @@ jobs:
           done
       - name: Run migrations
         run: |
-          python -m alembic -c api/alembic.ini upgrade head -x db_url=$SYNC_DATABASE_URL
+          python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
       - name: Run Lighthouse CI
         run: |
           python start_app.py &

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run migrations
         run: |
-          python -m alembic -c api/alembic.ini upgrade head -x db_url=$SYNC_DATABASE_URL
+          python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
 
       - name: Start API
         run: |


### PR DESCRIPTION
## Summary
- ensure alembic db_url flag precedes `upgrade head` in a11y, lighthouse, and pa11y workflows

## Testing
- `SYNC_DATABASE_URL=sqlite:///test.db python -m alembic -c alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head --sql` (fails: ImportError: cannot import name 'models' from 'app')
- `pytest -q` (fails: import file mismatch)


------
https://chatgpt.com/codex/tasks/task_e_68af038c0ddc832a92fcec71240d233d