### PR TITLE
docs: explain Postgres env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Copy the example environment file and adjust values as needed:
 cp .env.example .env
 ```
 
+See [Database URLs](docs/ENV_VARS.md#database-urls) for connection settings and a local Postgres quickstart.
+
 At startup the API validates that critical variables like `DB_URL` and
 `REDIS_URL` are present. CI runs `scripts/env_audit.py` during linting to
 keep `.env.example` in sync, and you can run the script locally to compare

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -4,9 +4,10 @@ The application relies on the following environment variables:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `POSTGRES_MASTER_URL` | Connection string for the master database. Defaults to a local SQLite file for development. | `postgresql+asyncpg://postgres:postgres@postgres:5432/master` |
-| `POSTGRES_TENANT_DSN_TEMPLATE` | Template DSN for tenant databases, with `{tenant_id}` placeholder. Defaults to local SQLite files. | `postgresql+asyncpg://postgres:postgres@postgres:5432/tenant_{tenant_id}` |
+| `POSTGRES_MASTER_URL` | Async connection string for the master database. | `postgresql+asyncpg://postgres:postgres@localhost:5432/master` |
+| `POSTGRES_TENANT_DSN_TEMPLATE` | Template DSN for tenant databases, with `{tenant_id}` placeholder. | `postgresql+asyncpg://tenant:tenant@localhost:5432/tenant_{tenant_id}` |
 | `POSTGRES_SUPER_URL` (optional) | Superuser connection URL used when creating databases. Not required for SQLite. |  |
+| `SYNC_DATABASE_URL` | Sync DSN used by Alembic migrations and scripts. | `postgresql://postgres:postgres@localhost:5432/master` |
 | `DB_SLOW_QUERY_MS` (optional) | Emit a warning when a DB query exceeds this many milliseconds. Defaults to `200`. | `250` |
 | `ONBOARDING_DB` | Path to onboarding session SQLite DB. Defaults to the system temp directory. | `/var/lib/neo/onboarding.db` |
 | `DEFAULT_TZ` | Default timezone for application processes. | `UTC` |
@@ -51,6 +52,33 @@ The application relies on the following environment variables:
 Defaults for these experimental flags are maintained in `config/feature_flags.yaml`.
 They must remain disabled in production; `validate_on_boot` enforces this when
 `ENV=prod`.
+
+## Database URLs
+
+Three environment variables control how the application talks to Postgres:
+
+- `POSTGRES_MASTER_URL` – async DSN for the shared "master" database.
+- `POSTGRES_TENANT_DSN_TEMPLATE` – async DSN template for per‑tenant databases; must include `{tenant_id}`.
+- `SYNC_DATABASE_URL` – sync DSN used by Alembic migrations and other scripts.
+
+Sample local values assume Postgres on `localhost:5432`:
+
+```bash
+POSTGRES_MASTER_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/master
+POSTGRES_TENANT_DSN_TEMPLATE=postgresql+asyncpg://tenant:tenant@localhost:5432/tenant_{tenant_id}
+SYNC_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/master
+```
+
+### Local Postgres
+
+Run a Postgres container for development:
+
+```bash
+docker run --name neo-postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres:15
+createdb -h localhost -U postgres master
+```
+
+Use the connection strings above in your `.env` file, adjusting credentials as needed.
 
 ## JWT/JOSE
 


### PR DESCRIPTION
## Summary
- document POSTGRES_MASTER_URL, SYNC_DATABASE_URL, and POSTGRES_TENANT_DSN_TEMPLATE
- add sample Postgres DSNs and local container quickstart
- link to database URL docs from README

## Testing
- `pre-commit run --files README.md docs/ENV_VARS.md`
- `pytest -q` *(fails: import mismatch errors for tests/test_analytics_outlets.py and others)*

------
https://chatgpt.com/codex/tasks/task_e_68afabc4e860832a895e625181c9c7d2