### PR TITLE
fix: correct env context in synthetic monitor

### DIFF
--- a/.github/workflows/synthetic_monitor.yml
+++ b/.github/workflows/synthetic_monitor.yml
@@ -101,11 +101,11 @@ jobs:
     if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
       github.ref == 'refs/heads/main' &&
       !github.event.pull_request.head.repo.fork &&
-      env.API_BASE_URL != '' &&
-      env.SYN_TENANT_ID != '' &&
-      env.SYN_TABLE_CODE != '' &&
-      env.AUTH_TOKEN != '' &&
-      env.SYN_ENABLED_PROD == 'true' }}
+      secrets.API_BASE_URL != '' &&
+      secrets.SYN_TENANT_ID != '' &&
+      secrets.SYN_TABLE_CODE != '' &&
+      secrets.AUTH_TOKEN != '' &&
+      secrets.SYN_ENABLED_PROD == 'true' }}
     runs-on: ubuntu-latest
     environment: prod
     env:


### PR DESCRIPTION
## Summary
- fix synthetic monitor workflow using secrets context in prod job

## Testing
- `pre-commit run --files .github/workflows/synthetic_monitor.yml`
- `pytest` *(fails: Interrupted: 7 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b03b6c90bc832ab85d1b789ca116f6