### PR TITLE
fix: point alembic to api folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ the test suite:
 ```bash
 pip install -r requirements.txt
 python run_all.py --env --install
-alembic upgrade head
+cd api && python -m alembic -c alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
+cd ..
 pytest -q
 ```
 
@@ -479,7 +480,7 @@ pip install -r requirements.txt python-dotenv
 python start_app.py
 ```
 
-The script loads environment variables from `.env`, executes `alembic upgrade head` using `api/alembic.ini` via `python -m alembic`, and starts the application via `uvicorn api.app.main:app`. If Alembic is missing, it will prompt you to install dependencies with `pip install -r requirements.txt`.
+The script loads environment variables from `.env`, runs `python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head`, and starts the application via `uvicorn api.app.main:app`. If Alembic is missing, it will prompt you to install dependencies with `pip install -r requirements.txt`.
 
 ### Notification Worker
 

--- a/api/alembic.ini
+++ b/api/alembic.ini
@@ -1,5 +1,7 @@
 [alembic]
-script_location = alembic
+# Point directly to the migrations folder so commands can run
+# from the repository root without changing directories.
+script_location = api/alembic
 sqlalchemy.url =
 
 offline_mode = true

--- a/docs/DEPLOY_DOCKER.md
+++ b/docs/DEPLOY_DOCKER.md
@@ -15,7 +15,7 @@ docker compose build
 Run migrations once the database is ready. This uses the Alembic configuration bundled with the API image.
 
 ```bash
-docker compose run --rm api alembic -c api/alembic.ini upgrade head
+docker compose run --rm api bash -c "cd api && python -m alembic -c alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head"
 ```
 
 ## Launch services


### PR DESCRIPTION
## Summary
- set alembic.ini script_location to the api folder
- document running migrations from api directory

## Testing
- `pytest -q --import-mode=importlib` *(fails: ImportError: cannot import name 'stream_rows' from 'api.app.utils.csv_stream')*

------
https://chatgpt.com/codex/tasks/task_e_68af075a9cc8832ab8b7db5e432d9cbb