### PR TITLE
ci: start api before lighthouse checks

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -34,6 +34,8 @@ jobs:
       SQLALCHEMY_DATABASE_URI: postgresql://neo:neo@localhost:5432/neo
       SYNC_DATABASE_URL: postgresql://neo:neo@localhost:5432/neo
       REDIS_URL: redis://localhost:6379/0
+      ALLOWED_ORIGINS: http://localhost
+      SECRET_KEY: 0123456789abcdef0123456789abcdef
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -57,8 +59,16 @@ jobs:
       - name: Run migrations
         run: |
           python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
+      - name: Start API server
+        env:
+          ALLOWED_ORIGINS: ${{ env.ALLOWED_ORIGINS }}
+          SECRET_KEY: ${{ env.SECRET_KEY }}
+          SYNC_DATABASE_URL: ${{ env.SYNC_DATABASE_URL }}
+        run: |
+          set +e
+          uvicorn api.app.main:app --host 0.0.0.0 --port 8000 > api.log 2>&1 &
       - name: Wait for /ready
-        run: bash scripts/ci_wait_ready.sh
+        run: bash scripts/ci_wait_ready.sh api.log
       - name: Run Lighthouse CI
         run: lhci autorun --config=lighthouserc.json
 

--- a/scripts/ci_wait_ready.sh
+++ b/scripts/ci_wait_ready.sh
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+LOG_FILE=${1:-api.log}
+
+if ! npx --yes wait-on tcp:localhost:8000 --timeout 60000; then
+  echo "Port 8000 did not open in time" >&2
+  ps aux
+  [[ -f "$LOG_FILE" ]] && cat "$LOG_FILE"
+  exit 1
+fi
+
 for i in {1..40}; do
-  curl -fsS http://localhost:8000/ready && exit 0
+  if curl -fsS --max-time 5 http://localhost:8000/ready; then
+    exit 0
+  fi
   sleep 2
 done
+
 echo "API not ready" >&2
+ps aux
+[[ -f "$LOG_FILE" ]] && cat "$LOG_FILE"
 exit 1


### PR DESCRIPTION
## Summary
- ensure FastAPI server starts before Lighthouse waits
- wait for TCP port and surface logs if the API fails to become ready

## Testing
- `pre-commit run --files scripts/ci_wait_ready.sh .github/workflows/lighthouse.yml`
- `pytest -q` *(fails: Interrupted: 104 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b0052a1a40832aaa701bbce8308b5b