### PR TITLE
docs: expand app and api guides

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -2,13 +2,38 @@
 
 Each app is a Vite + React shell.
 
-## Running
+## Install
 
 ```bash
 pnpm install
+```
+
+## Develop
+
+```bash
 pnpm dev --filter @neo/guest   # Guest PWA
 pnpm dev --filter @neo/kds     # Kitchen Display
 pnpm dev --filter @neo/admin   # Admin console
 ```
 
-Set `VITE_API_BASE` and `VITE_WS_BASE` in the app's `.env` file.
+## Build
+
+```bash
+pnpm build --filter @neo/guest
+pnpm build --filter @neo/kds
+pnpm build --filter @neo/admin
+```
+
+## Test
+
+```bash
+pnpm test --filter @neo/guest
+pnpm test --filter @neo/kds
+pnpm test --filter @neo/admin
+```
+
+## Environment
+
+Set `VITE_API_BASE` and `VITE_WS_BASE` in each app's `.env` file.
+Serve the built apps over HTTPS with a valid `manifest.webmanifest` and
+`sw.js` service worker to satisfy PWA requirements.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,13 +1,21 @@
 # API Client
 
-Typed API helpers and realtime hooks.
+Typed API helpers and realtime hooks for frontend apps.
 
-## Adding endpoints
+## Overview
 
-Add types and functions in `src/endpoints.ts` and export them from `src/index.ts`.
-Use `apiFetch` for REST calls and `useSSE` / `useWS` for realtime.
+`@neo/api` wraps `fetch` with helpers for base URLs and headers and exposes
+hooks for realtime communication. Consumers typically configure
+`VITE_API_BASE` and `VITE_WS_BASE` environment variables to point to the HTTP
+and WebSocket servers.
 
-## Realtime hooks
+## Adding endpoints and types
+
+Define endpoint functions and `zod` types in `src/endpoints.ts` and export them
+from `src/index.ts`. Use `apiFetch` for REST calls and the hooks below for
+realtime updates.
+
+## Hooks
 
 ### `useSSE`
 
@@ -45,3 +53,6 @@ function App() {
   return null;
 }
 ```
+
+These utilities are PWA‑friendly; serve your app over HTTPS with a registered
+service worker for full functionality.


### PR DESCRIPTION
## Summary
- clarify how to install, develop, build, and test each app
- document required environment variables and PWA hosting needs
- expand API client guide with overview, endpoint instructions, and realtime hook examples

## Testing
- `pnpm test`
- `pytest -q` *(fails: cannot collect tests: multiple errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b03cbf0b00832aa291a197d2042fd7