### PR TITLE
docs: remove unused env flag for backup smoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ pilot: release-rc stage
 	pytest -q
 	npx playwright test
 	python scripts/pdf_smoke.py --env=staging
-	bash scripts/backup_smoke.sh --env=staging
+	bash scripts/backup_smoke.sh
 
 release-ga:
 	python scripts/release_tag.py --ga

--- a/deploy/BACKUP_RESTORE.md
+++ b/deploy/BACKUP_RESTORE.md
@@ -98,3 +98,10 @@ Postgres database, and running a basic tenant count query. It reports the
 encrypted size, timings, and row count. The `backup-smoke` GitHub workflow runs
 this weekly against the staging cluster and posts a summary to the workflow
 run.
+
+To run the script manually, set `POSTGRES_URL`, `BACKUP_PUBLIC_KEY`, and
+`BACKUP_PRIVATE_KEY` in the environment and invoke:
+
+```
+bash scripts/backup_smoke.sh
+```


### PR DESCRIPTION
## Summary
- drop unused `--env` flag from backup smoke Makefile target
- document environment variables required to run backup smoke

## Testing
- `pre-commit run --files Makefile deploy/BACKUP_RESTORE.md`
- `pytest scripts/tests -q`
- `POSTGRES_URL=postgres://localhost:5432/neo BACKUP_PUBLIC_KEY=test BACKUP_PRIVATE_KEY=test bash scripts/backup_smoke.sh` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aff6918cc0832aaeeeab53610bb928