### PR TITLE
feat(i18n): menu translation import/export + outlet lang settings + middleware + tests

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -85,7 +85,7 @@ from .middlewares import (
     HttpErrorCounterMiddleware,
     IdempotencyMetricsMiddleware,
     IdempotencyMiddleware,
-    LanguageMiddleware,
+    I18nMiddleware,
     LicensingMiddleware,
     LoggingMiddleware,
     MaintenanceMiddleware,
@@ -158,6 +158,7 @@ from .routes_limits_usage import router as limits_router
 from .routes_maintenance import router as maintenance_router
 from .routes_media import router as media_router
 from .routes_menu_import import router as menu_import_router
+from .routes_menu_i18n import router as menu_i18n_router
 from .routes_metrics import router as metrics_router
 from .routes_metrics import ws_messages_total
 from .routes_onboarding import router as onboarding_router
@@ -260,7 +261,7 @@ app.add_middleware(GuestBlockMiddleware)
 app.add_middleware(TableStateGuardMiddleware)
 app.add_middleware(RoomStateGuard)
 app.add_middleware(GuestRateLimitMiddleware)
-app.add_middleware(LanguageMiddleware)
+app.add_middleware(I18nMiddleware)
 app.add_middleware(LicensingMiddleware)
 app.add_middleware(IdempotencyMiddleware)
 app.add_middleware(IdempotencyMetricsMiddleware)
@@ -906,6 +907,7 @@ app.include_router(kds_expo_router)
 app.include_router(counter_admin_router)
 app.include_router(staff_router)
 app.include_router(admin_menu_router)
+app.include_router(menu_i18n_router)
 app.include_router(admin_onboarding_router)
 app.include_router(slo_router)
 app.include_router(admin_ops_router)

--- a/api/app/middlewares/__init__.py
+++ b/api/app/middlewares/__init__.py
@@ -6,6 +6,7 @@ from .guest_ratelimit import GuestRateLimitMiddleware
 from .http_errors import HttpErrorCounterMiddleware
 from .idempotency import IdempotencyMetricsMiddleware, IdempotencyMiddleware
 from .language import LanguageMiddleware
+from .i18n_mw import I18nMiddleware
 from .licensing import LicensingMiddleware
 from .logging import LoggingMiddleware
 from .maintenance import MaintenanceMiddleware
@@ -21,6 +22,7 @@ __all__ = [
     "GuestRateLimitMiddleware",
     "GuestBlockMiddleware",
     "LanguageMiddleware",
+    "I18nMiddleware",
     "PrometheusMiddleware",
     "TableStateGuardMiddleware",
     "IdempotencyMiddleware",

--- a/api/app/middlewares/i18n_mw.py
+++ b/api/app/middlewares/i18n_mw.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+
+class I18nMiddleware(BaseHTTPMiddleware):
+    """Resolve request language from query, cookie, or default."""
+
+    def __init__(self, app, cookie_name: str = "glang") -> None:
+        super().__init__(app)
+        self.cookie_name = cookie_name
+        self.max_age = 60 * 60 * 24 * 180  # six months
+
+    async def dispatch(self, request: Request, call_next):
+        query_lang = request.query_params.get("lang")
+        cookie_lang = request.cookies.get(self.cookie_name)
+        default_lang = getattr(request.app.state, "default_lang", "en")
+        enabled = getattr(request.app.state, "enabled_langs", ["en"])
+
+        if query_lang and query_lang in enabled:
+            lang = query_lang
+        elif cookie_lang and cookie_lang in enabled:
+            lang = cookie_lang
+        else:
+            lang = default_lang if default_lang in enabled else "en"
+
+        request.state.lang = lang
+        response = await call_next(request)
+        response.set_cookie(self.cookie_name, lang, max_age=self.max_age)
+        return response

--- a/api/app/routes_menu_i18n.py
+++ b/api/app/routes_menu_i18n.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import csv
+import io
+import re
+from contextlib import asynccontextmanager
+from typing import List
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .auth import User, role_required
+from .db.tenant import get_engine
+from .models_tenant import MenuItem, TenantMeta
+from .utils.audit import audit
+from .utils.responses import ok
+
+router = APIRouter()
+
+
+@asynccontextmanager
+async def _session(tenant_id: str):
+    engine = get_engine(tenant_id)
+    maker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    try:
+        async with maker() as session:
+            yield session
+    finally:
+        await engine.dispose()
+
+
+@router.post("/api/outlet/{tenant_id}/menu/i18n/import")
+@audit("i18n.import")
+async def import_menu_i18n(
+    tenant_id: str,
+    file: UploadFile = File(...),
+    user: User = Depends(role_required("super_admin", "outlet_admin", "manager")),
+) -> dict:
+    data = (await file.read()).decode("utf-8")
+    reader = csv.DictReader(io.StringIO(data))
+    updated = 0
+    skipped = 0
+    errors: List[str] = []
+    async with _session(tenant_id) as session:
+        enabled = await session.scalar(select(TenantMeta.enabled_langs)) or ["en"]
+        for row in reader:
+            try:
+                item_id = int(row.get("item_id", ""))
+            except ValueError:
+                skipped += 1
+                errors.append(f"row {reader.line_num} invalid_item_id")
+                continue
+            lang = row.get("lang")
+            if lang not in enabled:
+                skipped += 1
+                errors.append(f"row {reader.line_num} unsupported_lang")
+                continue
+            item = await session.get(MenuItem, item_id)
+            if not item:
+                skipped += 1
+                errors.append(f"row {reader.line_num} missing_item")
+                continue
+            ni = item.name_i18n or {}
+            di = item.desc_i18n or {}
+            if row.get("name"):
+                ni[lang] = row["name"]
+            if row.get("description"):
+                di[lang] = row["description"]
+            item.name_i18n = ni
+            item.desc_i18n = di
+            updated += 1
+        await session.commit()
+    return ok({"updated_rows": updated, "skipped": skipped, "errors": errors})
+
+
+@router.get("/api/outlet/{tenant_id}/menu/i18n/export")
+@audit("i18n.export")
+async def export_menu_i18n(
+    tenant_id: str,
+    langs: str | None = None,
+    user: User = Depends(role_required("super_admin", "outlet_admin", "manager")),
+):
+    async with _session(tenant_id) as session:
+        enabled = await session.scalar(select(TenantMeta.enabled_langs)) or ["en"]
+        requested = [c for c in (langs.split(",") if langs else enabled) if c]
+        for code in requested:
+            if code not in enabled:
+                raise HTTPException(status_code=400, detail="unsupported language")
+        result = await session.execute(select(MenuItem))
+        output = io.StringIO()
+        writer = csv.DictWriter(
+            output, fieldnames=["item_id", "lang", "name", "description"]
+        )
+        writer.writeheader()
+        for item in result.scalars():
+            for code in requested:
+                name = (item.name_i18n or {}).get(code)
+                desc = (item.desc_i18n or {}).get(code)
+                if name or desc:
+                    writer.writerow(
+                        {
+                            "item_id": item.id,
+                            "lang": code,
+                            "name": name,
+                            "description": desc,
+                        }
+                    )
+        output.seek(0)
+    return StreamingResponse(iter([output.getvalue()]), media_type="text/csv")
+
+
+class I18nSettings(BaseModel):
+    default_lang: str
+    enabled_langs: List[str]
+
+
+@router.patch("/api/outlet/{tenant_id}/settings/i18n")
+@audit("i18n.settings")
+async def update_i18n_settings(
+    tenant_id: str,
+    payload: I18nSettings,
+    user: User = Depends(role_required("super_admin", "outlet_admin", "manager")),
+) -> dict:
+    if any(not re.fullmatch(r"[a-z]{2}", code) for code in payload.enabled_langs):
+        raise HTTPException(status_code=400, detail="invalid_lang_code")
+    if payload.default_lang not in payload.enabled_langs:
+        raise HTTPException(status_code=400, detail="default_not_enabled")
+    async with _session(tenant_id) as session:
+        meta = await session.get(TenantMeta, 1)
+        if not meta:
+            meta = TenantMeta(id=1)
+            session.add(meta)
+        meta.default_lang = payload.default_lang
+        meta.enabled_langs = payload.enabled_langs
+        await session.commit()
+    return ok(
+        {
+            "default_lang": payload.default_lang,
+            "enabled_langs": payload.enabled_langs,
+        }
+    )

--- a/api/tests/test_i18n.py
+++ b/api/tests/test_i18n.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+BASE_DIR = pathlib.Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE_DIR))
+sys.path.append(str(BASE_DIR / "api"))
+import os
+os.environ.setdefault("POSTGRES_TENANT_DSN_TEMPLATE", "sqlite+aiosqlite:///./{tenant_id}.db")
+
+from api.app import auth
+from api.app.middlewares.i18n_mw import I18nMiddleware
+from api.app.models_tenant import Category, MenuItem, TenantMeta
+from api.app.routes_menu_i18n import router as i18n_router
+import api.app.routes_menu_i18n as routes_menu_i18n
+from api.app.utils.responses import ok
+from api.tests.conftest_tenant import tenant_session  # noqa: F401
+
+
+@pytest.fixture
+def app(tenant_session, monkeypatch):
+    app = FastAPI()
+    app.include_router(i18n_router)
+    app.add_middleware(I18nMiddleware)
+
+    class DummyUser:
+        username = "tester"
+        role = "super_admin"
+
+    app.dependency_overrides[auth.get_current_user] = lambda: DummyUser()
+
+    @asynccontextmanager
+    async def _fake_session(_tenant_id: str):
+        yield tenant_session
+
+    monkeypatch.setattr(routes_menu_i18n, "_session", _fake_session)
+    return app
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_import_valid_and_invalid_lang(app):
+    transport = ASGITransport(app=app)
+    async with tenant_session_context(app) as session:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # prepare DB
+            cat = Category(id=1, name="Beverages", sort=1)
+            item = MenuItem(id=1, category_id=1, name="Tea", price=10)
+            meta = TenantMeta(id=1, default_lang="en", enabled_langs=["en", "hi"])
+            session.add_all([cat, item, meta])
+            await session.commit()
+            csv_data = (
+                "item_id,lang,name,description\n"
+                "1,hi,Chai,Hindi tea\n"
+                "1,zz,Bad,Bad\n"
+            )
+            files = {"file": ("t.csv", csv_data, "text/csv")}
+            resp = await client.post("/api/outlet/demo/menu/i18n/import", files=files)
+            assert resp.status_code == 200
+            body = resp.json()["data"]
+            assert body["updated_rows"] == 1
+            assert body["skipped"] == 1
+            assert body["errors"]
+            item = await session.get(MenuItem, 1)
+            assert item.name_i18n["hi"] == "Chai"
+            assert "zz" not in item.name_i18n
+
+
+@pytest.mark.anyio
+async def test_export_returns_requested_langs(app):
+    transport = ASGITransport(app=app)
+    async with tenant_session_context(app) as session:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            cat = Category(id=1, name="Beverages", sort=1)
+            item = MenuItem(
+                id=1,
+                category_id=1,
+                name="Tea",
+                price=10,
+                name_i18n={"hi": "Chai", "gu": "Chaa"},
+            )
+            meta = TenantMeta(id=1, default_lang="en", enabled_langs=["en", "hi", "gu"])
+            session.add_all([cat, item, meta])
+            await session.commit()
+            resp = await client.get(
+                "/api/outlet/demo/menu/i18n/export?langs=hi",
+            )
+            assert resp.status_code == 200
+            text = resp.text
+            lines = text.strip().splitlines()
+            assert lines[0] == "item_id,lang,name,description"
+            assert len(lines) == 2
+            assert lines[1].startswith("1,hi,Chai")
+
+
+@pytest.mark.anyio
+async def test_settings_rejects_invalid_default(app):
+    transport = ASGITransport(app=app)
+    async with tenant_session_context(app) as session:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            meta = TenantMeta(id=1, default_lang="en", enabled_langs=["en", "hi"])
+            session.add(meta)
+            await session.commit()
+            payload = {"default_lang": "fr", "enabled_langs": ["en", "hi"]}
+            resp = await client.patch(
+                "/api/outlet/demo/settings/i18n", json=payload
+            )
+            assert resp.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_middleware_query_overrides_cookie_and_persists():
+    mapp = FastAPI()
+    mapp.add_middleware(I18nMiddleware)
+    mapp.state.enabled_langs = ["en", "hi", "gu"]
+    mapp.state.default_lang = "en"
+
+    @mapp.get("/")
+    async def root(request: Request):
+        return ok({"lang": request.state.lang})
+
+    transport = ASGITransport(app=mapp)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        client.cookies.set("glang", "gu")
+        resp1 = await client.get("/?lang=hi")
+        assert resp1.json()["data"]["lang"] == "hi"
+        resp2 = await client.get("/")
+        assert resp2.json()["data"]["lang"] == "hi"
+
+
+@asynccontextmanager
+async def tenant_session_context(app: FastAPI):
+    """Yield the session from patched _session."""
+    # Retrieve the patched session from app fixture via dependency.
+    # monkeypatch set on routes module ensures same session is used.
+    from api.app.routes_menu_i18n import _session as patched_session
+    from api.app.models_tenant import Base as TenantBase
+
+    async with patched_session("demo") as session:
+        engine = session.bind
+        async with engine.begin() as conn:
+            await conn.run_sync(TenantBase.metadata.create_all)
+        yield session

--- a/db/migrations/2025-08-28_menu_i18n.sql
+++ b/db/migrations/2025-08-28_menu_i18n.sql
@@ -1,0 +1,10 @@
+-- Menu and outlet i18n support
+ALTER TABLE menu_items
+  ADD COLUMN IF NOT EXISTS name_i18n JSONB DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS desc_i18n JSONB DEFAULT NULL;
+
+ALTER TABLE outlets
+  ADD COLUMN IF NOT EXISTS default_lang TEXT DEFAULT 'en',
+  ADD COLUMN IF NOT EXISTS enabled_langs TEXT[] DEFAULT ARRAY['en'];
+
+UPDATE outlets SET default_lang='en' WHERE default_lang IS NULL;

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -15,6 +15,18 @@ item_id,lang,name,description
 
 Use `POST /api/outlet/{tenant_id}/menu/i18n/import` with the CSV file to upsert translations. Export existing translations for selected languages via `GET /api/outlet/{tenant_id}/menu/i18n/export?langs=hi,gu`.
 
+Outlet language defaults and allowed languages are managed with:
+
+```
+PATCH /api/outlet/{tenant_id}/settings/i18n
+{
+  "default_lang": "en",
+  "enabled_langs": ["en", "hi"]
+}
+```
+
+`default_lang` must be one of the values in `enabled_langs` otherwise the request is rejected with `400 default_not_enabled`.
+
 ## Onboarding
 
 Outlets can configure a default language and the list of enabled languages. Guests may switch languages through the UI; the choice persists in a cookie for six months.
@@ -23,3 +35,4 @@ Outlets can configure a default language and the list of enabled languages. Gues
 
 * Only one language is delivered to guests at a time.
 * All supported Indian languages are rendered left-to-right. Right-to-left support is not yet enabled.
+* Import skips rows where the language code is not enabled for the outlet.

--- a/samples/menu_i18n_sample.csv
+++ b/samples/menu_i18n_sample.csv
@@ -1,0 +1,3 @@
+item_id,lang,name,description
+1,hi,Chai,Hindi tea
+1,gu,Chaa,Gujarati tea

--- a/templates/admin_menu_editor.html
+++ b/templates/admin_menu_editor.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Menu i18n</title>
+</head>
+<body>
+  <h1>Menu i18n</h1>
+  <section>
+    <h2>Export i18n CSV</h2>
+    <form id="export-form" method="get" action="/api/outlet/{{ tenant_id }}/menu/i18n/export">
+      <input type="text" name="langs" placeholder="hi,gu" />
+      <button type="submit">Export i18n CSV</button>
+    </form>
+  </section>
+  <section>
+    <h2>Import i18n CSV</h2>
+    <form id="import-form" method="post" enctype="multipart/form-data" action="/api/outlet/{{ tenant_id }}/menu/i18n/import">
+      <input type="file" name="file" />
+      <button type="submit">Import i18n CSV</button>
+    </form>
+  </section>
+  <section>
+    <h2>Settings</h2>
+    <form id="settings-form" method="patch" action="/api/outlet/{{ tenant_id }}/settings/i18n">
+      <label>Enabled Languages</label>
+      <select name="enabled_langs" multiple>
+        <option value="en">English</option>
+        <option value="hi">Hindi</option>
+        <option value="gu">Gujarati</option>
+      </select>
+      <label>Default Language</label>
+      <select name="default_lang">
+        <option value="en">English</option>
+        <option value="hi">Hindi</option>
+        <option value="gu">Gujarati</option>
+      </select>
+      <button type="submit">Save Settings</button>
+    </form>
+  </section>
+  <div id="toaster"></div>
+  <script>
+    function showToast(msg){
+      const t=document.getElementById('toaster');
+      t.textContent=msg;
+    }
+    document.getElementById('export-form').addEventListener('submit', async function(e){
+      e.preventDefault();
+      const params=new URLSearchParams(new FormData(e.target));
+      const resp=await fetch(e.target.action+'?'+params.toString());
+      showToast(await resp.text());
+    });
+    document.getElementById('import-form').addEventListener('submit', async function(e){
+      e.preventDefault();
+      const resp=await fetch(e.target.action,{method:'POST',body:new FormData(e.target)});
+      showToast(JSON.stringify(await resp.json()));
+    });
+    document.getElementById('settings-form').addEventListener('submit', async function(e){
+      e.preventDefault();
+      const formData=new FormData(e.target);
+      const enabled=formData.getAll('enabled_langs');
+      const payload={default_lang:formData.get('default_lang'), enabled_langs:enabled};
+      const resp=await fetch(e.target.action,{method:'PATCH',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+      showToast(JSON.stringify(await resp.json()));
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add menu translation import/export and outlet i18n settings endpoints
- persist guest language via new I18nMiddleware
- document i18n APIs and provide sample CSV

## Testing
- `pytest api/tests/test_i18n.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aff22bde90832a862af8369b40d464