### PR TITLE
ci: refine deploy env gates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
   deploy-staging:
     needs: build-and-push
-    if: ${{ env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    if: env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -93,15 +93,14 @@ jobs:
     env:
       KUBE_CONFIG_STAGING: ${{ secrets.KUBE_CONFIG_STAGING }}
       KUBE_CONFIG_PROD: ${{ secrets.KUBE_CONFIG_PROD }}
-    environment:
-      name: production
+    environment: prod
     steps:
       - name: Awaiting approval
         run: echo "Manual approval required to deploy to production"
 
   deploy-prod:
     needs: manual-approval
-    if: ${{ env.KUBE_CONFIG_PROD != '' && env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    if: env.KUBE_CONFIG_PROD != '' && env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     environment: prod
     env:


### PR DESCRIPTION
## Summary
- gate deploy jobs using env context instead of secrets
- set manual approval job to use prod environment

## Testing
- `act -n -W .github/workflows/deploy.yml` *(fails: Unknown Variable Access env)*

------
https://chatgpt.com/codex/tasks/task_e_68b02e1d09b4832a8c1b2cfcfde72f64