### PR TITLE
Fix Alembic env import to use master models

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -12,7 +12,7 @@ sys.path.append(str(BASE_DIR))
 sys.path.append(str(BASE_DIR.parent))
 
 from config import get_settings  # type: ignore  # noqa: E402
-from app import models  # type: ignore  # noqa: E402
+from app import models_master  # type: ignore  # noqa: E402
 
 config = context.config
 fileConfig(config.config_file_name)
@@ -23,7 +23,7 @@ DB_URLS = {
     "tenant": settings.postgres_tenant_dsn_template.format(tenant_id="tenant"),
 }
 
-target_metadata = models.Base.metadata
+target_metadata = models_master.Base.metadata
 
 
 def _get_url() -> str:


### PR DESCRIPTION
## Summary
- fix Alembic env by importing models_master instead of missing models

## Testing
- `python -m alembic -c api/alembic.ini -x db_url=sqlite:/// upgrade head` *(fails: no such table: main.invoices)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_config.py` *(fails: KeyboardInterrupt during import)*

------
https://chatgpt.com/codex/tasks/task_e_68af0ab688ec832abc744004221b3be2