### PR TITLE
fix: reference ASSETLINKS_HOST via env

### DIFF
--- a/.github/workflows/twa.yml
+++ b/.github/workflows/twa.yml
@@ -6,10 +6,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      ASSETLINKS_HOST: ${{ secrets.ASSETLINKS_HOST }}
     steps:
       - uses: actions/checkout@v4
       - name: Build TWAs
         run: ./scripts/twa_build.sh
       - name: Deploy asset links
-        if: ${{ secrets.ASSETLINKS_HOST != '' }}
+        if: ${{ env.ASSETLINKS_HOST != '' }}
         run: ./scripts/deploy_assetlinks.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Remove invalid conditional from python-tests workflow to restore CI checks.
 - Correct tenant DB creation script to import `build_dsn` from `api.app.db`.
 - Fix YAML indentation in `flags_guard` workflow to resolve CI parsing error.
+- Reference `ASSETLINKS_HOST` secret via env in TWA workflow to fix invalid conditional.
 
 ## v1.0.0 - 2025-08-26
 


### PR DESCRIPTION
## Summary
- fix TWA workflow conditional by referencing ASSETLINKS_HOST secret via env
- document TWA workflow fix in changelog

## Testing
- `pre-commit run --files .github/workflows/twa.yml CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68afa1cf86bc832a815d438ef7ae1e94