### PR TITLE
Use build_renew_url in dunning banners

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -75,6 +75,10 @@ from .events import alerts_sender, ema_updater, event_bus, report_aggregator
 from .hooks import order_rejection
 from .hooks.table_map import publish_table_state
 from .i18n import get_msg, resolve_lang
+from .dunning import build_renew_url
+
+template_globals = {"build_renew_url": build_renew_url}
+
 from .menu import router as menu_router
 from .middleware import RateLimitMiddleware
 from .middlewares import (

--- a/api/app/routes_floor.py
+++ b/api/app/routes_floor.py
@@ -10,6 +10,8 @@ from fastapi.responses import StreamingResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
+from .main import template_globals
+
 from .auth import User, role_required
 from .db import SessionLocal
 from .models_tenant import Table
@@ -18,6 +20,7 @@ from .utils.responses import ok
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
+templates.env.globals.update(template_globals)
 
 
 class TableGeom(BaseModel):

--- a/api/app/routes_support_console.py
+++ b/api/app/routes_support_console.py
@@ -9,6 +9,8 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from fastapi.templating import Jinja2Templates
 
+from .main import template_globals
+
 from .auth import User, get_current_user, role_required
 from .db import SessionLocal
 from .models_master import Tenant
@@ -19,6 +21,7 @@ from .utils.responses import err, ok
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
+templates.env.globals.update(template_globals)
 
 
 _MACRO_FILE = pathlib.Path(__file__).resolve().parents[2] / "docs" / "SUPPORT_MACROS.md"

--- a/templates/base_admin.html
+++ b/templates/base_admin.html
@@ -12,7 +12,7 @@
       {% else %}
       Subscription expired — renew to resume orders
       {% endif %}
-      <a href="/admin/billing">Renew now</a>
+      <a href="{{ build_renew_url(request.state.plan, request.url.path, 'T+0') }}">Renew now</a>
       <a href="#" class="snooze" onclick="document.cookie='dunning_snooze=1;path=/;expires='+new Date(new Date().setHours(24,0,0,0)).toUTCString(); this.parentElement.remove(); return false;">Snooze for today</a>
     </div>
     {% endif %}

--- a/templates/base_kds.html
+++ b/templates/base_kds.html
@@ -12,7 +12,7 @@
       {% else %}
       Subscription expired — renew to resume orders
       {% endif %}
-      <a href="/admin/billing">Renew now</a>
+      <a href="{{ build_renew_url(request.state.plan, request.url.path, 'T+0') }}">Renew now</a>
       <a href="#" class="snooze" onclick="document.cookie='dunning_snooze=1;path=/;expires='+new Date(new Date().setHours(24,0,0,0)).toUTCString(); this.parentElement.remove(); return false;">Snooze for today</a>
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- replace hardcoded billing links with build_renew_url in admin and KDS templates
- expose build_renew_url to Jinja template globals for banner rendering

## Testing
- `pytest` *(fails: Missing required environment variables: POSTGRES_MASTER_URL)*
- `PYTHONPATH=. pytest api/tests/test_dunning.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0215a3004832a8b86f89bb75faa9f