### PR TITLE
chore: add staging environment config

### DIFF
--- a/staging.env
+++ b/staging.env
@@ -1,0 +1,21 @@
+POSTGRES_MASTER_URL=postgresql+asyncpg://postgres:postgres@staging-postgres:5432/master
+# If a tenant database is missing, scripts will connect to "postgres" (falling
+# back to "template1") to create it before applying schema.
+POSTGRES_TENANT_DSN_TEMPLATE=postgresql+asyncpg://postgres:postgres@staging-postgres:5432/tenant_{tenant_id}
+JWT_SECRET=staging_secret
+REDIS_URL=redis://staging-redis:6379/0
+ALLOWED_ORIGINS=https://staging.example.com
+ENABLE_HSTS=0
+BODY_MAX_KB=128
+ADMIN_API_ENABLED=true
+SSE_KEEPALIVE_INTERVAL=15
+MAX_CONN_PER_IP=50
+QUEUE_MAX=100
+EXPORT_MAX_ROWS=10000
+ENV=staging
+HEARTBEAT_TIMEOUT_SEC=30
+TENANT_ANALYTICS_ENABLED=0
+ANALYTICS_TENANTS=tenant_staging
+FLAG_SIMPLE_MODIFIERS=1
+FLAG_WA_ENABLED=1
+AB_TESTS_ENABLED=0


### PR DESCRIPTION
## Summary
- add `staging.env` with staging-specific values for all production environment variables
- verify variable parity with production example

## Testing
- `pre-commit run --files staging.env`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement ecdsa==0.19.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68aff69ead58832aa7919e74b527be19