### PR TITLE
docs: document webhook usage and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+WEBHOOK=https://hooks.example.com/endpoint

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -30,6 +30,7 @@ jobs:
       POSTGRES_PASSWORD: ${{ matrix.db == 'postgres' && 'postgres' || '' }}
       POSTGRES_DB: ${{ matrix.db == 'postgres' && 'postgres' || '' }}
       POSTGRES_TENANT_DSN_TEMPLATE: ${{ matrix.db == 'postgres' && 'postgresql+asyncpg://postgres:postgres@localhost:5432/{tenant_id}' || '' }}
+      WEBHOOK: ${{ secrets.WEBHOOK }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -243,6 +243,25 @@ docker build -t worker -f Dockerfile.worker .
 trivy image --severity HIGH,CRITICAL api worker
 ```
 
+## Monitoring
+
+The synthetic monitor posts its results to a chat channel via a webhook URL. Export the webhook locally so
+messages can be delivered:
+
+```bash
+export WEBHOOK=https://hooks.example.com/endpoint
+```
+
+In GitHub Actions workflows, expose a repository secret and map it to the same environment variable:
+
+```yaml
+env:
+  WEBHOOK: ${{ secrets.WEBHOOK }}
+```
+
+Refer to the [webhook verification runbook](docs/runbooks/webhook_verification.md) for obtaining the URL and
+troubleshooting failures.
+
 ## Accessibility
 
 Buttons across major flows include descriptive ARIA labels, visible focus

--- a/api/app/providers/slack_stub.py
+++ b/api/app/providers/slack_stub.py
@@ -7,8 +7,8 @@ import requests
 
 
 def send(event: Any, payload: Dict[str, Any], target: Optional[str]) -> None:
-    url = os.getenv("SLACK_WEBHOOK_URL")
+    url = os.getenv("WEBHOOK") or os.getenv("SLACK_WEBHOOK_URL")
     if not url:
-        raise RuntimeError("SLACK_WEBHOOK_URL not configured")
+        raise RuntimeError("WEBHOOK not configured")
     text = payload.get("text") or payload.get("message") or ""
     requests.post(url, json={"text": text}, timeout=5).raise_for_status()

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -29,6 +29,7 @@ The application relies on the following environment variables:
 | `WEBHOOK_SIGNING_SECRET` (optional) | Shared secret for signing outbound webhook requests. | `supersecret` |
 | `WEBHOOK_ALLOW_HOSTS` | Allowed webhook hostnames (comma, supports `*` wildcard). | `hooks.slack.com,*.example.com` |
 | `WEBHOOK_DENY_CIDRS` (optional) | CIDR ranges blocked for webhook egress. | `10.0.0.0/8` |
+| `WEBHOOK` | Chat webhook for synthetic monitor alerts (alias: `SLACK_WEBHOOK_URL`). | `https://hooks.example.com/endpoint` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` (optional) | OTLP trace exporter endpoint. Tracing is disabled when unset. | `http://otel-collector:4318/v1/traces` |
 | `OTEL_SERVICE_NAME` (optional) | Service name used for OpenTelemetry traces. Defaults to `neo-api`. | `neo-api` |
 | `OTEL_SAMPLER_RATIO` (optional) | Sampling ratio between 0 and 1. Defaults to `0.1`. | `0.25` |

--- a/docs/runbooks/webhook_verification.md
+++ b/docs/runbooks/webhook_verification.md
@@ -1,0 +1,26 @@
+# Webhook Verification
+
+This runbook outlines how to verify the monitoring webhook used by automated checks.
+
+## Obtain the Webhook URL
+
+Generate an incoming webhook in your chat or monitoring service (e.g. Slack) and copy the full URL.
+
+## Verify the Webhook
+
+Export the webhook and send a test message:
+
+```bash
+export WEBHOOK=https://hooks.example.com/endpoint
+curl -X POST -H 'Content-Type: application/json' -d '{"text":"test"}' "$WEBHOOK"
+```
+
+## Expected Response
+
+A successful request returns a `2xx` status code. A `404` or `410` indicates the URL is invalid or revoked.
+
+## Troubleshooting
+
+- **Connection refused** – check firewall rules or proxy settings.
+- **5xx responses** – the remote service is down; retry later.
+- **Timeouts** – ensure the URL is reachable from your network.

--- a/scripts/emit_test_alert.py
+++ b/scripts/emit_test_alert.py
@@ -27,6 +27,12 @@ def main() -> None:
 
     url = os.environ.get("ALERTMANAGER_URL")
     if url:
+        try:
+            ping = requests.get(url, timeout=5)
+            ping.raise_for_status()
+        except Exception as exc:
+            raise SystemExit(f"Alertmanager unreachable at {url}: {exc}") from exc
+
         payload = [
             {
                 "labels": {"alertname": "SyntheticTestAlert", "severity": "critical"},

--- a/scripts/tests/test_emit_test_alert.py
+++ b/scripts/tests/test_emit_test_alert.py
@@ -1,0 +1,31 @@
+import importlib.util
+import sys
+
+import pytest
+import responses
+
+spec = importlib.util.spec_from_file_location(
+    "emit_test_alert", "scripts/emit_test_alert.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def test_emit_alert_success(monkeypatch):
+    monkeypatch.setenv("ALERTMANAGER_URL", "http://alert.local")
+    monkeypatch.setattr(sys, "argv", ["emit_test_alert.py"])
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, "http://alert.local", status=200)
+        rsps.add(
+            responses.POST, "http://alert.local/api/v1/alerts", json={}, status=200
+        )
+        module.main()
+
+
+def test_emit_alert_unreachable(monkeypatch):
+    monkeypatch.setenv("ALERTMANAGER_URL", "http://alert.local")
+    monkeypatch.setattr(sys, "argv", ["emit_test_alert.py"])
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, "http://alert.local", status=500)
+        with pytest.raises(SystemExit, match="unreachable"):
+            module.main()


### PR DESCRIPTION
## Summary
- document `WEBHOOK` variable and provide runbook
- validate alert endpoints and add webhook tests
- load `WEBHOOK` secret in CI

## Testing
- `pre-commit run --files .env.example docs/ENV_VARS.md README.md docs/runbooks/webhook_verification.md api/app/providers/slack_stub.py tests/test_notify_worker.py scripts/emit_test_alert.py scripts/tests/test_emit_test_alert.py .github/workflows/python-tests.yml`
- `pytest tests/test_notify_worker.py::test_slack_delivery tests/test_notify_worker.py::test_slack_missing_webhook scripts/tests/test_emit_test_alert.py::test_emit_alert_success scripts/tests/test_emit_test_alert.py::test_emit_alert_unreachable -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1147213c832a886be1043fa14035