### PR TITLE
Fix Alembic argument order in a11y workflows

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Migrate and seed demo data
         run: |
-          python -m alembic -c api/alembic.ini upgrade head -x db_url=$SYNC_DATABASE_URL
+          python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
           PYTHONPATH=. python scripts/tenant_migrate.py --tenant demo
           PYTHONPATH=. python scripts/demo_seed.py --tenant demo --reset
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -42,7 +42,7 @@ jobs:
           done
       - name: Run migrations
         run: |
-          python -m alembic -c api/alembic.ini upgrade head -x db_url=$SYNC_DATABASE_URL
+          python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
       - name: Run Lighthouse CI
         run: |
           python start_app.py &

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run migrations
         run: |
-          python -m alembic -c api/alembic.ini upgrade head -x db_url=$SYNC_DATABASE_URL
+          python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
 
       - name: Start API
         run: |


### PR DESCRIPTION
## Summary
- fix Alembic argument order in a11y CI workflow
- fix Alembic argument order in Lighthouse CI workflow
- fix Alembic argument order in pa11y CI workflow

## Testing
- `pre-commit run --files .github/workflows/a11y.yml .github/workflows/lighthouse.yml .github/workflows/pa11y.yml`
- `SYNC_DATABASE_URL=sqlite:///test.db python -m alembic -c alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head --sql` (fails: ImportError: cannot import name 'models' from 'app')

------
https://chatgpt.com/codex/tasks/task_e_68af042e8bd4832abc57ab3f15075431