### PR TITLE
Fix tenant migration chain and seed

### DIFF
--- a/api/alembic_tenant/env.py
+++ b/api/alembic_tenant/env.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from logging.config import fileConfig
 from pathlib import Path
-import sys
 
 from alembic import context
+from sqlalchemy.engine import reflection
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -19,6 +20,16 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 target_metadata = models_tenant.Base.metadata
+
+# ``Inspector.has_column`` is missing on some SQLite versions shipped with
+# SQLAlchemy; add a lightweight fallback so migrations can introspect columns
+# consistently during tests.
+if not hasattr(reflection.Inspector, "has_column"):
+
+    def _has_column(self, table_name: str, column_name: str, schema: str | None = None) -> bool:  # type: ignore[override]
+        return column_name in {c["name"] for c in self.get_columns(table_name, schema)}
+
+    reflection.Inspector.has_column = _has_column  # type: ignore[attr-defined]
 
 
 def run_migrations_offline() -> None:

--- a/api/alembic_tenant/versions/0001_initial_tenant.py
+++ b/api/alembic_tenant/versions/0001_initial_tenant.py
@@ -5,8 +5,9 @@ Revises: None
 Create Date: 2025-08-20
 """
 
-from alembic import op  # noqa: F401
-import sqlalchemy as sa  # noqa: F401
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
 
 revision: str = "0001_initial_tenant"
 down_revision: str | None = None
@@ -15,10 +16,129 @@ depends_on: tuple[str, ...] | None = None
 
 
 def upgrade() -> None:
-    # will be autogen
-    pass
+    """Create the initial tenant schema with core tables."""
+
+    op.create_table(
+        "tenant_meta",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("menu_version", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+
+    op.create_table(
+        "menu_categories",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("sort", sa.Integer(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=True,
+        ),
+    )
+
+    op.create_table(
+        "menu_items",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "category_id",
+            sa.Integer(),
+            sa.ForeignKey("menu_categories.id"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("price", sa.Numeric(10, 2), nullable=False),
+        sa.Column(
+            "is_veg", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column("gst_rate", sa.Numeric(5, 2), nullable=True),
+        sa.Column("hsn_sac", sa.String(), nullable=True),
+        sa.Column(
+            "show_fssai", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "out_of_stock",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("modifiers", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("combos", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("dietary", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("allergens", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=True,
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "tables",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("tenant_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("code", sa.String(), nullable=True),
+        sa.Column("qr_token", sa.String(), nullable=True, unique=True),
+        sa.Column("status", sa.String(), nullable=False, server_default="AVAILABLE"),
+        sa.Column("width", sa.Integer(), nullable=True, server_default="80"),
+        sa.Column("height", sa.Integer(), nullable=True, server_default="80"),
+        sa.Column("shape", sa.String(12), nullable=True, server_default="rect"),
+        sa.Column("zone", sa.String(64), nullable=True),
+        sa.Column("capacity", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "invoices",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("order_group_id", sa.Integer(), nullable=False),
+        sa.Column("number", sa.String(), nullable=False, unique=True),
+        sa.Column("bill_json", sa.JSON(), nullable=False),
+        sa.Column("gst_breakup", sa.JSON(), nullable=True),
+        sa.Column("total", sa.Numeric(10, 2), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+
+    op.create_table(
+        "coupons",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("code", sa.String(), nullable=False, unique=True),
+        sa.Column("percent", sa.Numeric(5, 2), nullable=True),
+        sa.Column("flat", sa.Numeric(10, 2), nullable=True),
+        sa.Column(
+            "active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+    )
 
 
 def downgrade() -> None:
-    # will be autogen
-    pass
+    """Drop core tables introduced in :func:`upgrade`."""
+
+    op.drop_table("coupons")
+    op.drop_table("invoices")
+    op.drop_table("tables")
+    op.drop_table("menu_items")
+    op.drop_table("menu_categories")
+    op.drop_table("tenant_meta")

--- a/api/alembic_tenant/versions/0002_alerts_and_outbox.py
+++ b/api/alembic_tenant/versions/0002_alerts_and_outbox.py
@@ -5,12 +5,12 @@ Revises: 0001_initial_tenant
 Create Date: 2024-08-18
 """
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 revision: str = "0002_alerts_and_outbox"
-down_revision: str | None = "0001_initial_tenant"
+# Chain after invoice settlement to maintain a single linear history
+down_revision: str | None = "0002_invoice_settlement"
 branch_labels: tuple[str, ...] | None = None
 depends_on: tuple[str, ...] | None = None
 
@@ -32,7 +32,9 @@ def upgrade() -> None:
         sa.Column("channel", sa.String(), nullable=False),
         sa.Column("target", sa.String(), nullable=False),
         sa.Column("status", sa.String(), nullable=False, server_default="queued"),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")
+        ),
         sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
     )
 

--- a/api/alembic_tenant/versions/0003_tables_map_fields.py
+++ b/api/alembic_tenant/versions/0003_tables_map_fields.py
@@ -5,8 +5,8 @@ Revises: 0002_table_state
 Create Date: 2024-10-07
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision: str = "0003_tables_map_fields"
 down_revision: str | None = "0002_table_state"
@@ -17,17 +17,18 @@ depends_on: tuple[str, ...] | None = None
 def upgrade() -> None:
     conn = op.get_bind()
     insp = sa.inspect(conn)
-    if not insp.has_column("tables", "pos_x"):
+    cols = {c["name"] for c in insp.get_columns("tables")}
+    if "pos_x" not in cols:
         op.add_column(
             "tables",
-            sa.Column("pos_x", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("pos_x", sa.Integer(), nullable=True, server_default="0"),
         )
-    if not insp.has_column("tables", "pos_y"):
+    if "pos_y" not in cols:
         op.add_column(
             "tables",
-            sa.Column("pos_y", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("pos_y", sa.Integer(), nullable=True, server_default="0"),
         )
-    if not insp.has_column("tables", "label"):
+    if "label" not in cols:
         op.add_column(
             "tables",
             sa.Column("label", sa.Text(), nullable=True),
@@ -37,9 +38,10 @@ def upgrade() -> None:
 def downgrade() -> None:
     conn = op.get_bind()
     insp = sa.inspect(conn)
-    if insp.has_column("tables", "label"):
+    cols = {c["name"] for c in insp.get_columns("tables")}
+    if "label" in cols:
         op.drop_column("tables", "label")
-    if insp.has_column("tables", "pos_y"):
+    if "pos_y" in cols:
         op.drop_column("tables", "pos_y")
-    if insp.has_column("tables", "pos_x"):
+    if "pos_x" in cols:
         op.drop_column("tables", "pos_x")

--- a/api/alembic_tenant/versions/0004_rooms.py
+++ b/api/alembic_tenant/versions/0004_rooms.py
@@ -5,8 +5,8 @@ Revises: 0003_rooms, 0003_tables_map_fields
 Create Date: 2025-08-21
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision: str = "0004_rooms"
 down_revision: str | tuple[str, ...] | None = ("0003_rooms", "0003_tables_map_fields")
@@ -17,43 +17,55 @@ depends_on: tuple[str, ...] | None = None
 def upgrade() -> None:
     conn = op.get_bind()
     insp = sa.inspect(conn)
-    if insp.has_table("rooms") and not insp.has_column("rooms", "last_cleaned_at"):
-        op.add_column(
-            "rooms",
-            sa.Column("last_cleaned_at", sa.DateTime(timezone=True), nullable=True),
-        )
-    if insp.has_table("room_orders") and insp.has_column("room_orders", "placed_at"):
-        op.alter_column(
-            "room_orders",
-            "placed_at",
-            existing_type=sa.DateTime(timezone=True),
-            nullable=False,
-        )
-    if insp.has_table("room_order_items") and insp.has_column("room_order_items", "item_id"):
-        op.alter_column(
-            "room_order_items",
-            "item_id",
-            existing_type=sa.Integer(),
-            nullable=True,
-        )
+    if insp.has_table("rooms"):
+        cols = {c["name"] for c in insp.get_columns("rooms")}
+        if "last_cleaned_at" not in cols:
+            op.add_column(
+                "rooms",
+                sa.Column("last_cleaned_at", sa.DateTime(timezone=True), nullable=True),
+            )
+    if insp.has_table("room_orders"):
+        cols = {c["name"] for c in insp.get_columns("room_orders")}
+        if "placed_at" in cols and conn.dialect.name != "sqlite":
+            op.alter_column(
+                "room_orders",
+                "placed_at",
+                existing_type=sa.DateTime(timezone=True),
+                nullable=False,
+            )
+    if insp.has_table("room_order_items"):
+        cols = {c["name"] for c in insp.get_columns("room_order_items")}
+        if "item_id" in cols and conn.dialect.name != "sqlite":
+            op.alter_column(
+                "room_order_items",
+                "item_id",
+                existing_type=sa.Integer(),
+                nullable=True,
+            )
 
 
 def downgrade() -> None:
     conn = op.get_bind()
     insp = sa.inspect(conn)
-    if insp.has_table("room_order_items") and insp.has_column("room_order_items", "item_id"):
-        op.alter_column(
-            "room_order_items",
-            "item_id",
-            existing_type=sa.Integer(),
-            nullable=False,
-        )
-    if insp.has_table("room_orders") and insp.has_column("room_orders", "placed_at"):
-        op.alter_column(
-            "room_orders",
-            "placed_at",
-            existing_type=sa.DateTime(timezone=True),
-            nullable=True,
-        )
-    if insp.has_table("rooms") and insp.has_column("rooms", "last_cleaned_at"):
-        op.drop_column("rooms", "last_cleaned_at")
+    if insp.has_table("room_order_items"):
+        cols = {c["name"] for c in insp.get_columns("room_order_items")}
+        if "item_id" in cols and conn.dialect.name != "sqlite":
+            op.alter_column(
+                "room_order_items",
+                "item_id",
+                existing_type=sa.Integer(),
+                nullable=False,
+            )
+    if insp.has_table("room_orders"):
+        cols = {c["name"] for c in insp.get_columns("room_orders")}
+        if "placed_at" in cols and conn.dialect.name != "sqlite":
+            op.alter_column(
+                "room_orders",
+                "placed_at",
+                existing_type=sa.DateTime(timezone=True),
+                nullable=True,
+            )
+    if insp.has_table("rooms"):
+        cols = {c["name"] for c in insp.get_columns("rooms")}
+        if "last_cleaned_at" in cols:
+            op.drop_column("rooms", "last_cleaned_at")


### PR DESCRIPTION
## Summary
- build initial tenant schema with core tables
- order early tenant migrations into a single chain
- ensure SQLite compatibility and run seed script

## Testing
- `python - <<'PY'\nfrom alembic.config import Config\nfrom alembic import command\ncfg=Config(); cfg.set_main_option('script_location','api/alembic_tenant'); command.heads(cfg)\nPY`
- `PYTHONPATH=. python scripts/tenant_seed.py --tenant seedtest`

------
https://chatgpt.com/codex/tasks/task_e_68afc595424c832a8263396c9bb8dc52