### PR TITLE
ci: wait for api before pa11y

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Start API
         run: |
           python start_app.py &
-          sleep 5
+          npx wait-on tcp:localhost:8000
 
       - name: Run Pa11y
         run: npx pa11y-ci -c pa11y-ci.json

--- a/README.md
+++ b/README.md
@@ -287,8 +287,11 @@ troubleshooting failures.
 ## Accessibility
 
 Buttons across major flows include descriptive ARIA labels, visible focus
-outlines, and high-contrast color tokens. Run `npx pa11y-ci -c pa11y-ci.json`
-to verify key screens remain accessible.
+outlines, and high-contrast color tokens. The Pa11y GitHub Actions workflow
+provisions a Postgres service, applies migrations, launches
+`python start_app.py` in the background, waits for `localhost:8000` with
+`wait-on`, and then runs `npx pa11y-ci -c pa11y-ci.json` to verify key screens
+remain accessible.
 
 ## Localization
 


### PR DESCRIPTION
## Summary
- wait for API to accept connections before running pa11y-ci
- document pa11y workflow and its database setup

## Testing
- `pre-commit run --files .github/workflows/pa11y.yml README.md`
- `pytest` *(fails: import file mismatch between api/tests and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68afabbbe554832a8e8730fcf1a1b819