### PR TITLE
chore: update lighthouse URLs for dev server

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -2,9 +2,9 @@
   "ci": {
     "collect": {
       "url": [
-        "http://localhost:8000/guest",
-        "http://localhost:8000/admin",
-        "http://localhost:8000/kds"
+        "http://localhost:5173/guest",
+        "http://localhost:5173/admin",
+        "http://localhost:5173/kds"
       ],
       "numberOfRuns": 1,
       "output": ["html"],


### PR DESCRIPTION
## Summary
- point Lighthouse CI config to Vite dev server routes

## Testing
- `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5173/guest`
- `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5173/admin`
- `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5173/kds`
- `npx -y @lhci/cli autorun --config=lighthouserc.json` *(fails: Invalid timing metric: interaction-to-next-paint)*


------
https://chatgpt.com/codex/tasks/task_e_68b01df4fc90832aa4b625c8e9096f6f