### PR TITLE
Fix Trivy workflow indentation

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,26 +14,26 @@ jobs:
             dockerfile: Dockerfile.api
           - image: worker
             dockerfile: Dockerfile.worker
-      steps:
-        - uses: actions/checkout@v4
-        - uses: docker/setup-buildx-action@v3
-        - name: Build ${{ matrix.image }} image
-          run: docker build -t ${{ matrix.image }} -f ${{ matrix.dockerfile }} .
-        - name: Cache Trivy database
-          uses: actions/cache@v4
-          with:
-            path: ~/.cache/trivy
-            key: ${{ runner.os }}-trivy-${{ hashFiles('Dockerfile.api', 'Dockerfile.worker') }}
-            restore-keys: |
-              ${{ runner.os }}-trivy-
-        - name: Scan ${{ matrix.image }} image
-          uses: aquasecurity/trivy-action@0.20.0
-          with:
-            image-ref: ${{ matrix.image }}
-            format: table
-            exit-code: 1
-            vuln-type: os,library
-            severity: HIGH,CRITICAL
-            ignore-unfixed: true
-            cache-dir: ~/.cache/trivy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build ${{ matrix.image }} image
+        run: docker build -t ${{ matrix.image }} -f ${{ matrix.dockerfile }} .
+      - name: Cache Trivy database
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/trivy
+          key: ${{ runner.os }}-trivy-${{ hashFiles('Dockerfile.api', 'Dockerfile.worker') }}
+          restore-keys: |
+            ${{ runner.os }}-trivy-
+      - name: Scan ${{ matrix.image }} image
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: table
+          exit-code: 1
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          cache-dir: ~/.cache/trivy
 


### PR DESCRIPTION
## Summary
- fix indentation for `steps` in Trivy workflow

## Testing
- `pre-commit run --files .github/workflows/trivy.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', 'fakeredis', 'responses', 'schemathesis', 'psycopg2', 'sqlalchemy', etc.; 211 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b0022ed390832aa73621d3a361891a