### PR TITLE
Handle DATABASE_URL and improve backup utilities

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,8 +19,8 @@ jobs:
         options: >-
           --health-cmd="pg_isready -U neo" --health-interval=10s --health-timeout=5s --health-retries=5
     env:
-      DATABASE_URL: postgresql+asyncpg://neo:neo@localhost:5432/neo
-      SYNC_DATABASE_URL: postgresql://neo:neo@localhost:5432/neo
+      POSTGRES_MASTER_URL: postgresql://neo:neo@localhost:5432/neo
+      DATABASE_URL: postgresql://neo:neo@localhost:5432/neo
       SQLALCHEMY_DATABASE_URI: postgresql://neo:neo@localhost:5432/neo
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
           done
       - name: Run migrations
         run: |
-          python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
+          python -m alembic -c api/alembic.ini -x db_url=$POSTGRES_MASTER_URL upgrade head
       - name: Run Lighthouse CI
         run: |
           python start_app.py &

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ This repository contains three main services:
  - `ops/` – Docker Compose for local development.
 
 A Lighthouse CI workflow enforces performance budgets for the guest, admin, and KDS routes.
+
+### Lighthouse workflow
+
+The workflow requires a PostgreSQL DSN for migrations. Set `POSTGRES_MASTER_URL`
+or `DATABASE_URL` to the same DSN and provide `SQLALCHEMY_DATABASE_URI` for
+tools needing a synchronous connection string.
 Monitoring tools such as UptimeRobot should poll the `/status.json` endpoint for platform health. A synthetic monitor (`scripts/synthetic_order_monitor.py`) exercises a full guest order path end-to-end and reports metrics. Status is persisted in Redis with `status.json` on disk as a fallback. Administrators can override it via `POST /admin/status` or the helper script in `ops/scripts/status_page.py` during incidents.
 Invoices support optional FSSAI license details when provided.
 QR pack generation events are audited and can be exported via admin APIs. See

--- a/config.py
+++ b/config.py
@@ -74,5 +74,8 @@ def get_settings() -> Settings:
         if k.lower() in Settings.model_fields
     }
     merged = {**data, **env_override}
+    db_url = os.environ.get("DATABASE_URL")
+    if db_url and "postgres_master_url" not in env_override:
+        merged["postgres_master_url"] = db_url
     # Environment variables override values from the JSON file.
     return Settings(**merged)

--- a/scripts/tenant_backup.py
+++ b/scripts/tenant_backup.py
@@ -71,13 +71,16 @@ def backup(tenant: str, out_path: Path) -> None:
         else:
             _export_sqlite(db_path, out_path)
     else:
-        if out_path.suffix == ".json":
-            out_path.write_text(json.dumps({"todo": "implement postgres export"}))
-        else:
-            pg_dump = shutil.which("pg_dump")
-            if not pg_dump:
-                raise RuntimeError("pg_dump not available – TODO: invoke pg_dump for backups")
-            subprocess.run([pg_dump, dsn, "-f", str(out_path)], check=True)
+        pg_dump = shutil.which("pg_dump")
+        if not pg_dump:
+            raise FileNotFoundError(
+                "pg_dump not found; install PostgreSQL client tools"
+            )
+        cmd = [pg_dump]
+        if out_path.suffix != ".sql":
+            cmd.append("-Fc")
+        cmd.extend(["-f", str(out_path), dsn])
+        subprocess.run(cmd, check=True)
 
 
 def main() -> None:

--- a/start_app.py
+++ b/start_app.py
@@ -28,7 +28,14 @@ def main() -> None:
                 "head",
             ],
             check=True,
+            capture_output=True,
+            text=True,
         )
+    except subprocess.CalledProcessError as exc:
+        if exc.stderr:
+            sys.stderr.write(exc.stderr)
+        print("database connection failed", file=sys.stderr)
+        raise SystemExit(1)
     except FileNotFoundError:
         print("Install dependencies first: pip install -r requirements.txt")
         return

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,3 +39,10 @@ def test_missing_key_uses_default(monkeypatch):
     )
     settings = _settings()
     assert settings.acceptance_mode == AcceptanceMode.ITEM
+
+
+def test_database_url_populates_master(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://example")
+    settings = _settings()
+    assert settings.postgres_master_url == "postgresql://example"
+    monkeypatch.delenv("DATABASE_URL")

--- a/tests/test_start_app.py
+++ b/tests/test_start_app.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from start_app import main  # noqa: E402
+
+
+def test_failed_migration_logs_error(monkeypatch, capsys):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd, stderr="boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit):
+        main()
+    err = capsys.readouterr().err
+    assert "boom" in err
+    assert "database connection failed" in err

--- a/tests/test_tenant_backup.py
+++ b/tests/test_tenant_backup.py
@@ -3,6 +3,8 @@ import sqlite3
 import subprocess
 import sys
 from pathlib import Path
+import shutil
+import pytest
 
 
 def test_backup_creates_file(tmp_path, monkeypatch):
@@ -30,3 +32,53 @@ def test_backup_creates_file(tmp_path, monkeypatch):
     )
     assert out_file.exists()
     assert out_file.read_text().strip()
+
+
+def test_pg_backup_invokes_pg_dump(tmp_path, monkeypatch):
+    from scripts import tenant_backup
+
+    monkeypatch.setattr(tenant_backup, "build_dsn", lambda tenant: "postgresql://foo")
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/pg_dump")
+
+    calls = {}
+
+    def fake_run(cmd, check):
+        calls["cmd"] = cmd
+        Path(cmd[cmd.index("-f") + 1]).write_text("dump")
+
+    monkeypatch.setattr(tenant_backup.subprocess, "run", fake_run)
+
+    out_file = tmp_path / "backup.dump"
+    tenant_backup.backup("demo", out_file)
+    assert out_file.read_text() == "dump"
+    assert calls["cmd"][0] == "/usr/bin/pg_dump"
+    assert "-Fc" in calls["cmd"]
+
+
+def test_pg_backup_missing_pg_dump(tmp_path, monkeypatch):
+    from scripts import tenant_backup
+
+    monkeypatch.setattr(tenant_backup, "build_dsn", lambda tenant: "postgresql://foo")
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+
+    with pytest.raises(FileNotFoundError, match="pg_dump"):
+        tenant_backup.backup("demo", tmp_path / "backup.sql")
+
+
+def test_pg_backup_sql_format(tmp_path, monkeypatch):
+    from scripts import tenant_backup
+
+    monkeypatch.setattr(tenant_backup, "build_dsn", lambda tenant: "postgresql://foo")
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/pg_dump")
+
+    calls = {}
+
+    def fake_run(cmd, check):
+        calls["cmd"] = cmd
+        Path(cmd[cmd.index("-f") + 1]).write_text("dump")
+
+    monkeypatch.setattr(tenant_backup.subprocess, "run", fake_run)
+
+    out_file = tmp_path / "backup.sql"
+    tenant_backup.backup("demo", out_file)
+    assert "-Fc" not in calls["cmd"]


### PR DESCRIPTION
## Summary
- support `DATABASE_URL` as a fallback for `postgres_master_url`
- handle Alembic migration failures cleanly in `start_app`
- invoke `pg_dump` for tenant backups and cover missing binary cases
- align Lighthouse workflow DB env vars and document them

## Testing
- `pytest tests/test_config.py tests/test_start_app.py tests/test_tenant_backup.py`

------
https://chatgpt.com/codex/tasks/task_e_68afa7a9b760832aba9505cbb596f47f