### PR TITLE
Upload pa11y screenshots on CI

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -54,3 +54,11 @@ jobs:
 
       - name: Run Pa11y
         run: npx pa11y-ci -c pa11y-ci.json
+
+      - name: Upload Pa11y screenshots
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pa11y-screenshots
+          path: pa11y-screenshots
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -293,7 +293,9 @@ outlines, and high-contrast color tokens. The Pa11y GitHub Actions workflow
 provisions a Postgres service, applies migrations, launches
 `python start_app.py` in the background, waits for `localhost:8000` with
 `wait-on`, and then runs `npx pa11y-ci -c pa11y-ci.json` to verify key screens
-remain accessible.
+remain accessible. Pa11y stores screenshots in the `pa11y-screenshots/`
+directory, which GitHub Actions uploads as a `pa11y-screenshots` artifact for
+later review.
 
 ## Localization
 


### PR DESCRIPTION
## Summary
- upload pa11y screenshots as a workflow artifact even on failure
- document where pa11y screenshots are stored and how to retrieve them

## Testing
- `pre-commit run --files .github/workflows/pa11y.yml README.md`
- `pytest` *(fails: import file mismatch in tests/test_analytics_outlets.py, tests/test_export_streaming.py, tests/test_kds_expo.py, tests/test_rum_vitals.py, tests/test_slo_metrics.py, tests/test_time_skew.py)*

------
https://chatgpt.com/codex/tasks/task_e_68afbcd598d4832aaf3790bc4c0d90ec