### PR TITLE
Allow pa11y to run without sandbox

### DIFF
--- a/pa11y-ci.json
+++ b/pa11y-ci.json
@@ -2,7 +2,10 @@
   "defaults": {
     "standard": "WCAG2AA",
     "timeout": 60000,
-    "screenCapture": "pa11y-screenshots/${TIMESTAMP}.png"
+    "screenCapture": "pa11y-screenshots/${TIMESTAMP}.png",
+    "chromeLaunchConfig": {
+      "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+    }
   },
   "urls": [
     "http://localhost:8000/guest",


### PR DESCRIPTION
## Summary
- allow pa11y to launch Chrome with `--no-sandbox`

## Testing
- `pre-commit run --files pa11y-ci.json`
- `npx --yes pa11y-ci -c pa11y-ci.json` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68af1492b770832a83dff305c96cf9ea