### PR TITLE
Scaffold state and form hooks across apps

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -11,28 +11,29 @@
     "test": "echo 'no tests'"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
+    "@neo/api": "workspace:*",
+    "@neo/ui": "workspace:*",
+    "@neo/utils": "workspace:*",
+    "@tanstack/react-query": "^5.40.1",
+    "i18next": "^23.8.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3",
-    "@tanstack/react-query": "^5.40.1",
-    "zustand": "^4.5.2",
     "react-hook-form": "^7.49.3",
-    "zod": "^3.22.2",
     "react-i18next": "^13.0.2",
-    "i18next": "^23.8.2",
+    "react-router-dom": "^6.22.3",
     "workbox-window": "^7.0.0",
-    "@neo/ui": "workspace:*",
-    "@neo/api": "workspace:*",
-    "@neo/utils": "workspace:*"
+    "zod": "^3.22.2",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
-    "vite": "^5.1.4",
-    "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.0.0",
-    "tailwindcss": "^3.4.0",
-    "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0",
     "@neo/config": "workspace:*",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.1.4",
     "workbox-precaching": "^7.0.0"
   }
 }

--- a/apps/admin/src/components/DemoForm.tsx
+++ b/apps/admin/src/components/DemoForm.tsx
@@ -1,0 +1,29 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCounterStore } from '../store';
+
+const schema = z.object({
+  name: z.string().min(1, 'Name is required'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export function DemoForm() {
+  const inc = useCounterStore((s) => s.inc);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+  });
+
+  return (
+    <form onSubmit={handleSubmit(() => inc())}>
+      <input {...register('name')} />
+      {errors.name && <p>{errors.name.message}</p>}
+      <button type="submit">Submit</button>
+    </form>
+  );
+}

--- a/apps/admin/src/pages/HealthPage.tsx
+++ b/apps/admin/src/pages/HealthPage.tsx
@@ -1,14 +1,29 @@
 import { useEffect, useState } from 'react';
 import { API_BASE } from '../env';
+import { useCounterStore } from '../store';
+import { DemoForm } from '../components/DemoForm';
 
 export function HealthPage() {
   const [ok, setOk] = useState(false);
+  const count = useCounterStore((s) => s.count);
+
   useEffect(() => {
     fetch(`${API_BASE}/status.json`)
       .then((r) => setOk(r.ok))
       .catch(() => setOk(false));
   }, []);
+
   return (
-    <div className={ok ? 'w-3 h-3 rounded-full bg-green-500' : 'w-3 h-3 rounded-full bg-red-500'} />
+    <div className="space-y-2">
+      <div
+        className={
+          ok
+            ? 'w-3 h-3 rounded-full bg-green-500'
+            : 'w-3 h-3 rounded-full bg-red-500'
+        }
+      />
+      <div>{count}</div>
+      <DemoForm />
+    </div>
   );
 }

--- a/apps/admin/src/store.ts
+++ b/apps/admin/src/store.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface CounterState {
+  count: number;
+  inc: () => void;
+}
+
+export const useCounterStore = create<CounterState>((set) => ({
+  count: 0,
+  inc: () => set((s) => ({ count: s.count + 1 })),
+}));

--- a/apps/guest/package.json
+++ b/apps/guest/package.json
@@ -11,28 +11,29 @@
     "test": "echo 'no tests'"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
+    "@neo/api": "workspace:*",
+    "@neo/ui": "workspace:*",
+    "@neo/utils": "workspace:*",
+    "@tanstack/react-query": "^5.40.1",
+    "i18next": "^23.8.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3",
-    "@tanstack/react-query": "^5.40.1",
-    "zustand": "^4.5.2",
     "react-hook-form": "^7.49.3",
-    "zod": "^3.22.2",
     "react-i18next": "^13.0.2",
-    "i18next": "^23.8.2",
+    "react-router-dom": "^6.22.3",
     "workbox-window": "^7.0.0",
-    "@neo/ui": "workspace:*",
-    "@neo/api": "workspace:*",
-    "@neo/utils": "workspace:*"
+    "zod": "^3.22.2",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
-    "vite": "^5.1.4",
-    "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.0.0",
-    "tailwindcss": "^3.4.0",
-    "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0",
     "@neo/config": "workspace:*",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.1.4",
     "workbox-precaching": "^7.0.0"
   }
 }

--- a/apps/guest/src/components/DemoForm.tsx
+++ b/apps/guest/src/components/DemoForm.tsx
@@ -1,0 +1,29 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCounterStore } from '../store';
+
+const schema = z.object({
+  name: z.string().min(1, 'Name is required'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export function DemoForm() {
+  const inc = useCounterStore((s) => s.inc);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+  });
+
+  return (
+    <form onSubmit={handleSubmit(() => inc())}>
+      <input {...register('name')} />
+      {errors.name && <p>{errors.name.message}</p>}
+      <button type="submit">Submit</button>
+    </form>
+  );
+}

--- a/apps/guest/src/pages/HealthPage.tsx
+++ b/apps/guest/src/pages/HealthPage.tsx
@@ -1,14 +1,29 @@
 import { useEffect, useState } from 'react';
 import { API_BASE } from '../env';
+import { useCounterStore } from '../store';
+import { DemoForm } from '../components/DemoForm';
 
 export function HealthPage() {
   const [ok, setOk] = useState(false);
+  const count = useCounterStore((s) => s.count);
+
   useEffect(() => {
     fetch(`${API_BASE}/status.json`)
       .then((r) => setOk(r.ok))
       .catch(() => setOk(false));
   }, []);
+
   return (
-    <div className={ok ? 'w-3 h-3 rounded-full bg-green-500' : 'w-3 h-3 rounded-full bg-red-500'} />
+    <div className="space-y-2">
+      <div
+        className={
+          ok
+            ? 'w-3 h-3 rounded-full bg-green-500'
+            : 'w-3 h-3 rounded-full bg-red-500'
+        }
+      />
+      <div>{count}</div>
+      <DemoForm />
+    </div>
   );
 }

--- a/apps/guest/src/store.ts
+++ b/apps/guest/src/store.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface CounterState {
+  count: number;
+  inc: () => void;
+}
+
+export const useCounterStore = create<CounterState>((set) => ({
+  count: 0,
+  inc: () => set((s) => ({ count: s.count + 1 })),
+}));

--- a/apps/kds/package.json
+++ b/apps/kds/package.json
@@ -11,28 +11,29 @@
     "test": "echo 'no tests'"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
+    "@neo/api": "workspace:*",
+    "@neo/ui": "workspace:*",
+    "@neo/utils": "workspace:*",
+    "@tanstack/react-query": "^5.40.1",
+    "i18next": "^23.8.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3",
-    "@tanstack/react-query": "^5.40.1",
-    "zustand": "^4.5.2",
     "react-hook-form": "^7.49.3",
-    "zod": "^3.22.2",
     "react-i18next": "^13.0.2",
-    "i18next": "^23.8.2",
+    "react-router-dom": "^6.22.3",
     "workbox-window": "^7.0.0",
-    "@neo/ui": "workspace:*",
-    "@neo/api": "workspace:*",
-    "@neo/utils": "workspace:*"
+    "zod": "^3.22.2",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
-    "vite": "^5.1.4",
-    "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.0.0",
-    "tailwindcss": "^3.4.0",
-    "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0",
     "@neo/config": "workspace:*",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.1.4",
     "workbox-precaching": "^7.0.0"
   }
 }

--- a/apps/kds/src/components/DemoForm.tsx
+++ b/apps/kds/src/components/DemoForm.tsx
@@ -1,0 +1,29 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useCounterStore } from '../store';
+
+const schema = z.object({
+  name: z.string().min(1, 'Name is required'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export function DemoForm() {
+  const inc = useCounterStore((s) => s.inc);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+  });
+
+  return (
+    <form onSubmit={handleSubmit(() => inc())}>
+      <input {...register('name')} />
+      {errors.name && <p>{errors.name.message}</p>}
+      <button type="submit">Submit</button>
+    </form>
+  );
+}

--- a/apps/kds/src/pages/HealthPage.tsx
+++ b/apps/kds/src/pages/HealthPage.tsx
@@ -1,14 +1,29 @@
 import { useEffect, useState } from 'react';
 import { API_BASE } from '../env';
+import { useCounterStore } from '../store';
+import { DemoForm } from '../components/DemoForm';
 
 export function HealthPage() {
   const [ok, setOk] = useState(false);
+  const count = useCounterStore((s) => s.count);
+
   useEffect(() => {
     fetch(`${API_BASE}/status.json`)
       .then((r) => setOk(r.ok))
       .catch(() => setOk(false));
   }, []);
+
   return (
-    <div className={ok ? 'w-3 h-3 rounded-full bg-green-500' : 'w-3 h-3 rounded-full bg-red-500'} />
+    <div className="space-y-2">
+      <div
+        className={
+          ok
+            ? 'w-3 h-3 rounded-full bg-green-500'
+            : 'w-3 h-3 rounded-full bg-red-500'
+        }
+      />
+      <div>{count}</div>
+      <DemoForm />
+    </div>
   );
 }

--- a/apps/kds/src/store.ts
+++ b/apps/kds/src/store.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface CounterState {
+  count: number;
+  inc: () => void;
+}
+
+export const useCounterStore = create<CounterState>((set) => ({
+  count: 0,
+  inc: () => set((s) => ({ count: s.count + 1 })),
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   apps/admin:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.1
+        version: 5.2.1(react-hook-form@7.62.0(react@18.3.1))
       '@neo/api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -90,6 +93,9 @@ importers:
 
   apps/guest:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.1
+        version: 5.2.1(react-hook-form@7.62.0(react@18.3.1))
       '@neo/api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -157,6 +163,9 @@ importers:
 
   apps/kds:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.1
+        version: 5.2.1(react-hook-form@7.62.0(react@18.3.1))
       '@neo/api':
         specifier: workspace:*
         version: link:../../packages/api
@@ -689,6 +698,11 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@hookform/resolvers@5.2.1':
+    resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -841,6 +855,9 @@ packages:
     resolution: {integrity: sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tanstack/query-core@5.85.5':
     resolution: {integrity: sha512-KO0WTob4JEApv69iYp1eGvfMSUkgw//IpMnq+//cORBzXf0smyRwPLrUvEe5qtAEGjwZTXrjxg+oJNP/C00t6w==}
@@ -2074,6 +2091,11 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@hookform/resolvers@5.2.1(react-hook-form@7.62.0(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.62.0(react@18.3.1)
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -2187,6 +2209,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.49.0':
     optional: true
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tanstack/query-core@5.85.5': {}
 


### PR DESCRIPTION
## Summary
- add @hookform/resolvers to app dependencies
- scaffold Zustand counter store
- demo form with zodResolver on health page

## Testing
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_68b030ee4f8c832a9910890fc6f74e63