### PR TITLE
feat: add referral signup rate limit and credit guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - 24×7 synthetic order monitor with CI alerts and dashboards.
 - Floor map editor with live table status (SSE/WS).
 - Validate async DB URLs for Alembic migrations and expose `SYNC_DATABASE_URL` in Lighthouse workflow.
+- Referral signup rate limiting and credit caps via `REFERRAL_MAX_CREDITS` with self-referral safeguards.
 
 ### Fixed
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -164,6 +164,7 @@ from .routes_menu_i18n import router as menu_i18n_router
 from .routes_metrics import router as metrics_router
 from .routes_metrics import ws_messages_total
 from .routes_onboarding import router as onboarding_router
+from .routes_referrals import router as referrals_router
 from .routes_order_void import router as order_void_router
 from .routes_orders_batch import router as orders_batch_router
 from .routes_outbox_admin import router as outbox_admin_router
@@ -898,6 +899,7 @@ app.include_router(billing_router)
 app.include_router(admin_billing_router)
 app.include_router(billing_webhook_router)
 app.include_router(onboarding_router)
+app.include_router(referrals_router)
 app.include_router(qrpack_router)
 app.include_router(order_void_router)
 

--- a/api/app/routes_referrals.py
+++ b/api/app/routes_referrals.py
@@ -1,0 +1,109 @@
+"""Referral signup and credit award routes."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Set
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from .routes_onboarding import TENANTS
+from .security import ratelimit
+from .utils import ratelimits
+from .utils.rate_limit import rate_limited
+from .utils.responses import ok
+
+router = APIRouter()
+
+# Environment configuration
+REFERRAL_MAX_CREDITS = int(os.getenv("REFERRAL_MAX_CREDITS", "5000"))
+
+# In-memory stores for demo purposes
+REFERRAL_CREDITS: Dict[str, int] = {}
+SUBSCRIPTION_EVENTS: Set[str] = set()
+
+
+class SignupPayload(BaseModel):
+    """Incoming referral signup attribution payload."""
+
+    referrer_tenant_id: str
+    email: str
+    phone: str | None = None
+
+
+@router.post("/referrals/signup")
+async def referral_signup(payload: SignupPayload, request: Request):
+    """Attribution endpoint for referred signups.
+
+    Applies IP based rate limits and blocks self referrals using owner
+    email/phone metadata looked up from :mod:`routes_onboarding` ``TENANTS``.
+    """
+
+    ip = request.client.host if request.client else "unknown"
+    policy = ratelimits.referral_signup()
+    allowed = await ratelimit.allow(
+        request.app.state.redis,
+        ip,
+        "referral_signup",
+        rate_per_min=policy.rate_per_min,
+        burst=policy.burst,
+    )
+    if not allowed:
+        retry_after = await request.app.state.redis.ttl(
+            f"ratelimit:{ip}:referral_signup"
+        )
+        return rate_limited(retry_after)
+
+    referrer = TENANTS.get(payload.referrer_tenant_id)
+    if referrer:
+        owner = referrer.get("owner", {})
+        if payload.email == owner.get("email") or (
+            payload.phone and payload.phone == owner.get("phone")
+        ):
+            raise HTTPException(status_code=400, detail="self-referral")
+
+    return ok(True)
+
+
+class CreditPayload(BaseModel):
+    """Payload for awarding referral credits."""
+
+    event_id: str
+    referrer_tenant_id: str
+    amount_inr: int
+    invoice_amount_inr: int
+    plan_price_inr: int
+
+
+@router.post("/referrals/credit")
+async def referral_credit(payload: CreditPayload):
+    """Award referral credit if eligibility checks pass.
+
+    Ensures idempotency using ``subscription_events`` and caps credits per
+    referrer based on ``REFERRAL_MAX_CREDITS``.
+    """
+
+    if payload.event_id in SUBSCRIPTION_EVENTS:
+        return ok({"awarded": 0})
+    SUBSCRIPTION_EVENTS.add(payload.event_id)
+
+    if payload.invoice_amount_inr < payload.plan_price_inr:
+        return ok({"awarded": 0})
+
+    current = REFERRAL_CREDITS.get(payload.referrer_tenant_id, 0)
+    remaining = REFERRAL_MAX_CREDITS - current
+    if remaining <= 0:
+        return ok({"awarded": 0})
+
+    credit = min(payload.amount_inr, remaining)
+    REFERRAL_CREDITS[payload.referrer_tenant_id] = current + credit
+    return ok({"awarded": credit})
+
+
+__all__ = [
+    "router",
+    "REFERRAL_MAX_CREDITS",
+    "REFERRAL_CREDITS",
+    "SUBSCRIPTION_EVENTS",
+]

--- a/api/app/utils/ratelimits.py
+++ b/api/app/utils/ratelimits.py
@@ -51,6 +51,11 @@ def two_factor_verify() -> Policy:
     return _policy("two_factor_verify", 5, 5)
 
 
+def referral_signup() -> Policy:
+    """Limit referred signups per IP."""
+    return _policy("referral_signup", 5 / 60, 5)
+
+
 __all__ = [
     "Policy",
     "guest_order",
@@ -59,4 +64,5 @@ __all__ = [
     "qrpack",
     "exports",
     "two_factor_verify",
+    "referral_signup",
 ]

--- a/api/tests/test_referrals.py
+++ b/api/tests/test_referrals.py
@@ -1,0 +1,85 @@
+import importlib
+import pathlib
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import fakeredis.aioredis
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from api.app.routes_onboarding import TENANTS
+import api.app.routes_referrals as referrals
+
+
+def _setup_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(referrals.router)
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    return app
+
+
+def test_referral_signup_self_and_ratelimit(monkeypatch):
+    monkeypatch.setenv("RL_REFERRAL_SIGNUP_BURST", "1")
+    monkeypatch.setenv("RL_REFERRAL_SIGNUP_RPM", "1")
+    importlib.reload(referrals)
+
+    TENANTS.clear()
+    TENANTS["t1"] = {"owner": {"email": "a@example.com", "phone": "123"}}
+
+    app = _setup_app()
+    client = TestClient(app)
+
+    # self-referral by email
+    resp = client.post(
+        "/referrals/signup",
+        json={"referrer_tenant_id": "t1", "email": "a@example.com", "phone": "999"},
+    )
+    assert resp.status_code == 400
+
+    # fresh app for rate limit test
+    app = _setup_app()
+    client = TestClient(app)
+    payload = {"referrer_tenant_id": "t1", "email": "b@example.com", "phone": "999"}
+    assert client.post("/referrals/signup", json=payload).status_code == 200
+    assert client.post("/referrals/signup", json=payload).status_code == 429
+
+
+def test_referral_credit_cap_invoice_idempotent(monkeypatch):
+    monkeypatch.setenv("REFERRAL_MAX_CREDITS", "100")
+    importlib.reload(referrals)
+    referrals.REFERRAL_CREDITS.clear()
+    referrals.SUBSCRIPTION_EVENTS.clear()
+
+    app = _setup_app()
+    client = TestClient(app)
+
+    payload = {
+        "event_id": "e1",
+        "referrer_tenant_id": "t1",
+        "amount_inr": 60,
+        "invoice_amount_inr": 100,
+        "plan_price_inr": 50,
+    }
+    assert client.post("/referrals/credit", json=payload).json()["data"]["awarded"] == 60
+
+    payload2 = {
+        "event_id": "e2",
+        "referrer_tenant_id": "t1",
+        "amount_inr": 60,
+        "invoice_amount_inr": 100,
+        "plan_price_inr": 50,
+    }
+    assert client.post("/referrals/credit", json=payload2).json()["data"]["awarded"] == 40
+
+    payload3 = {
+        "event_id": "e3",
+        "referrer_tenant_id": "t1",
+        "amount_inr": 10,
+        "invoice_amount_inr": 40,
+        "plan_price_inr": 50,
+    }
+    assert client.post("/referrals/credit", json=payload3).json()["data"]["awarded"] == 0
+
+    # replay event should be idempotent
+    assert client.post("/referrals/credit", json=payload2).json()["data"]["awarded"] == 0


### PR DESCRIPTION
## Summary
- add referral signup endpoint with IP rate limiting and self-referral checks
- enforce REFERRAL_MAX_CREDITS when awarding credits with invoice and idempotency safeguards
- document referral limits in changelog and add tests

## Testing
- `pytest api/tests/test_referrals.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b020a04ad0832ab8fb39b1ad1e945a