### PR TITLE
fix: remove unused credit note import

### DIFF
--- a/api/app/routes_admin_billing.py
+++ b/api/app/routes_admin_billing.py
@@ -19,7 +19,7 @@ from .billing import (
     MockGateway,
     SubscriptionEvent,
 )
-from .billing.invoice_service import create_invoice, create_credit_note
+from .billing.invoice_service import create_invoice
 from .utils.responses import ok
 from .middlewares.license_gate import billing_always_allowed
 from .db import SessionLocal


### PR DESCRIPTION
## Summary
- remove unused `create_credit_note` import from admin billing routes

## Testing
- `ruff check`
- `pytest -q` *(fails: import file mismatch in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b01c96ac8c832a9b94ee689450c701