### PR TITLE
feat(billing): license enforcement middleware + UI banners + metrics + tests

### DIFF
--- a/GO_LIVE_CHECKLIST.md
+++ b/GO_LIVE_CHECKLIST.md
@@ -11,3 +11,6 @@
 - [ ] Run production rollout
     - `make prod`
     - weighted canary ramp 5→25→50→100 with rollback gate
+- [ ] Simulate subscription expiry and renewal
+    - mark a test tenant expired, verify banners and blocked actions
+    - renew via `/admin/billing`

--- a/api/app/middlewares/license_gate.py
+++ b/api/app/middlewares/license_gate.py
@@ -1,0 +1,106 @@
+"""Subscription enforcement middleware with caching and decorators."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from typing import Any, Callable, Awaitable
+
+from fastapi import Depends, HTTPException, Request
+from redis.asyncio import Redis
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+
+def license_required(allow_in_grace: bool = True) -> Depends:
+    async def checker(request: Request):
+        status = getattr(request.state, "license_status", "ACTIVE")
+        if status == "EXPIRED" or (status == "GRACE" and not allow_in_grace):
+            from ..routes_metrics import blocked_actions_total
+
+            blocked_actions_total.labels(route=request.url.path).inc()
+            raise HTTPException(
+                status_code=402,
+                detail={"code": "SUBSCRIPTION_EXPIRED", "renew_url": "/admin/billing"},
+            )
+    return Depends(checker)
+
+
+def billing_always_allowed(func: Callable) -> Callable:
+    return func
+
+
+class LicenseGate(BaseHTTPMiddleware):
+    """Attach license status to request and cache for 60s."""
+
+    def __init__(self, app, ttl: int = 60):
+        super().__init__(app)
+        self.ttl = ttl
+
+    async def _status_from_cache(self, redis: Redis, key: str) -> tuple[str, int | None] | None:
+        cached = await redis.get(key)
+        if not cached:
+            return None
+        try:
+            data = json.loads(cached)
+            return data.get("status", "ACTIVE"), data.get("days_left")
+        except Exception:  # pragma: no cover
+            return None
+
+    async def _compute_status(self, tenant: dict[str, Any] | None) -> tuple[str, int | None]:
+        status = "ACTIVE"
+        days_left: int | None = None
+        if not tenant:
+            return status, days_left
+        now = datetime.utcnow()
+        expiry = tenant.get("subscription_expires_at")
+        grace_days = tenant.get("grace_period_days", 0)
+        if not expiry:
+            return status, days_left
+        if now > expiry + timedelta(days=grace_days):
+            status = "EXPIRED"
+            days_left = 0
+        elif now > expiry:
+            status = "GRACE"
+            days_left = (expiry + timedelta(days=grace_days) - now).days
+        else:
+            status = "ACTIVE"
+            days_left = (expiry - now).days
+        return status, days_left
+
+    async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]):
+        tenant_id = request.headers.get("X-Tenant-ID")
+        redis: Redis | None = getattr(request.app.state, "redis", None)
+        status = "ACTIVE"
+        days_left: int | None = None
+        cache_key = f"license:{tenant_id}" if tenant_id else None
+        if tenant_id and redis and cache_key:
+            cached = await self._status_from_cache(redis, cache_key)
+            if cached:
+                status, days_left = cached
+        if days_left is None:
+            from ..main import TENANTS  # inline import
+
+            tenant = TENANTS.get(tenant_id) if tenant_id else None
+            status, days_left = await self._compute_status(tenant)
+            if tenant_id and redis and cache_key:
+                await redis.set(
+                    cache_key,
+                    json.dumps({"status": status, "days_left": days_left}),
+                    ex=self.ttl,
+                )
+
+        request.state.license_status = status
+        request.state.license_days_left = days_left
+
+        try:  # metrics
+            from ..routes_metrics import license_status_gauge
+
+            license_status_gauge.labels(tenant=tenant_id or "", status=status).set(1)
+        except Exception:
+            pass
+
+        return await call_next(request)
+
+
+__all__ = ["LicenseGate", "license_required", "billing_always_allowed"]

--- a/api/app/routes_admin_billing.py
+++ b/api/app/routes_admin_billing.py
@@ -18,6 +18,7 @@ from .billing import (
     SubscriptionEvent,
 )
 from .utils.responses import ok
+from .middlewares.license_gate import billing_always_allowed
 
 router = APIRouter(prefix="/admin/billing")
 webhook_router = APIRouter()
@@ -25,6 +26,7 @@ _gateway = MockGateway()
 
 
 @router.get("/subscription")
+@billing_always_allowed
 async def get_subscription(x_tenant_id: str = Header(...)) -> dict:
     from .main import TENANTS  # inline import to avoid circular deps
 
@@ -58,6 +60,7 @@ async def get_subscription(x_tenant_id: str = Header(...)) -> dict:
 
 
 @router.post("/checkout")
+@billing_always_allowed
 async def checkout(payload: dict, x_tenant_id: str = Header(...)) -> dict:
     plan_id = payload.get("plan_id")
     plan = PLANS.get(plan_id)
@@ -68,6 +71,7 @@ async def checkout(payload: dict, x_tenant_id: str = Header(...)) -> dict:
 
 
 @router.get("/invoices.csv")
+@billing_always_allowed
 async def invoices_csv(x_tenant_id: str = Header(...)) -> Response:
     rows = [inv for inv in INVOICES if inv.tenant_id == x_tenant_id]
     buf = io.StringIO()
@@ -99,6 +103,7 @@ async def invoices_csv(x_tenant_id: str = Header(...)) -> Response:
 
 
 @webhook_router.post("/billing/webhook/mock")
+@billing_always_allowed
 async def mock_webhook(request: Request, x_mock_signature: str = Header(...)) -> dict:
     body = await request.body()
     if not _gateway.verify_webhook(x_mock_signature, body):

--- a/api/app/routes_admin_menu.py
+++ b/api/app/routes_admin_menu.py
@@ -30,6 +30,7 @@ from .models_tenant import MenuItem, TenantMeta
 from .repos_sqlalchemy.menu_repo_sql import MenuRepoSQL
 from .utils.audit import audit
 from .utils.responses import ok
+from .middlewares.license_gate import license_required
 
 router = APIRouter()
 
@@ -40,7 +41,10 @@ class ItemCreate(BaseModel):
     name: str
 
 
-@router.post("/api/outlet/{tenant_id}/menu/items")
+@router.post(
+    "/api/outlet/{tenant_id}/menu/items",
+    dependencies=[license_required()],
+)
 @audit("create_menu_item")
 async def create_menu_item(
     tenant_id: str,
@@ -90,7 +94,10 @@ async def list_menu_items(
     return ok(items)
 
 
-@router.post("/api/outlet/{tenant_id}/menu/item/{item_id}/out_of_stock")
+@router.post(
+    "/api/outlet/{tenant_id}/menu/item/{item_id}/out_of_stock",
+    dependencies=[license_required()],
+)
 @audit("toggle_out_of_stock")
 async def toggle_out_of_stock(
     tenant_id: str,
@@ -128,7 +135,10 @@ async def delete_menu_item(
     return ok({"id": str(item.id), "name": item.name, "deleted_at": item.deleted_at})
 
 
-@router.post("/api/outlet/{tenant_id}/menu/items/{item_id}/restore")
+@router.post(
+    "/api/outlet/{tenant_id}/menu/items/{item_id}/restore",
+    dependencies=[license_required()],
+)
 @audit("item.restore")
 async def restore_menu_item(
     tenant_id: str,
@@ -145,7 +155,10 @@ async def restore_menu_item(
     return ok({"id": str(item.id), "name": item.name, "deleted_at": item.deleted_at})
 
 
-@router.post("/api/outlet/{tenant_id}/menu/i18n/import")
+@router.post(
+    "/api/outlet/{tenant_id}/menu/i18n/import",
+    dependencies=[license_required()],
+)
 @audit("menu_i18n_import")
 async def import_menu_i18n(
     tenant_id: str,

--- a/api/app/routes_billing.py
+++ b/api/app/routes_billing.py
@@ -8,11 +8,13 @@ from datetime import datetime, timedelta
 from fastapi import APIRouter, Header, HTTPException
 
 from .utils.responses import ok
+from .middlewares.license_gate import billing_always_allowed
 
 router = APIRouter()
 
 
 @router.get("/billing")
+@billing_always_allowed
 async def billing_info(x_tenant_id: str = Header(...)) -> dict:
     """Return subscription details and payment link for the tenant."""
     from .main import TENANTS  # inline import to avoid circular deps

--- a/api/app/routes_guest_order.py
+++ b/api/app/routes_guest_order.py
@@ -18,6 +18,7 @@ from .repos_sqlalchemy import orders_repo_sql
 from .routes_metrics import orders_created_total
 from .security import abuse_guard
 from .utils.responses import ok
+from .middlewares.license_gate import license_required
 
 router = APIRouter(prefix="/g")
 
@@ -48,7 +49,7 @@ async def get_tenant_session(
         yield session
 
 
-@router.post("/{table_token}/order")
+@router.post("/{table_token}/order", dependencies=[license_required()])
 async def create_guest_order(
     table_token: str,
     payload: OrderPayload,

--- a/api/app/routes_kds.py
+++ b/api/app/routes_kds.py
@@ -34,6 +34,7 @@ except Exception:  # pragma: no cover - fallback when watchdog unavailable
 from repos_sqlalchemy import orders_repo_sql
 from utils.audit import audit
 from utils.responses import ok
+from .middlewares.license_gate import license_required
 
 from .routes_metrics import kds_oldest_kot_seconds
 
@@ -163,7 +164,10 @@ async def _transition_item(
     return ok({"status": dest.value})
 
 
-@router.post("/api/outlet/{tenant_id}/kds/order/{order_id}/accept")
+@router.post(
+    "/api/outlet/{tenant_id}/kds/order/{order_id}/accept",
+    dependencies=[license_required()],
+)
 @audit("accept_order")
 async def accept_order(tenant_id: str, order_id: int) -> dict:
     """Mark an order as accepted."""
@@ -201,7 +205,10 @@ async def reject_order(tenant_id: str, order_id: int, request: Request) -> dict:
     return result
 
 
-@router.post("/api/outlet/{tenant_id}/kds/item/{order_item_id}/accept")
+@router.post(
+    "/api/outlet/{tenant_id}/kds/item/{order_item_id}/accept",
+    dependencies=[license_required()],
+)
 @audit("accept_item")
 async def accept_item(tenant_id: str, order_item_id: int) -> dict:
     """Mark an order item as accepted."""

--- a/api/app/routes_metrics.py
+++ b/api/app/routes_metrics.py
@@ -99,6 +99,21 @@ webhook_breaker_state = Gauge(
 )
 webhook_breaker_state.labels(url_hash="sample").set(0)
 
+# License enforcement metrics
+license_status_gauge = Gauge(
+    "license_status",
+    "Tenant license status",  # 1 when tenant in given status
+    ["tenant", "status"],
+)
+license_status_gauge.labels(tenant="sample", status="ACTIVE").set(0)
+
+blocked_actions_total = Counter(
+    "blocked_actions_total",
+    "Total actions blocked due to license expiration",
+    ["route"],
+)
+blocked_actions_total.labels(route="/sample").inc(0)
+
 db_replica_healthy = Gauge(
     "db_replica_healthy", "Replica database health (1 healthy, 0 unhealthy)"
 )

--- a/api/tests/test_license_gate.py
+++ b/api/tests/test_license_gate.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import types
+from datetime import datetime, timedelta
+
+import fakeredis.aioredis
+import pytest
+from fastapi.testclient import TestClient
+
+# stub optional deps
+sys.modules.setdefault("opentelemetry", types.ModuleType("opentelemetry"))
+sys.modules.setdefault("opentelemetry.trace", types.ModuleType("trace"))
+sys.modules.setdefault("qrcode", types.ModuleType("qrcode"))
+sys.modules.setdefault("jwt", types.ModuleType("jwt"))
+
+os.environ.setdefault("ALLOWED_ORIGINS", "*")
+os.environ.setdefault("POSTGRES_MASTER_URL", "postgresql://localhost")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+
+import api.app.main as app_main  # noqa: E402
+
+TENANTS = app_main.TENANTS
+app = app_main.app
+
+
+@pytest.fixture
+def client():
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    app_main.subscription_guard.ttl = 1
+    client = TestClient(app, raise_server_exceptions=False)
+    yield client
+    TENANTS.clear()
+
+
+def _create_tenant(client) -> str:
+    resp = client.post("/tenants", params={"name": "t1", "licensed_tables": 2})
+    return resp.json()["data"]["tenant_id"]
+
+
+def test_active_allows_orders(client):
+    tid = _create_tenant(client)
+    TENANTS[tid]["subscription_expires_at"] = datetime.utcnow() + timedelta(days=10)
+    payload = {"tenant_id": tid, "open_tables": 0}
+    headers = {"X-Tenant-ID": tid}
+    resp = client.post("/orders", json=payload, headers=headers)
+    assert resp.status_code == 200
+
+
+def test_expired_blocks_orders(client):
+    tid = _create_tenant(client)
+    TENANTS[tid]["subscription_expires_at"] = datetime.utcnow() - timedelta(days=8)
+    payload = {"tenant_id": tid, "open_tables": 0}
+    headers = {"X-Tenant-ID": tid}
+    resp = client.post("/orders", json=payload, headers=headers)
+    assert resp.status_code == 402
+    data = resp.json()
+    assert data["error"]["message"]["code"] == "SUBSCRIPTION_EXPIRED"
+
+
+def test_billing_route_bypass(client, monkeypatch):
+    tid = _create_tenant(client)
+    TENANTS[tid]["subscription_expires_at"] = datetime.utcnow() - timedelta(days=8)
+    headers = {"X-Tenant-ID": tid}
+    resp = client.get("/admin/billing/subscription", headers=headers)
+    assert resp.status_code == 200
+
+
+def test_cache_refresh_after_renewal(client):
+    tid = _create_tenant(client)
+    TENANTS[tid]["subscription_expires_at"] = datetime.utcnow() - timedelta(days=8)
+    payload = {"tenant_id": tid, "open_tables": 0}
+    headers = {"X-Tenant-ID": tid}
+    resp = client.post("/orders", json=payload, headers=headers)
+    assert resp.status_code == 402
+    TENANTS[tid]["subscription_expires_at"] = datetime.utcnow() + timedelta(days=5)
+    import time
+
+    time.sleep(1.2)
+    resp2 = client.post("/orders", json=payload, headers=headers)
+    assert resp2.status_code == 200

--- a/docs/BILLING.md
+++ b/docs/BILLING.md
@@ -13,3 +13,15 @@ The mock payment gateway posts events to `/billing/webhook/mock` with an `X-Mock
 ## Swapping Gateways
 
 `BillingGateway` is a small interface with `create_checkout_session`, `verify_webhook` and `list_payments`. A real UPI or payment processor can replace `MockGateway` by implementing the same interface and wiring it into the billing routes.
+
+## License enforcement
+
+Tenant access is gated based on subscription expiry. The middleware resolves the tenant and classifies the license status:
+
+| Status  | Description                              | Allowed routes                          |
+|---------|------------------------------------------|-----------------------------------------|
+| ACTIVE  | Current period valid                     | All routes                              |
+| GRACE   | Expired but within grace window          | Reads and writes, banner shown          |
+| EXPIRED | Beyond grace period                      | Read-only views; writes return HTTP 402 |
+
+Billing endpoints such as `/admin/billing/*` and `/billing/webhook/*` bypass the gate so owners can always renew.

--- a/templates/base_admin.html
+++ b/templates/base_admin.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block title %}Admin{% endblock %}</title>
+  </head>
+  <body>
+    {% if request.state.license_status == 'GRACE' %}
+    <div class="banner">Subscription ends in {{request.state.license_days_left}} days <a href="/admin/billing">Renew</a></div>
+    {% elif request.state.license_status == 'EXPIRED' %}
+    <div class="banner expired">Subscription expired — renew to resume orders <a href="/admin/billing">Renew</a></div>
+    {% endif %}
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/templates/base_guest.html
+++ b/templates/base_guest.html
@@ -5,6 +5,11 @@
     <title>{% block title %}Guest{% endblock %}</title>
   </head>
   <body>
+    {% if request.state.license_status == 'GRACE' %}
+    <div class="banner">Subscription ends in {{request.state.license_days_left}} days <a href="/admin/billing">Renew</a></div>
+    {% elif request.state.license_status == 'EXPIRED' %}
+    <div class="banner expired">Subscription expired — renew to resume orders <a href="/admin/billing">Renew</a></div>
+    {% endif %}
     <header>
       <select id="lang-switcher">
         {% for code in request.app.state.enabled_langs %}

--- a/templates/base_kds.html
+++ b/templates/base_kds.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block title %}KDS{% endblock %}</title>
+  </head>
+  <body>
+    {% if request.state.license_status == 'EXPIRED' %}
+    <div class="overlay">LICENSE EXPIRED</div>
+    {% elif request.state.license_status == 'GRACE' %}
+    <div class="banner">Subscription ends in {{request.state.license_days_left}} days <a href="/admin/billing">Renew</a></div>
+    {% endif %}
+    {% block content %}{% endblock %}
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- enforce tenant subscription status via LicenseGate middleware and helpers
- surface subscription banners across guest/admin/KDS templates
- track license status and blocked actions via Prometheus metrics

## Testing
- `PYTHONPATH=. pytest api/tests/test_license_gate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b003852c14832aa517a8e0f618b882