### PR TITLE
feat: centralize shared configs

### DIFF
--- a/e2e/playwright/package.json
+++ b/e2e/playwright/package.json
@@ -6,6 +6,7 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "^1.43.0"
+    "@playwright/test": "^1.43.0",
+    "@neo/config": "file:../../packages/config"
   }
 }

--- a/e2e/playwright/tsconfig.json
+++ b/e2e/playwright/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@neo/config/tsconfig.json",
+  "include": ["./"]
+}

--- a/packages/config/eslint.cjs
+++ b/packages/config/eslint.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  env: { browser: true, es2021: true },
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  parserOptions: {
+    ecmaFeatures: { jsx: true },
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['react'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+  },
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@neo/config",
+  "version": "1.0.0",
+  "private": true,
+  "exports": {
+    "./eslint": "./eslint.cjs",
+    "./prettier": "./prettier.cjs",
+    "./tsconfig": "./tsconfig.json",
+    "./vite": "./vite.cjs"
+  }
+}

--- a/packages/config/prettier.cjs
+++ b/packages/config/prettier.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  semi: false,
+  singleQuote: true,
+}

--- a/packages/config/tsconfig.cjs
+++ b/packages/config/tsconfig.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./tsconfig.json')

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/packages/config/vite.cjs
+++ b/packages/config/vite.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  server: {
+    port: 3000,
+  },
+  resolve: {
+    alias: {
+      '@': '/src',
+    },
+  },
+}

--- a/pwa/.prettierrc
+++ b/pwa/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "singleQuote": true,
-  "semi": false
-}

--- a/pwa/eslint.config.cjs
+++ b/pwa/eslint.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('@neo/config/eslint')

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "prettier --check src",
+    "lint": "eslint . && prettier --check src",
     "format": "prettier --write src",
     "test": "jest"
   },
@@ -26,6 +26,9 @@
     "@babel/preset-typescript": "^7.22.0",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
+    "@neo/config": "file:../packages/config",
+    "eslint": "^8.49.0",
+    "eslint-plugin-react": "^7.33.2",
     "babel-jest": "^29.6.0",
     "jest": "^29.6.0",
     "jest-environment-jsdom": "^29.6.0"

--- a/pwa/prettier.config.cjs
+++ b/pwa/prettier.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('@neo/config/prettier')

--- a/pwa/tsconfig.json
+++ b/pwa/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@neo/config/tsconfig.json",
+  "include": ["src"]
+}

--- a/pwa/vite.config.js
+++ b/pwa/vite.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import baseConfig from '@neo/config/vite'
 
 export default defineConfig({
+  ...baseConfig,
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- add `@neo/config` package exporting base eslint, prettier, tsconfig, and vite settings
- consume shared configs in pwa and e2e packages

## Testing
- `pre-commit run --files packages/config/eslint.cjs packages/config/prettier.cjs packages/config/tsconfig.json packages/config/tsconfig.cjs packages/config/vite.cjs packages/config/package.json pwa/prettier.config.cjs pwa/eslint.config.cjs pwa/vite.config.js pwa/package.json pwa/tsconfig.json e2e/playwright/package.json e2e/playwright/tsconfig.json`
- `cd pwa && npm test`
- `cd ../e2e/playwright && npm test` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b0285c5b40832ab2a4bc5646b8c61c