### PR TITLE
feat: support async migrations and skip flag

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -45,7 +45,7 @@ jobs:
           python -m alembic -c api/alembic.ini -x db_url=$POSTGRES_MASTER_URL upgrade head
       - name: Run Lighthouse CI
         run: |
-          python start_app.py &
+          SKIP_DB_MIGRATIONS=1 python start_app.py &
           sleep 5
           lhci autorun --config=lighthouserc.json
       - name: Upload Lighthouse reports

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A Lighthouse CI workflow enforces performance budgets for the guest, admin, and 
 The workflow requires a PostgreSQL DSN for migrations. Set `POSTGRES_MASTER_URL`
 or `DATABASE_URL` to the same DSN and provide `SQLALCHEMY_DATABASE_URI` for
 tools needing a synchronous connection string.
+Migrations run once before the server starts and the workflow launches
+`start_app.py` with `SKIP_DB_MIGRATIONS=1` to avoid redundant upgrades.
 Monitoring tools such as UptimeRobot should poll the `/status.json` endpoint for platform health. A synthetic monitor (`scripts/synthetic_order_monitor.py`) exercises a full guest order path end-to-end and reports metrics. Status is persisted in Redis with `status.json` on disk as a fallback. Administrators can override it via `POST /admin/status` or the helper script in `ops/scripts/status_page.py` during incidents.
 Invoices support optional FSSAI license details when provided.
 QR pack generation events are audited and can be exported via admin APIs. See
@@ -531,6 +533,8 @@ python start_app.py
 
 The script loads environment variables from `.env`, runs `python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head`, and starts the application via `uvicorn api.app.main:app`. If Alembic is missing, it will prompt you to install dependencies with `pip install -r requirements.txt`.
 Failed migrations now surface Alembic's stdout and stderr and exit with the same code for easier troubleshooting.
+
+Use the ``--skip-db-migrations`` flag or set ``SKIP_DB_MIGRATIONS=1`` to bypass Alembic. When skipped, the script falls back to an in-memory SQLite database unless ``DATABASE_URL`` is already configured.
 
 ### Notification Worker
 

--- a/start_app.py
+++ b/start_app.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import argparse
+import os
 import subprocess
 import sys
 
@@ -12,38 +14,57 @@ from dotenv import load_dotenv
 import config
 
 
-def main() -> None:
-    """Load settings, apply migrations, then start the API."""
+def main(argv: list[str] | None = None) -> None:
+    """Load settings, optionally apply migrations, then start the API."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip-db-migrations",
+        action="store_true",
+        help="Start without running Alembic migrations",
+    )
+    args = parser.parse_args(argv)
+
     load_dotenv()  # load environment variables from a .env file
-    config.get_settings()  # ensure settings are initialized
-    try:
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "alembic",
-                "-c",
-                "api/alembic.ini",
-                "upgrade",
-                "head",
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        if exc.stdout:
-            sys.stdout.write(exc.stdout)
-        if exc.stderr:
-            sys.stderr.write(exc.stderr)
-        print(
-            f"database migration failed (exit code {exc.returncode})",
-            file=sys.stderr,
-        )
-        raise SystemExit(exc.returncode)
-    except FileNotFoundError:
-        print("Install dependencies first: pip install -r requirements.txt")
-        return
+
+    env_flag = os.getenv("SKIP_DB_MIGRATIONS")
+    skip = args.skip_db_migrations or (
+        env_flag and env_flag.lower() not in {"0", "false"}
+    )
+    if skip:
+        os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite://")
+    config.get_settings()  # ensure settings are initialized with any override
+
+    if not skip:
+        try:
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "alembic",
+                    "-c",
+                    "api/alembic.ini",
+                    "upgrade",
+                    "head",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            if exc.stdout:
+                sys.stdout.write(exc.stdout)
+            if exc.stderr:
+                sys.stderr.write(exc.stderr)
+            print(
+                f"database migration failed (exit code {exc.returncode})",
+                file=sys.stderr,
+            )
+            raise SystemExit(exc.returncode)
+        except FileNotFoundError:
+            print("Install dependencies first: pip install -r requirements.txt")
+            return
+
     uvicorn.run("api.app.main:app")
 
 

--- a/tests/test_alembic_env.py
+++ b/tests/test_alembic_env.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+
+
+def _upgrade(url: str) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "alembic",
+            "-c",
+            "api/alembic.ini",
+            "-x",
+            f"db_url={url}",
+            "upgrade",
+            "head",
+        ],
+        check=True,
+    )
+
+
+def test_migrations_support_async_and_sync(tmp_path):
+    async_db = tmp_path / "async.db"
+    sync_db = tmp_path / "sync.db"
+    _upgrade(f"sqlite+aiosqlite:///{async_db}")
+    _upgrade(f"sqlite:///{sync_db}")

--- a/tests/test_start_app.py
+++ b/tests/test_start_app.py
@@ -6,22 +6,36 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+import start_app  # noqa: E402
 from start_app import main  # noqa: E402
 
 
 def test_failed_migration_surfaces_output(monkeypatch, capsys):
     def fake_run(cmd, **kwargs):
-        raise subprocess.CalledProcessError(
-            2, cmd, output="out\n", stderr="err\n"
-        )
+        raise subprocess.CalledProcessError(2, cmd, output="out\n", stderr="err\n")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     with pytest.raises(SystemExit) as excinfo:
-        main()
+        main([])
 
     captured = capsys.readouterr()
     assert "out" in captured.out
     assert "err" in captured.err
     assert "exit code 2" in captured.err
     assert excinfo.value.code == 2
+
+
+def test_skip_db_migrations(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise AssertionError("migrations should be skipped")
+
+    called = {"uvicorn": False}
+
+    def fake_uvicorn_run(*args, **kwargs):
+        called["uvicorn"] = True
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(start_app, "uvicorn", type("U", (), {"run": fake_uvicorn_run}))
+    main(["--skip-db-migrations"])
+    assert called["uvicorn"]


### PR DESCRIPTION
## Summary
- handle asyncpg DSNs in Alembic by coercing to sync URLs or using `AsyncEngine`
- add `--skip-db-migrations`/`SKIP_DB_MIGRATIONS` option to `start_app.py`
- document and enable skip flag in Lighthouse workflow

## Testing
- `pytest tests/test_alembic_env.py::test_migrations_support_async_and_sync tests/test_start_app.py::test_failed_migration_surfaces_output tests/test_start_app.py::test_skip_db_migrations -q`
- `pre-commit run --files api/alembic/env.py start_app.py tests/test_start_app.py tests/test_alembic_env.py README.md .github/workflows/lighthouse.yml`

------
https://chatgpt.com/codex/tasks/task_e_68afbac4c16c832a88f16fa67ddae051