### PR TITLE
feat: allow DSN template override for tenant migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,9 +744,12 @@ python scripts/tenant_create_db.py --tenant TENANT_ID
 
 The script will print `READY` once the database is available.
 
-To apply migrations for an existing tenant database, run:
+To apply migrations for an existing tenant database, provide a DSN template via
+``--dsn-template`` or the ``POSTGRES_TENANT_DSN_TEMPLATE`` environment variable
+(e.g. ``postgresql+asyncpg://u:p@host:5432/tenant_{tenant_id}``) and run:
 
 ```bash
+POSTGRES_TENANT_DSN_TEMPLATE=postgresql+asyncpg://u:p@host:5432/tenant_{tenant_id} \
 python scripts/tenant_migrate.py --tenant TENANT_ID
 ```
 

--- a/docs/DEV_TENANT.md
+++ b/docs/DEV_TENANT.md
@@ -9,7 +9,9 @@ Run each command from the project root:
    ```
 2. Apply database migrations
    ```bash
+   POSTGRES_TENANT_DSN_TEMPLATE=postgresql+asyncpg://u:p@host:5432/tenant_{tenant_id} \
    python scripts/tenant_migrate.py --tenant demo
+   # or: python scripts/tenant_migrate.py --tenant demo --dsn-template 'postgresql+asyncpg://u:p@host:5432/tenant_{tenant_id}'
    ```
 3. Seed the database with demo data
    ```bash

--- a/docs/perf_indexes.md
+++ b/docs/perf_indexes.md
@@ -20,8 +20,11 @@ exports:
 - `idx_orders_tenant_status_created` on `orders(tenant_id, status, created_at DESC)`
 - `idx_audit_tenant_created` on `audit_tenant(tenant_id, created_at DESC)`
 
-Run tenant migrations as usual to apply the indexes:
+Run tenant migrations as usual to apply the indexes. Supply a DSN template via
+``--dsn-template`` or the ``POSTGRES_TENANT_DSN_TEMPLATE`` environment
+variable::
 
 ```bash
+POSTGRES_TENANT_DSN_TEMPLATE=postgresql+asyncpg://u:p@host:5432/tenant_{tenant_id} \
 python scripts/tenant_migrate.py --tenant <tenant>
 ```

--- a/scripts/tenant_migrate.py
+++ b/scripts/tenant_migrate.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 """Run tenant-specific Alembic migrations.
 
-This CLI generates a DSN for the provided tenant ID using the
-``POSTGRES_TENANT_DSN_TEMPLATE`` environment variable and executes
-``alembic upgrade head`` against the tenant migration environment.
+This CLI generates a DSN for the provided tenant ID using either the
+``--dsn-template`` option or the ``POSTGRES_TENANT_DSN_TEMPLATE`` environment
+variable and executes ``alembic upgrade head`` against the tenant migration
+environment. The template must contain a ``{tenant_id}`` placeholder, for
+example::
+
+    postgresql+asyncpg://u:p@host:5432/tenant_{tenant_id}
+
+Either the flag or environment variable must be set before running migrations.
 """
 
 from __future__ import annotations
@@ -16,17 +22,20 @@ from alembic import command
 from alembic.config import Config
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from api.app.db.tenant import build_dsn
-
 TEMPLATE_ENV = "POSTGRES_TENANT_DSN_TEMPLATE"
 
 
-def migrate(tenant_id: str) -> None:
+def migrate(tenant_id: str, dsn_template: str | None = None) -> None:
     """Run Alembic migrations for ``tenant_id``."""
-    if not os.getenv(TEMPLATE_ENV):
-        raise RuntimeError(f"{TEMPLATE_ENV} environment variable is not set")
-
-    dsn = build_dsn(tenant_id)
+    template = dsn_template or os.getenv(TEMPLATE_ENV)
+    if not template:
+        raise RuntimeError(
+            f"--dsn-template or {TEMPLATE_ENV} environment variable must be set"
+        )
+    try:
+        dsn = template.format(tenant_id=tenant_id)
+    except Exception as exc:  # pragma: no cover - invalid format string
+        raise ValueError("Invalid DSN template") from exc
     engine = create_async_engine(dsn)
     cfg = Config()
     cfg.set_main_option("script_location", "api/alembic_tenant")
@@ -41,8 +50,12 @@ def migrate(tenant_id: str) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run tenant migrations")
     parser.add_argument("--tenant", required=True, help="Tenant identifier")
+    parser.add_argument(
+        "--dsn-template",
+        help=f"DSN template for tenant databases (overrides {TEMPLATE_ENV})",
+    )
     args = parser.parse_args()
-    migrate(args.tenant)
+    migrate(args.tenant, args.dsn_template)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `--dsn-template` option to `scripts/tenant_migrate.py`
- document DSN template usage for tenant migrations

## Testing
- `python scripts/tenant_migrate.py --help`
- `pytest scripts/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68af14e6087c832a9199ffa89393ff4e