### PR TITLE
fix: migrate tenant before seeding

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -44,11 +44,16 @@ jobs:
           pip install -r api/requirements.txt
           pip install pytest pytest-cov pillow
           if [ "${{ matrix.db }}" = "postgres" ]; then pip install asyncpg; fi
-      - name: Run tenant migrations
+      - name: Prepare tenant database
         if: matrix.db == 'postgres'
+        env:
+          TENANT_ID: demo
         run: |
-          python scripts/tenant_create_db.py --tenant demo
-          python scripts/tenant_seed.py --tenant demo
+          python scripts/tenant_create_db.py --tenant "$TENANT_ID"
+          python scripts/tenant_migrate.py --tenant "$TENANT_ID"
+          TENANT_DSN=$(python -c "from api.app.db.tenant import build_dsn; import os; print(build_dsn(os.environ['TENANT_ID']).replace('+asyncpg',''))")
+          psql "$TENANT_DSN" -c '\dt'
+          python scripts/tenant_seed.py --tenant "$TENANT_ID"
       - name: Lint
         run: pre-commit run --all-files --show-diff-on-failure
       - name: Audit environment


### PR DESCRIPTION
## Summary
- run tenant migrations before seeding in CI
- enforce autocommit when provisioning tenant DBs
- fail fast if tenant migrations are missing before seeding

## Testing
- `pre-commit run --files scripts/tenant_create_db.py scripts/tenant_seed.py .github/workflows/python-tests.yml`
- `pytest -q` *(fails: tests/test_alembic_env.py, tests/test_analytics_outlets.py, tests/test_export_streaming.py, tests/test_kds_expo.py, tests/test_rum_vitals.py, tests/test_slo_metrics.py, tests/test_time_skew.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b0273179fc832ab45d562966a6507f