### PR TITLE
chore(ci): enforce 15m job timeouts

### DIFF
--- a/.ci/scripts/run_with_timeout.sh
+++ b/.ci/scripts/run_with_timeout.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -u
+
+TIMEOUT_DURATION="${CI_TIMEOUT:-15m}"
+
+timeout "$TIMEOUT_DURATION" "$@"
+status=$?
+if [ $status -eq 124 ]; then
+  echo "Command timed out after $TIMEOUT_DURATION" >&2
+fi
+exit $status

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:16
@@ -45,10 +46,7 @@ jobs:
         run: |
           python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
       - name: Run Lighthouse CI
-        run: |
-          SKIP_DB_MIGRATIONS=1 python start_app.py &
-          sleep 5
-          lhci autorun --config=lighthouserc.json
+        run: ./.ci/scripts/run_with_timeout.sh bash -c "SKIP_DB_MIGRATIONS=1 python start_app.py & sleep 5 && lhci autorun --config=lighthouserc.json"
       - name: Upload Lighthouse reports
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   accessibility:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:16
@@ -53,7 +54,7 @@ jobs:
           npx wait-on tcp:localhost:8000
 
       - name: Run Pa11y
-        run: npx pa11y-ci -c pa11y-ci.json
+        run: ./.ci/scripts/run_with_timeout.sh npx pa11y-ci -c pa11y-ci.json
 
       - name: Upload Pa11y screenshots
         if: ${{ always() }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: e2e/playwright
@@ -23,4 +24,4 @@ jobs:
       - name: Run tests
         env:
           BASE_URL: https://staging.example.com
-        run: npx playwright test
+        run: ../../.ci/scripts/run_with_timeout.sh npx playwright test

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         db: [sqlite, postgres]
@@ -55,7 +56,7 @@ jobs:
       - name: Check i18n keys
         run: pre-commit run --hook-stage manual i18n-lint --all-files
       - name: Test
-        run: pytest --cov --cov-report=term --cov-fail-under=80 -q
+        run: ./.ci/scripts/run_with_timeout.sh pytest --cov --cov-report=term --cov-fail-under=80 -q
       - name: Save print-test PNG
         run: python scripts/save_print_test_png.py
       - name: Upload print-test PNG


### PR DESCRIPTION
## Summary
- enforce 15-minute timeout on python, playwright, pa11y, and lighthouse workflows
- add run_with_timeout.sh helper to wrap long-running commands

## Testing
- `CI_TIMEOUT=1s .ci/scripts/run_with_timeout.sh sleep 5 || echo timeout`
- `CI_TIMEOUT=30s .ci/scripts/run_with_timeout.sh pytest -q || echo pytest-failed` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pre-commit run --files .github/workflows/python-tests.yml .github/workflows/playwright.yml .github/workflows/pa11y.yml .github/workflows/lighthouse.yml .ci/scripts/run_with_timeout.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afec952d48832ab06ff056422f24d3