### PR TITLE
chore: reorder alembic db_url flag in CI workflows

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Migrate and seed demo data
         run: |
-          python -m alembic -c api/alembic.ini upgrade head -x db_url=$SYNC_DATABASE_URL
+          python -m alembic -x db_url=$SYNC_DATABASE_URL -c api/alembic.ini upgrade head
           PYTHONPATH=. python scripts/tenant_migrate.py --tenant demo
           PYTHONPATH=. python scripts/demo_seed.py --tenant demo --reset
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -42,7 +42,7 @@ jobs:
           done
       - name: Run migrations
         run: |
-          python -m alembic -c api/alembic.ini upgrade head -x db_url=$SYNC_DATABASE_URL
+          python -m alembic -x db_url=$SYNC_DATABASE_URL -c api/alembic.ini upgrade head
       - name: Run Lighthouse CI
         run: |
           python start_app.py &

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run migrations
         run: |
-          python -m alembic -c api/alembic.ini upgrade head -x db_url=$SYNC_DATABASE_URL
+          python -m alembic -x db_url=$SYNC_DATABASE_URL -c api/alembic.ini upgrade head
 
       - name: Start API
         run: |


### PR DESCRIPTION
## Summary
- reorder alembic db_url flag ahead of config in pa11y workflow
- move alembic db_url flag ahead of subcommand in lighthouse workflow
- run alembic with db_url flag first in a11y workflow

## Testing
- `pre-commit run --files .github/workflows/pa11y.yml .github/workflows/lighthouse.yml .github/workflows/a11y.yml`
- `pytest tests/test_status_route.py::test_status_route_serves_json -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0297ce38832a9b66faa96325e3dd