### PR TITLE
Fix CI environment handling for API startup

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -49,6 +49,9 @@ jobs:
           python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
 
       - name: Start API
+        env:
+          ALLOWED_ORIGINS: http://localhost
+          SECRET_KEY: ${{ secrets.SECRET_KEY || 'test-secret' }}
         run: |
           python start_app.py &
           npx wait-on tcp:localhost:8000

--- a/scripts/ci_wait_ready.sh
+++ b/scripts/ci_wait_ready.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-SKIP_DB_MIGRATIONS=1 python start_app.py &
 for i in {1..40}; do
   curl -fsS http://localhost:8000/ready && exit 0
   sleep 2


### PR DESCRIPTION
## Summary
- inject safe ALLOWED_ORIGINS and SECRET_KEY defaults for non-prod runs
- simplify CI wait script to only poll API readiness
- export ALLOWED_ORIGINS and SECRET_KEY in Pa11y workflow and fall back to a dummy secret

## Testing
- `pre-commit run --files api/app/config/validate.py scripts/ci_wait_ready.sh .github/workflows/pa11y.yml`
- `pytest tests/test_start_app.py -q`
- `npx --yes wait-on tcp:localhost:8000`

------
https://chatgpt.com/codex/tasks/task_e_68affb5d8458832ab332fb23f41f653a