### PR TITLE
chore(ci): harden lighthouse workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,23 +18,36 @@ jobs:
           - 5432:5432
         options: >-
           --health-cmd="pg_isready -U neo" --health-interval=10s --health-timeout=5s --health-retries=5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping || exit 1"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=20
     env:
       POSTGRES_MASTER_URL: postgresql://neo:neo@localhost:5432/neo
       DATABASE_URL: postgresql://neo:neo@localhost:5432/neo
       SQLALCHEMY_DATABASE_URI: postgresql://neo:neo@localhost:5432/neo
       SYNC_DATABASE_URL: postgresql://neo:neo@localhost:5432/neo
+      REDIS_URL: redis://localhost:6379/0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: actions/setup-python@v4
+          cache: "npm"
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
-      - name: Install Python dependencies
-        run: pip install -r api/requirements.txt
+          python-version: "3.12"
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r api/requirements.txt
       - name: Install Lighthouse CI
-        run: npm install -g @lhci/cli
+        run: npm i -g @lhci/cli@0.13.x
       - name: Wait for Postgres
         run: |
           until pg_isready -h localhost -U neo; do
@@ -44,11 +57,10 @@ jobs:
       - name: Run migrations
         run: |
           python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
+      - name: Wait for /ready
+        run: bash scripts/ci_wait_ready.sh
       - name: Run Lighthouse CI
-        run: |
-          SKIP_DB_MIGRATIONS=1 python start_app.py &
-          sleep 5
-          lhci autorun --config=lighthouserc.json
+        run: lhci autorun --config=lighthouserc.json
       - name: Upload Lighthouse reports
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/ci_wait_ready.sh
+++ b/scripts/ci_wait_ready.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKIP_DB_MIGRATIONS=1 python start_app.py &
+for i in {1..40}; do
+  curl -fsS http://localhost:8000/ready && exit 0
+  sleep 2
+done
+echo "API not ready" >&2
+exit 1

--- a/start_app.py
+++ b/start_app.py
@@ -66,7 +66,12 @@ def main(argv: list[str] | None = None) -> None:
             return
 
     try:
-        uvicorn.run("api.app.main:app")
+        uvicorn.run(
+            "api.app.main:app",
+            host="0.0.0.0",
+            port=int(os.getenv("PORT", "8000")),
+            log_level="info",
+        )
     except ModuleNotFoundError as exc:
         missing = exc.name or str(exc)
         print(


### PR DESCRIPTION
## Summary
- pin Python 3.12 in Lighthouse CI workflow
- add Redis service and deterministic readiness gate
- expose API on all interfaces and add helper wait script

## Testing
- `pytest -q` *(fails: import file mismatch in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68afeb882dac832a95064ae599523ca1