### PR TITLE
chore: track master and tenant bases in alembic

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ cd ..
 pytest -q
 ```
 
+The Alembic environment now pulls metadata from both `MasterBase` and `TenantBase`
+so migrations cover the master schema as well as tenant-specific tables.
+
 Dependencies are pinned in `api/requirements.txt`, generated from
 `api/requirements.in` using `pip-compile`. Update the `.in` file and
 rerun `pip-compile` to refresh locked versions.

--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import sys
 from logging.config import fileConfig
 from pathlib import Path
-import sys
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
@@ -11,8 +11,9 @@ BASE_DIR = Path(__file__).resolve().parents[1]
 sys.path.append(str(BASE_DIR))
 sys.path.append(str(BASE_DIR.parent))
 
+from app.db import MasterBase, TenantBase  # type: ignore  # noqa: E402
+
 from config import get_settings  # type: ignore  # noqa: E402
-from app import models  # type: ignore  # noqa: E402
 
 config = context.config
 fileConfig(config.config_file_name)
@@ -23,7 +24,7 @@ DB_URLS = {
     "tenant": settings.postgres_tenant_dsn_template.format(tenant_id="tenant"),
 }
 
-target_metadata = models.Base.metadata
+target_metadata = [MasterBase.metadata, TenantBase.metadata]
 
 
 def _get_url() -> str:


### PR DESCRIPTION
## Summary
- import `MasterBase` and `TenantBase` into Alembic env
- target both metadata sets for migrations
- document Alembic handling of master and tenant tables

## Testing
- `python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head --sql`
- `pre-commit run --files api/alembic/env.py README.md`
- `pytest -q` *(fails: import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68af0a04c448832ab74d8dbee3749e16