### PR TITLE
feat: support staging env vars

### DIFF
--- a/scripts/synthetic_order_monitor.py
+++ b/scripts/synthetic_order_monitor.py
@@ -8,6 +8,11 @@ Env variables:
 - SYN_UPI_VPA (optional)
 - API_BASE_URL
 - AUTH_TOKEN
+- OR use the following *_STAGING variables:
+  - API_BASE_URL_STAGING
+  - SYN_TENANT_ID_STAGING
+  - SYN_TABLE_CODE_STAGING
+  - AUTH_TOKEN_STAGING
 - PUSHGATEWAY (optional)
 - DRY_RUN (optional, bypass HTTP calls for tests)
 """
@@ -87,6 +92,16 @@ def main() -> None:
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
     )
+
+    # Map staging variables to defaults if present
+    for src, dest in {
+        "API_BASE_URL_STAGING": "API_BASE_URL",
+        "SYN_TENANT_ID_STAGING": "SYN_TENANT_ID",
+        "SYN_TABLE_CODE_STAGING": "SYN_TABLE_CODE",
+        "AUTH_TOKEN_STAGING": "AUTH_TOKEN",
+    }.items():
+        if src in os.environ and dest not in os.environ:
+            os.environ[dest] = os.environ[src]
 
     required = [
         "SYN_TENANT_ID",

--- a/scripts/tests/test_synthetic_monitor_stub.py
+++ b/scripts/tests/test_synthetic_monitor_stub.py
@@ -26,3 +26,27 @@ def test_stub_run(tmp_path):
     assert metrics["http_status_map"]["refund_1"] == 200
     assert metrics["http_status_map"]["refund_2"] == 200
 
+
+def test_stub_run_staging_vars(tmp_path):
+    env = {
+        "DRY_RUN": "1",
+        "SYN_MENU_ITEM_IDS": "1,2,3",
+        "API_BASE_URL_STAGING": "http://localhost",
+        "SYN_TENANT_ID_STAGING": "demo",
+        "SYN_TABLE_CODE_STAGING": "t1",
+        "AUTH_TOKEN_STAGING": "test-token",
+    }
+    env.update(os.environ)
+    out = subprocess.run(
+        ["python", "scripts/synthetic_order_monitor.py"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    metrics = json.loads(out.stdout.strip().splitlines()[-1])
+    assert metrics["success"] is True
+    assert metrics["step_failed"] is None
+    assert metrics["http_status_map"]["refund_1"] == 200
+    assert metrics["http_status_map"]["refund_2"] == 200
+


### PR DESCRIPTION
## Summary
- allow synthetic order monitor to read staging-specific env variables
- test synthetic order monitor with *_STAGING env vars

## Testing
- `pytest scripts/tests/test_synthetic_monitor_stub.py`

------
https://chatgpt.com/codex/tasks/task_e_68afc3e23584832aa26180a2303df293