### PR TITLE
fix: remove unsupported conditional from python-tests workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,7 +12,6 @@ jobs:
         db: [sqlite, postgres]
     services:
       postgres:
-        if: matrix.db == 'postgres'
         image: postgres:16
         env:
           POSTGRES_USER: postgres

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 
 - 24×7 synthetic order monitor with CI alerts and dashboards.
 
+### Fixed
+
+- Remove invalid conditional from python-tests workflow to restore CI checks.
+
 ## v1.0.0 - 2025-08-26
 
 ### Fixed


### PR DESCRIPTION
## Summary
- remove unsupported `if` from postgres service in python tests workflow
- document CI workflow fix in changelog

## Testing
- `pre-commit run --files .github/workflows/python-tests.yml CHANGELOG.md`
- `pytest -q` *(fails: tests/test_analytics_outlets.py, tests/test_export_streaming.py, tests/test_kds_expo.py, tests/test_rum_vitals.py, tests/test_slo_metrics.py, tests/test_time_skew.py: collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af09cfb010832a9adfd68eaa9d6ab5