### PR TITLE
chore: relax ecdsa requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
-- Pin ``ecdsa`` dependency to ``>=0.19.2`` to address upstream vulnerability.
+- Pin ``ecdsa`` dependency to ``>=0.19.1`` to address upstream vulnerability.
 - Pin worker image to a digest-based Python base, upgrade ``setuptools`` during build, and run as non-root ``app`` user.
 
 ## v1.0.0 - 2025-08-26

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -60,7 +60,7 @@ cryptography==45.0.6
     # via python-jose
 dnspython==2.7.0
     # via email-validator
-ecdsa==0.19.1
+ecdsa>=0.19.1
     # via python-jose
 email-validator==2.3.0
     # via -r api/requirements.in


### PR DESCRIPTION
## Summary
- relax ecdsa constraint to >=0.19.1
- document ecdsa requirement change in changelog

## Testing
- `pip install -r api/requirements.txt`
- `pytest -q` *(fails: import file mismatch between api/tests and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68af0445c508832a9ee208119fd1b3de