### PR TITLE
feat(i18n): guest multi-language menu + receipts with CSV import/export, switcher, and fallbacks

### DIFF
--- a/api/alembic_tenant/versions/0014_i18n.py
+++ b/api/alembic_tenant/versions/0014_i18n.py
@@ -1,0 +1,35 @@
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0014_i18n"
+down_revision = "0013_coupon_caps_windows"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("menu_items") as batch:
+        batch.add_column(sa.Column("name_i18n", sa.JSON(), nullable=True))
+        batch.add_column(sa.Column("desc_i18n", sa.JSON(), nullable=True))
+    with op.batch_alter_table("tenant_meta") as batch:
+        batch.add_column(
+            sa.Column("default_lang", sa.String(), nullable=False, server_default="en")
+        )
+        batch.add_column(
+            sa.Column(
+                "enabled_langs", sa.JSON(), nullable=False, server_default='["en"]'
+            )
+        )
+    with op.batch_alter_table("invoices") as batch:
+        batch.add_column(sa.Column("bill_lang", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("menu_items") as batch:
+        batch.drop_column("name_i18n")
+        batch.drop_column("desc_i18n")
+    with op.batch_alter_table("tenant_meta") as batch:
+        batch.drop_column("default_lang")
+        batch.drop_column("enabled_langs")
+    with op.batch_alter_table("invoices") as batch:
+        batch.drop_column("bill_lang")

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -85,6 +85,7 @@ from .middlewares import (
     HttpErrorCounterMiddleware,
     IdempotencyMetricsMiddleware,
     IdempotencyMiddleware,
+    LanguageMiddleware,
     LicensingMiddleware,
     LoggingMiddleware,
     MaintenanceMiddleware,
@@ -259,6 +260,7 @@ app.add_middleware(GuestBlockMiddleware)
 app.add_middleware(TableStateGuardMiddleware)
 app.add_middleware(RoomStateGuard)
 app.add_middleware(GuestRateLimitMiddleware)
+app.add_middleware(LanguageMiddleware)
 app.add_middleware(LicensingMiddleware)
 app.add_middleware(IdempotencyMiddleware)
 app.add_middleware(IdempotencyMetricsMiddleware)

--- a/api/app/middlewares/__init__.py
+++ b/api/app/middlewares/__init__.py
@@ -1,24 +1,26 @@
+from .api_key_auth import APIKeyAuthMiddleware
 from .error_pages import HTMLErrorPagesMiddleware
 from .feature_flags import FeatureFlagsMiddleware
 from .guest_block import GuestBlockMiddleware
 from .guest_ratelimit import GuestRateLimitMiddleware
 from .http_errors import HttpErrorCounterMiddleware
 from .idempotency import IdempotencyMetricsMiddleware, IdempotencyMiddleware
+from .language import LanguageMiddleware
 from .licensing import LicensingMiddleware
 from .logging import LoggingMiddleware
 from .maintenance import MaintenanceMiddleware
+from .pin_security import PinSecurityMiddleware
 from .prometheus import PrometheusMiddleware
+from .request_id import RequestIdMiddleware
 from .security import SecurityMiddleware
 from .table_state_guard import TableStateGuardMiddleware
-from .api_key_auth import APIKeyAuthMiddleware
-from .pin_security import PinSecurityMiddleware
-from .request_id import RequestIdMiddleware
 
 __all__ = [
     "RequestIdMiddleware",
     "LoggingMiddleware",
     "GuestRateLimitMiddleware",
     "GuestBlockMiddleware",
+    "LanguageMiddleware",
     "PrometheusMiddleware",
     "TableStateGuardMiddleware",
     "IdempotencyMiddleware",

--- a/api/app/middlewares/language.py
+++ b/api/app/middlewares/language.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+
+class LanguageMiddleware(BaseHTTPMiddleware):
+    """Persist guest language preference via query param and cookie."""
+
+    def __init__(self, app, cookie_name: str = "lang") -> None:
+        super().__init__(app)
+        self.cookie_name = cookie_name
+        self.max_age = 60 * 60 * 24 * 180  # six months
+
+    async def dispatch(self, request: Request, call_next):
+        query_lang = request.query_params.get("lang")
+        cookie_lang = request.cookies.get(self.cookie_name)
+        default_lang = getattr(request.app.state, "default_lang", "en")
+        enabled = getattr(request.app.state, "enabled_langs", ["en"])
+
+        if query_lang and query_lang in enabled:
+            lang = query_lang
+        elif cookie_lang and cookie_lang in enabled:
+            lang = cookie_lang
+        else:
+            lang = default_lang if default_lang in enabled else "en"
+
+        request.state.lang = lang
+        response = await call_next(request)
+        response.set_cookie(self.cookie_name, lang, max_age=self.max_age)
+        return response

--- a/api/app/models_tenant.py
+++ b/api/app/models_tenant.py
@@ -49,6 +49,7 @@ class MenuItem(Base):
     id = Column(Integer, primary_key=True)
     category_id = Column(Integer, ForeignKey("menu_categories.id"), nullable=False)
     name = Column(String, nullable=False)
+    name_i18n = Column(JSON, nullable=True)
     price = Column(Numeric(10, 2), nullable=False)
     is_veg = Column(Boolean, nullable=False, default=False)
     gst_rate = Column(Numeric(5, 2), nullable=True)
@@ -59,6 +60,7 @@ class MenuItem(Base):
     combos = Column(JSON, nullable=False, server_default="[]")
     dietary = Column(JSON, nullable=False, server_default="[]", default=list)
     allergens = Column(JSON, nullable=False, server_default="[]", default=list)
+    desc_i18n = Column(JSON, nullable=True)
 
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
@@ -73,6 +75,8 @@ class TenantMeta(Base):
 
     id = Column(Integer, primary_key=True, default=1)
     menu_version = Column(Integer, nullable=False, default=0)
+    default_lang = Column(String, nullable=False, server_default="en")
+    enabled_langs = Column(JSON, nullable=False, server_default='["en"]')
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
@@ -216,6 +220,7 @@ class Invoice(Base):
     id = Column(Integer, primary_key=True)
     order_group_id = Column(Integer, nullable=False)
     number = Column(String, unique=True, nullable=False)
+    bill_lang = Column(String, nullable=True)
     bill_json = Column(JSON, nullable=False)
     gst_breakup = Column(JSON, nullable=True)
     tip = Column(Numeric(10, 2), nullable=False, default=0, server_default="0")

--- a/api/app/routes_admin_menu.py
+++ b/api/app/routes_admin_menu.py
@@ -6,19 +6,30 @@ within a tenant-specific database. Access is restricted to admin roles.
 
 from __future__ import annotations
 
+import csv
+import io
 from contextlib import asynccontextmanager
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+)
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from .auth import User, role_required
 from .db.tenant import get_engine
+from .models_tenant import MenuItem, TenantMeta
 from .repos_sqlalchemy.menu_repo_sql import MenuRepoSQL
 from .utils.audit import audit
 from .utils.responses import ok
-from .models_tenant import MenuItem
 
 router = APIRouter()
 
@@ -114,9 +125,7 @@ async def delete_menu_item(
         await repo.soft_delete_item(session, item_id)
         item = await session.get(MenuItem, item_id)
     await request.app.state.redis.delete(f"menu:{tenant_id}")
-    return ok(
-        {"id": str(item.id), "name": item.name, "deleted_at": item.deleted_at}
-    )
+    return ok({"id": str(item.id), "name": item.name, "deleted_at": item.deleted_at})
 
 
 @router.post("/api/outlet/{tenant_id}/menu/items/{item_id}/restore")
@@ -133,6 +142,71 @@ async def restore_menu_item(
         await repo.restore_item(session, item_id)
         item = await session.get(MenuItem, item_id)
     await request.app.state.redis.delete(f"menu:{tenant_id}")
-    return ok(
-        {"id": str(item.id), "name": item.name, "deleted_at": item.deleted_at}
+    return ok({"id": str(item.id), "name": item.name, "deleted_at": item.deleted_at})
+
+
+@router.post("/api/outlet/{tenant_id}/menu/i18n/import")
+@audit("menu_i18n_import")
+async def import_menu_i18n(
+    tenant_id: str,
+    file: UploadFile = File(...),
+    user: User = Depends(role_required("super_admin", "outlet_admin", "manager")),
+) -> dict:
+    data = (await file.read()).decode("utf-8")
+    reader = csv.DictReader(io.StringIO(data))
+    async with _session(tenant_id) as session:
+        enabled = await session.scalar(select(TenantMeta.enabled_langs)) or ["en"]
+        for row in reader:
+            lang = row.get("lang")
+            if lang not in enabled:
+                raise HTTPException(status_code=400, detail="unsupported language")
+            item = await session.get(MenuItem, int(row["item_id"]))
+            if not item:
+                continue
+            ni = item.name_i18n or {}
+            di = item.desc_i18n or {}
+            if row.get("name"):
+                ni[lang] = row["name"]
+            if row.get("description"):
+                di[lang] = row["description"]
+            item.name_i18n = ni
+            item.desc_i18n = di
+        await session.commit()
+    return ok({"status": "imported"})
+
+
+@router.get("/api/outlet/{tenant_id}/menu/i18n/export")
+@audit("menu_i18n_export")
+async def export_menu_i18n(
+    tenant_id: str,
+    langs: str,
+    user: User = Depends(role_required("super_admin", "outlet_admin", "manager")),
+) -> Response:
+    lang_list = [code for code in langs.split(",") if code]
+    async with _session(tenant_id) as session:
+        enabled = await session.scalar(select(TenantMeta.enabled_langs)) or ["en"]
+        for code in lang_list:
+            if code not in enabled:
+                raise HTTPException(status_code=400, detail="unsupported language")
+        result = await session.execute(select(MenuItem))
+        rows = []
+        for item in result.scalars().all():
+            for code in lang_list:
+                name = (item.name_i18n or {}).get(code)
+                desc = (item.desc_i18n or {}).get(code)
+                if name or desc:
+                    rows.append(
+                        {
+                            "item_id": item.id,
+                            "lang": code,
+                            "name": name,
+                            "description": desc,
+                        }
+                    )
+    output = io.StringIO()
+    writer = csv.DictWriter(
+        output, fieldnames=["item_id", "lang", "name", "description"]
     )
+    writer.writeheader()
+    writer.writerows(rows)
+    return Response(output.getvalue(), media_type="text/csv")

--- a/api/app/routes_guest_bill.py
+++ b/api/app/routes_guest_bill.py
@@ -7,12 +7,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import get_settings
 
+from .exp.ab_allocator import get_variant
 from .repos_sqlalchemy import invoices_repo_sql
+from .routes_metrics import record_ab_conversion
 from .services import billing_service, notifications
 from .services.receipt_vault import ReceiptVault
 from .utils.responses import ok
-from .exp.ab_allocator import get_variant
-from .routes_metrics import record_ab_conversion
 
 
 async def get_tenant_id() -> str:  # pragma: no cover - placeholder dependency
@@ -68,6 +68,7 @@ async def generate_bill(
         coupons=coupons,
         guest_id=guest_id,
         outlet_id=outlet_id,
+        bill_lang=getattr(request.state, "lang", None),
     )
     settings = get_settings()
     invoice_payload = billing_service.compute_bill(

--- a/api/app/utils/i18n.py
+++ b/api/app/utils/i18n.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+
+def get_text(
+    field: Optional[str],
+    lang: str,
+    field_i18n: Optional[Dict[str, str]] = None,
+    fallback: str = "en",
+) -> str:
+    """Return localized text from ``field_i18n`` with graceful fallbacks.
+
+    Parameters
+    ----------
+    field:
+        The default English value.
+    lang:
+        Desired language code.
+    field_i18n:
+        Optional mapping of language codes to translations.
+    fallback:
+        Fallback language code used when ``lang`` is unavailable.
+    """
+    if field_i18n:
+        if lang in field_i18n and field_i18n[lang]:
+            return field_i18n[lang]
+        if fallback in field_i18n and field_i18n[fallback]:
+            return field_i18n[fallback]
+        if field:
+            return field
+        for value in field_i18n.values():
+            if value:
+                return value
+    return field or ""

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -1,0 +1,25 @@
+# Internationalization
+
+This project supports menu and receipt translations for the following ISO language codes:
+
+```
+"en", "hi", "gu", "mr", "ta", "te", "kn", "ml", "bn", "pa"
+```
+
+## CSV Import Format
+
+```
+item_id,lang,name,description
+1,hi,Chai,Hindi tea
+```
+
+Use `POST /api/outlet/{tenant_id}/menu/i18n/import` with the CSV file to upsert translations. Export existing translations for selected languages via `GET /api/outlet/{tenant_id}/menu/i18n/export?langs=hi,gu`.
+
+## Onboarding
+
+Outlets can configure a default language and the list of enabled languages. Guests may switch languages through the UI; the choice persists in a cookie for six months.
+
+## Known Limits
+
+* Only one language is delivered to guests at a time.
+* All supported Indian languages are rendered left-to-right. Right-to-left support is not yet enabled.

--- a/tests/test_i18n_utils.py
+++ b/tests/test_i18n_utils.py
@@ -1,0 +1,11 @@
+from api.app.utils.i18n import get_text
+
+
+def test_get_text_fallback():
+    field = "English"
+    field_i18n = {"hi": "Hindi"}
+    assert get_text(field, "hi", field_i18n) == "Hindi"
+    # falls back to English when translation missing
+    assert get_text(field, "gu", field_i18n) == "English"
+    # falls back to any available translation when English missing
+    assert get_text(None, "gu", {"mr": "Marathi"}) == "Marathi"

--- a/tests/test_language_middleware.py
+++ b/tests/test_language_middleware.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI, Request
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+from api.app.middlewares.language import LanguageMiddleware
+
+
+def create_app():
+    app = FastAPI()
+    app.state.default_lang = "en"
+    app.state.enabled_langs = ["en", "hi"]
+
+    @app.get("/")
+    async def root(request: Request):
+        return PlainTextResponse(request.state.lang)
+
+    app.add_middleware(LanguageMiddleware)
+    return app
+
+
+def test_query_overrides_cookie():
+    app = create_app()
+    client = TestClient(app)
+    client.cookies.set("lang", "hi")
+    resp = client.get("/?lang=en")
+    assert resp.text == "en"
+    assert resp.cookies["lang"] == "en"
+
+
+def test_cookie_used_when_no_query():
+    app = create_app()
+    client = TestClient(app)
+    client.cookies.set("lang", "hi")
+    resp = client.get("/")
+    assert resp.text == "hi"
+
+
+def test_default_when_no_cookie_or_query():
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.text == "en"


### PR DESCRIPTION
## Summary
- extend tenant models for multilingual menu items, outlet defaults, and invoice language snapshots
- add utility helpers and middleware for language resolution and cookie persistence
- support CSV import/export of item translations with enabled-language validation

## Testing
- `pytest tests/test_i18n_utils.py tests/test_language_middleware.py -q`
- `pytest tests -q` *(fails: AssertionError, ValueError, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afe5bfd70c832a9124f0a7a5b33b0d