### PR TITLE
feat: validate async migrations and set sync DB for Lighthouse

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -22,6 +22,7 @@ jobs:
       POSTGRES_MASTER_URL: postgresql://neo:neo@localhost:5432/neo
       DATABASE_URL: postgresql://neo:neo@localhost:5432/neo
       SQLALCHEMY_DATABASE_URI: postgresql://neo:neo@localhost:5432/neo
+      SYNC_DATABASE_URL: postgresql://neo:neo@localhost:5432/neo
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -42,7 +43,7 @@ jobs:
           done
       - name: Run migrations
         run: |
-          python -m alembic -c api/alembic.ini -x db_url=$POSTGRES_MASTER_URL upgrade head
+          python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
       - name: Run Lighthouse CI
         run: |
           SKIP_DB_MIGRATIONS=1 python start_app.py &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - 24×7 synthetic order monitor with CI alerts and dashboards.
 - Floor map editor with live table status (SSE/WS).
+- Validate async DB URLs for Alembic migrations and expose `SYNC_DATABASE_URL` in Lighthouse workflow.
 
 ### Fixed
 

--- a/api/tests/test_alembic_env.py
+++ b/api/tests/test_alembic_env.py
@@ -1,0 +1,71 @@
+import importlib
+import logging.config
+import types
+
+import alembic
+import pytest
+from sqlalchemy.exc import NoSuchModuleError
+
+import config as app_config
+
+
+@pytest.fixture
+def env(monkeypatch):
+    class DummyCM:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    fake_context = types.SimpleNamespace(
+        config=types.SimpleNamespace(config_file_name=""),
+        get_x_argument=lambda as_dictionary=True: {},
+        is_offline_mode=lambda: True,
+        configure=lambda **kwargs: None,
+        begin_transaction=lambda: DummyCM(),
+        run_migrations=lambda: None,
+    )
+    monkeypatch.setattr(alembic, "context", fake_context)
+    monkeypatch.setattr(logging.config, "fileConfig", lambda *a, **k: None)
+    fake_settings = types.SimpleNamespace(
+        postgres_master_url="postgresql://",
+        postgres_tenant_dsn_template="{tenant_id}",
+    )
+    monkeypatch.setattr(app_config, "get_settings", lambda: fake_settings)
+    return importlib.reload(importlib.import_module("api.alembic.env"))
+
+
+def test_is_async_url_detects_async(env):
+    assert env._is_async_url("postgresql+asyncpg://localhost/test") is True
+
+
+def test_is_async_url_detects_sync(env):
+    assert env._is_async_url("postgresql://localhost/test") is False
+
+
+def test_is_async_url_missing_driver(env, monkeypatch):
+    url = "postgresql+asyncpg://localhost/test"
+    fake_url = types.SimpleNamespace(
+        drivername="postgresql+asyncpg",
+        get_dialect=lambda: (_ for _ in ()).throw(NoSuchModuleError("asyncpg")),
+    )
+    monkeypatch.setattr(env, "make_url", lambda _: fake_url)
+    with pytest.raises(RuntimeError, match="Async database driver not installed"):
+        env._is_async_url(url)
+
+
+def test_is_async_url_resolves_sync(env, monkeypatch):
+    url = "postgresql+asyncpg://localhost/test"
+
+    class FakeDialect:
+        is_async = False
+
+    fake_url = types.SimpleNamespace(
+        drivername="postgresql+asyncpg", get_dialect=lambda: FakeDialect
+    )
+    monkeypatch.setattr(env, "make_url", lambda _: fake_url)
+    with pytest.raises(
+        RuntimeError, match="Async URL resolved to a synchronous dialect"
+    ):
+        env._is_async_url(url)


### PR DESCRIPTION
## Summary
- expose SYNC_DATABASE_URL and use it for Lighthouse migrations
- ensure Alembic async URLs require proper drivers
- test async URL detection for Alembic environment

## Testing
- `pre-commit run --files .github/workflows/lighthouse.yml api/alembic/env.py api/tests/test_alembic_env.py CHANGELOG.md`
- `PYTHONPATH=. pytest api/tests/test_alembic_env.py`


------
https://chatgpt.com/codex/tasks/task_e_68afbec42934832a8ed1760e215871aa