### PR TITLE
Handle missing module for API start

### DIFF
--- a/start_app.py
+++ b/start_app.py
@@ -65,7 +65,15 @@ def main(argv: list[str] | None = None) -> None:
             print("Install dependencies first: pip install -r requirements.txt")
             return
 
-    uvicorn.run("api.app.main:app")
+    try:
+        uvicorn.run("api.app.main:app")
+    except ModuleNotFoundError as exc:
+        missing = exc.name or str(exc)
+        print(
+            f"Missing dependency: {missing}. Install it with 'pip install {missing}'",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- exit gracefully when uvicorn or application dependencies are missing

## Testing
- `pytest -q` *(fails: import file mismatch for tests/*)*

------
https://chatgpt.com/codex/tasks/task_e_68afc37dd244832ab6bc25081a5c1b20