### PR TITLE
feat: run alembic migrations asynchronously

### DIFF
--- a/api/alembic.ini
+++ b/api/alembic.ini
@@ -2,7 +2,7 @@
 # Point directly to the migrations folder so commands can run
 # from the repository root without changing directories.
 script_location = api/alembic
-sqlalchemy.url =
+sqlalchemy.url = postgresql+asyncpg://postgres:postgres@postgres_master:5432/master
 
 offline_mode = true
 

--- a/docs/DEPLOY_DOCKER.md
+++ b/docs/DEPLOY_DOCKER.md
@@ -12,7 +12,8 @@ docker compose build
 
 ## Apply database migrations
 
-Run migrations once the database is ready. This uses the Alembic configuration bundled with the API image.
+Run migrations once the database is ready. This uses the Alembic configuration
+bundled with the API image and executes them through an async SQLAlchemy engine.
 
 ```bash
 docker compose run --rm api bash -c "cd api && python -m alembic -c alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head"


### PR DESCRIPTION
## Summary
- use async SQLAlchemy engine for Alembic
- update migration DSN to asyncpg
- document async migration flow

## Testing
- `pre-commit run --files api/alembic/env.py api/alembic.ini docs/DEPLOY_DOCKER.md`
- `pytest tests/test_config.py tests/test_start_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68afabb3851c832a968723612d38b4c3