### PR TITLE
feat(billing): plans, subscriptions, license enforcement, mock gateway + owner billing UI & tests

### DIFF
--- a/api/app/billing.py
+++ b/api/app/billing.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+"""In-memory billing domain models and gateway."""
+
+import hashlib
+import hmac
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Protocol
+
+
+@dataclass
+class Plan:
+    id: str
+    name: str
+    price_inr: int
+    billing_interval: str
+    max_tables: int
+    features_json: Dict[str, Any]
+    is_active: bool = True
+
+
+@dataclass
+class Subscription:
+    id: str
+    tenant_id: str
+    plan_id: str
+    status: str
+    current_period_start: datetime
+    current_period_end: datetime
+    trial_end: datetime | None = None
+    cancel_at_period_end: bool = False
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class SubscriptionEvent:
+    id: str
+    subscription_id: str
+    type: str
+    payload_json: Dict[str, Any]
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class BillingInvoice:
+    id: str
+    tenant_id: str
+    number: str
+    amount_inr: int
+    gst_inr: int
+    period_start: datetime
+    period_end: datetime
+    status: str
+    pdf_url: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+PLANS: Dict[str, Plan] = {}
+SUBSCRIPTIONS: Dict[str, Subscription] = {}
+SUBSCRIPTION_EVENTS: List[SubscriptionEvent] = []
+INVOICES: List[BillingInvoice] = []
+PROCESSED_EVENTS: set[str] = set()
+
+
+def seed_default_plans() -> None:
+    if PLANS:
+        return
+    PLANS["starter"] = Plan(
+        id="starter",
+        name="Starter",
+        price_inr=0,
+        billing_interval="monthly",
+        max_tables=5,
+        features_json={},
+    )
+    PLANS["standard"] = Plan(
+        id="standard",
+        name="Standard",
+        price_inr=4999,
+        billing_interval="monthly",
+        max_tables=20,
+        features_json={"exports": True},
+    )
+    PLANS["pro"] = Plan(
+        id="pro",
+        name="Pro",
+        price_inr=9999,
+        billing_interval="monthly",
+        max_tables=50,
+        features_json={"exports": True, "coupons": True},
+    )
+
+
+seed_default_plans()
+
+
+class BillingGateway(Protocol):
+    def create_checkout_session(self, tenant_id: str, plan: Plan) -> Dict[str, Any]:
+        """Create a checkout session for ``tenant_id`` and ``plan``."""
+
+    def verify_webhook(self, sig: str, body: bytes) -> bool:
+        """Validate webhook signature."""
+
+    def list_payments(self, tenant_id: str) -> List[Dict[str, Any]]:
+        """List payments for ``tenant_id``."""
+
+
+class MockGateway:
+    """Mock gateway that auto-succeeds payments."""
+
+    secret = "mock_secret"
+
+    def create_checkout_session(self, tenant_id: str, plan: Plan) -> Dict[str, Any]:
+        from .main import TENANTS  # inline import to avoid circular deps
+
+        now = datetime.utcnow()
+        period_end = now + timedelta(days=30)
+        sub = Subscription(
+            id=str(uuid.uuid4()),
+            tenant_id=tenant_id,
+            plan_id=plan.id,
+            status="active",
+            current_period_start=now,
+            current_period_end=period_end,
+        )
+        SUBSCRIPTIONS[tenant_id] = sub
+        TENANTS[tenant_id]["plan"] = plan.id
+        TENANTS[tenant_id]["subscription_expires_at"] = period_end
+        inv = BillingInvoice(
+            id=str(uuid.uuid4()),
+            tenant_id=tenant_id,
+            number=f"INV-{len(INVOICES)+1:03d}",
+            amount_inr=plan.price_inr,
+            gst_inr=int(plan.price_inr * 0.18),
+            period_start=now,
+            period_end=period_end,
+            status="paid",
+            pdf_url="/invoices/mock.pdf",
+        )
+        INVOICES.append(inv)
+        SUBSCRIPTION_EVENTS.append(
+            SubscriptionEvent(
+                id=str(uuid.uuid4()),
+                subscription_id=sub.id,
+                type="payment_succeeded",
+                payload_json={"plan": plan.id},
+            )
+        )
+        return {"checkout_session_id": str(uuid.uuid4())}
+
+    def verify_webhook(self, sig: str, body: bytes) -> bool:
+        expected = hmac.new(self.secret.encode(), body, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, sig)
+
+    def list_payments(
+        self, tenant_id: str
+    ) -> List[Dict[str, Any]]:  # pragma: no cover - stub
+        return []

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -106,6 +106,8 @@ from .routes_ab_report import router as ab_report_router
 from .routes_ab_tests import router as ab_tests_router
 from .routes_accounting import router as accounting_router
 from .routes_accounting_exports import router as accounting_exports_router
+from .routes_admin_billing import router as admin_billing_router
+from .routes_admin_billing import webhook_router as billing_webhook_router
 from .routes_admin_devices import router as admin_devices_router
 from .routes_admin_menu import router as admin_menu_router
 from .routes_admin_onboarding import router as admin_onboarding_router
@@ -891,6 +893,8 @@ app.include_router(counter_guest_router)
 app.include_router(hotel_guest_router)
 app.include_router(invoice_pdf_router)
 app.include_router(billing_router)
+app.include_router(admin_billing_router)
+app.include_router(billing_webhook_router)
 app.include_router(onboarding_router)
 app.include_router(qrpack_router)
 app.include_router(order_void_router)

--- a/api/app/models_master.py
+++ b/api/app/models_master.py
@@ -119,6 +119,66 @@ class NotificationDLQ(Base):
     failed_at = Column(DateTime, server_default=func.now())
 
 
+class Plan(Base):
+    """Available subscription plans."""
+
+    __tablename__ = "plans"
+
+    id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    price_inr = Column(Integer, nullable=False)
+    billing_interval = Column(String, nullable=False)
+    max_tables = Column(Integer, nullable=False)
+    features_json = Column(JSON, nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+
+
+class Subscription(Base):
+    """Tenant subscription record."""
+
+    __tablename__ = "subscriptions"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id = Column(UUID(as_uuid=True), nullable=False)
+    plan_id = Column(String, ForeignKey("plans.id"), nullable=False)
+    status = Column(String, nullable=False, default="active")
+    current_period_start = Column(DateTime, nullable=False)
+    current_period_end = Column(DateTime, nullable=False)
+    trial_end = Column(DateTime, nullable=True)
+    cancel_at_period_end = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+
+class SubscriptionEvent(Base):
+    """Audit trail of subscription events."""
+
+    __tablename__ = "subscription_events"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    subscription_id = Column(UUID(as_uuid=True), nullable=False)
+    type = Column(String, nullable=False)
+    payload_json = Column(JSON, nullable=False)
+    created_at = Column(DateTime, server_default=func.now())
+
+
+class BillingInvoice(Base):
+    """Billing invoice for a tenant."""
+
+    __tablename__ = "billing_invoices"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id = Column(UUID(as_uuid=True), nullable=False)
+    number = Column(String, nullable=False)
+    amount_inr = Column(Integer, nullable=False)
+    gst_inr = Column(Integer, nullable=False)
+    period_start = Column(DateTime, nullable=False)
+    period_end = Column(DateTime, nullable=False)
+    status = Column(String, nullable=False)
+    pdf_url = Column(String, nullable=True)
+    created_at = Column(DateTime, server_default=func.now())
+
+
 class TwoFactorSecret(Base):
     """TOTP secret hashes for owner/admin accounts."""
 

--- a/api/app/routes_admin_billing.py
+++ b/api/app/routes_admin_billing.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+"""Owner billing endpoints using a mock gateway."""
+
+import csv
+import io
+import json
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Header, HTTPException, Request, Response
+
+from .billing import (
+    INVOICES,
+    PLANS,
+    PROCESSED_EVENTS,
+    SUBSCRIPTION_EVENTS,
+    MockGateway,
+    SubscriptionEvent,
+)
+from .utils.responses import ok
+
+router = APIRouter(prefix="/admin/billing")
+webhook_router = APIRouter()
+_gateway = MockGateway()
+
+
+@router.get("/subscription")
+async def get_subscription(x_tenant_id: str = Header(...)) -> dict:
+    from .main import TENANTS  # inline import to avoid circular deps
+
+    tenant = TENANTS.get(x_tenant_id)
+    if tenant is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    plan_id = tenant.get("plan")
+    expiry = tenant.get("subscription_expires_at")
+    grace_days = tenant.get("grace_period_days", 7)
+    now = datetime.utcnow()
+    grace = False
+    days_left = None
+    status = "inactive"
+    if expiry:
+        days_left = (expiry - now).days
+        if now <= expiry:
+            status = "active"
+        elif now <= expiry + timedelta(days=grace_days):
+            status = "grace"
+            grace = True
+        else:
+            status = "expired"
+    return ok(
+        {
+            "plan": plan_id,
+            "status": status,
+            "days_left": days_left,
+            "grace": grace,
+        }
+    )
+
+
+@router.post("/checkout")
+async def checkout(payload: dict, x_tenant_id: str = Header(...)) -> dict:
+    plan_id = payload.get("plan_id")
+    plan = PLANS.get(plan_id)
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    session = _gateway.create_checkout_session(x_tenant_id, plan)
+    return ok(session)
+
+
+@router.get("/invoices.csv")
+async def invoices_csv(x_tenant_id: str = Header(...)) -> Response:
+    rows = [inv for inv in INVOICES if inv.tenant_id == x_tenant_id]
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "number",
+            "amount_inr",
+            "gst_inr",
+            "period_start",
+            "period_end",
+            "status",
+            "pdf_url",
+        ]
+    )
+    for inv in rows:
+        writer.writerow(
+            [
+                inv.number,
+                inv.amount_inr,
+                inv.gst_inr,
+                inv.period_start.isoformat(),
+                inv.period_end.isoformat(),
+                inv.status,
+                inv.pdf_url,
+            ]
+        )
+    return Response(buf.getvalue(), media_type="text/csv")
+
+
+@webhook_router.post("/billing/webhook/mock")
+async def mock_webhook(request: Request, x_mock_signature: str = Header(...)) -> dict:
+    body = await request.body()
+    if not _gateway.verify_webhook(x_mock_signature, body):
+        raise HTTPException(status_code=401, detail="invalid signature")
+    payload = json.loads(body)
+    event_id = payload.get("id")
+    if event_id in PROCESSED_EVENTS:
+        return ok({"id": event_id})
+    PROCESSED_EVENTS.add(event_id)
+    SUBSCRIPTION_EVENTS.append(
+        SubscriptionEvent(
+            id=event_id,
+            subscription_id=payload.get("subscription_id", ""),
+            type=payload.get("type", ""),
+            payload_json=payload,
+        )
+    )
+    return ok({"id": event_id})

--- a/api/tests/test_billing_info.py
+++ b/api/tests/test_billing_info.py
@@ -1,8 +1,20 @@
+import os
+import sys
+import types
 from datetime import datetime, timedelta
 
 import fakeredis.aioredis
 import pytest
 from fastapi.testclient import TestClient
+
+# Stub optional dependencies
+sys.modules.setdefault("opentelemetry", types.ModuleType("opentelemetry"))
+sys.modules.setdefault("opentelemetry.trace", types.ModuleType("trace"))
+sys.modules.setdefault("qrcode", types.ModuleType("qrcode"))
+
+os.environ.setdefault("ALLOWED_ORIGINS", "*")
+os.environ.setdefault("POSTGRES_MASTER_URL", "postgresql://localhost")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 
 from api.app.main import TENANTS, app
 
@@ -20,7 +32,9 @@ def test_billing_endpoint_shows_grace(client, monkeypatch):
     resp = client.post("/tenants", params={"name": "t1", "licensed_tables": 1})
     tenant_id = resp.json()["data"]["tenant_id"]
     TENANTS[tenant_id]["plan"] = "basic"
-    TENANTS[tenant_id]["subscription_expires_at"] = datetime.utcnow() - timedelta(days=1)
+    TENANTS[tenant_id]["subscription_expires_at"] = datetime.utcnow() - timedelta(
+        days=1
+    )
     headers = {"X-Tenant-ID": tenant_id}
     resp_bill = client.get("/billing", headers=headers)
     assert resp_bill.status_code == 200
@@ -28,4 +42,3 @@ def test_billing_endpoint_shows_grace(client, monkeypatch):
     assert data["plan"] == "basic"
     assert data["pay_url"]
     assert data["grace"] is True
-

--- a/api/tests/test_billing_mock.py
+++ b/api/tests/test_billing_mock.py
@@ -1,0 +1,83 @@
+import hashlib
+import hmac
+import json
+import os
+import sys
+import types
+from datetime import datetime, timedelta
+
+import fakeredis.aioredis
+import pytest
+from fastapi.testclient import TestClient
+
+# Stub optional dependencies not needed in tests
+sys.modules.setdefault("opentelemetry", types.ModuleType("opentelemetry"))
+sys.modules.setdefault("opentelemetry.trace", types.ModuleType("trace"))
+sys.modules.setdefault("qrcode", types.ModuleType("qrcode"))
+
+os.environ.setdefault("ALLOWED_ORIGINS", "*")
+os.environ.setdefault("POSTGRES_MASTER_URL", "postgresql://localhost")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+from api.app import billing
+from api.app.billing import MockGateway
+from api.app.main import TENANTS, app
+
+
+@pytest.fixture
+def client():
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    client = TestClient(app, raise_server_exceptions=False)
+    yield client
+    TENANTS.clear()
+    billing.SUBSCRIPTIONS.clear()
+    billing.SUBSCRIPTION_EVENTS.clear()
+    billing.INVOICES.clear()
+    billing.PROCESSED_EVENTS.clear()
+
+
+def _make_tenant(client):
+    resp = client.post("/tenants", params={"name": "t1", "licensed_tables": 1})
+    return resp.json()["data"]["tenant_id"]
+
+
+def test_trial_expiry_and_renew(client):
+    tenant_id = _make_tenant(client)
+    headers = {"X-Tenant-ID": tenant_id}
+    TENANTS[tenant_id]["subscription_expires_at"] = datetime.utcnow() - timedelta(
+        days=5
+    )
+    resp = client.post("/orders", json={"tenant_id": tenant_id, "open_tables": 0})
+    assert resp.status_code == 200  # within grace
+    TENANTS[tenant_id]["subscription_expires_at"] = datetime.utcnow() - timedelta(
+        days=8
+    )
+    resp = client.post("/orders", json={"tenant_id": tenant_id, "open_tables": 0})
+    assert resp.status_code == 403
+    resp = client.post(
+        "/admin/billing/checkout", headers=headers, json={"plan_id": "starter"}
+    )
+    assert resp.status_code == 200
+    resp = client.post("/orders", json={"tenant_id": tenant_id, "open_tables": 0})
+    assert resp.status_code != 403
+
+
+def test_webhook_signature_idempotency(client):
+    payload = {"id": "evt1", "subscription_id": "s1", "type": "payment_succeeded"}
+    body = json.dumps(payload).encode()
+    sig = hmac.new(MockGateway.secret.encode(), body, hashlib.sha256).hexdigest()
+    bad = hmac.new(b"bad", body, hashlib.sha256).hexdigest()
+    resp = client.post(
+        "/billing/webhook/mock", data=body, headers={"X-Mock-Signature": bad}
+    )
+    assert resp.status_code == 401
+    resp = client.post(
+        "/billing/webhook/mock", data=body, headers={"X-Mock-Signature": sig}
+    )
+    assert resp.status_code == 200
+    assert len(billing.SUBSCRIPTION_EVENTS) == 1
+    resp = client.post(
+        "/billing/webhook/mock", data=body, headers={"X-Mock-Signature": sig}
+    )
+    assert resp.status_code == 200
+    assert len(billing.SUBSCRIPTION_EVENTS) == 1

--- a/docs/BILLING.md
+++ b/docs/BILLING.md
@@ -1,0 +1,15 @@
+# Billing Lifecycle
+
+Tenants subscribe to a plan that grants access for a billing period. Each subscription stores the plan, current period and status. Default plans (Starter, Standard, Pro) are seeded in-memory for now.
+
+## Grace Logic
+
+When a subscription expires the tenant enters a configurable grace period (default 7 days). During grace the product continues to function. Once the grace period elapses, table scans and guest orders are blocked until payment is received. Owners may still visit `/admin/billing` to renew.
+
+## Webhook Security
+
+The mock payment gateway posts events to `/billing/webhook/mock` with an `X-Mock-Signature` header. The body is signed using HMAC-SHA256 with a shared secret. Events are processed idempotently and recorded for audit.
+
+## Swapping Gateways
+
+`BillingGateway` is a small interface with `create_checkout_session`, `verify_webhook` and `list_payments`. A real UPI or payment processor can replace `MockGateway` by implementing the same interface and wiring it into the billing routes.


### PR DESCRIPTION
## Summary
- introduce in-memory billing domain with plans, subscriptions, invoices and events
- add mock BillingGateway and owner billing endpoints with checkout, invoices and webhook
- wire billing routes into app and document subscription lifecycle

## Testing
- `pre-commit run --files api/app/billing.py api/app/routes_admin_billing.py api/app/models_master.py api/app/main.py docs/BILLING.md api/tests/test_billing_mock.py api/tests/test_billing_info.py`
- `PYTHONPATH=. pytest api/tests/test_billing_info.py api/tests/test_billing_mock.py`


------
https://chatgpt.com/codex/tasks/task_e_68aff4de2320832abb7ba4e32621f882