### PR TITLE
chore: standardize postgres env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A Lighthouse CI workflow enforces performance budgets for the guest, admin, and 
 ### Lighthouse workflow
 
 The workflow requires a PostgreSQL DSN for migrations. Set `POSTGRES_MASTER_URL`
-or `DATABASE_URL` to the same DSN and provide `SQLALCHEMY_DATABASE_URI` for
-tools needing a synchronous connection string.
+to this DSN (or `DATABASE_URL` for compatibility) and provide
+`SQLALCHEMY_DATABASE_URI` for tools needing a synchronous connection string.
 Migrations run once before the server starts and the workflow launches
 `start_app.py` with `SKIP_DB_MIGRATIONS=1` to avoid redundant upgrades.
 Monitoring tools such as UptimeRobot should poll the `/status.json` endpoint for platform health. A synthetic monitor (`scripts/synthetic_order_monitor.py`) exercises a full guest order path end-to-end and reports metrics. Status is persisted in Redis with `status.json` on disk as a fallback. Administrators can override it via `POST /admin/status` or the helper script in `ops/scripts/status_page.py` during incidents.
@@ -215,7 +215,7 @@ cp .env.example .env
 
 See [Database URLs](docs/ENV_VARS.md#database-urls) for connection settings and a local Postgres quickstart.
 
-At startup the API validates that critical variables like `DB_URL`,
+At startup the API validates that critical variables like `POSTGRES_MASTER_URL`,
 `REDIS_URL`, and `SECRET_KEY` are present. CI runs `scripts/env_audit.py` during linting to
 keep `.env.example` in sync, and you can run the script locally to compare
 `.env.example` against the required list and spot missing keys.

--- a/api/alembic_tenant/README.md
+++ b/api/alembic_tenant/README.md
@@ -10,12 +10,12 @@ from alembic import command
 from alembic.config import Config
 from sqlalchemy.ext.asyncio import create_async_engine
 
-DB_URL = "postgresql+asyncpg://user:pass@host/db"
+POSTGRES_MASTER_URL = "postgresql+asyncpg://user:pass@host/db"
 
-engine = create_async_engine(DB_URL)
+engine = create_async_engine(POSTGRES_MASTER_URL)
 cfg = Config()
 cfg.set_main_option("script_location", "api/alembic_tenant")
-cfg.set_main_option("sqlalchemy.url", DB_URL)
+cfg.set_main_option("sqlalchemy.url", POSTGRES_MASTER_URL)
 cfg.attributes["engine"] = engine
 
 command.upgrade(cfg, "head")

--- a/api/app/config/validate.py
+++ b/api/app/config/validate.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 REQUIRED_ENVS = [
-    "DB_URL",
+    "POSTGRES_MASTER_URL",
     "REDIS_URL",
     "SECRET_KEY",
     "ALLOWED_ORIGINS",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,9 @@ sys.modules.setdefault("api.app.services.printer_watchdog", types.SimpleNamespac
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 os.environ.setdefault("DB_URL", "postgresql://localhost/test")
+os.environ.setdefault(
+    "POSTGRES_MASTER_URL", "sqlite+aiosqlite:///./dev_master.db"
+)
 os.environ.setdefault("REDIS_URL", "redis://redis:6379/0")
 os.environ.setdefault("SECRET_KEY", "x" * 32)
 os.environ.setdefault("ALLOWED_ORIGINS", "http://example.com")


### PR DESCRIPTION
## Summary
- use `POSTGRES_MASTER_URL` as canonical env var
- document new name in READMEs and examples
- ensure tests set `POSTGRES_MASTER_URL`

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for ecdsa==0.19.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68afec066e04832aa961adcea38ef9f4