### PR TITLE
ci: build apps with frozen lockfile

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   build:
@@ -17,19 +18,11 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm typecheck
-      - run: pnpm build
+      - run: pnpm build --filter apps/*
       - uses: actions/upload-artifact@v4
         with:
-          name: guest-dist
-          path: apps/guest/dist
-      - uses: actions/upload-artifact@v4
-        with:
-          name: kds-dist
-          path: apps/kds/dist
-      - uses: actions/upload-artifact@v4
-        with:
-          name: admin-dist
-          path: apps/admin/dist
+          name: apps-dist
+          path: apps/*/dist


### PR DESCRIPTION
## Summary
- build apps workflow installs dependencies with `pnpm install --frozen-lockfile`
- run lint, typecheck, and build for all apps
- upload `apps/*/dist` artifacts on push/PR to main

## Testing
- `pre-commit run --files .github/workflows/ui.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b03b4f49b4832a88e5d671d4193f33