### PR TITLE
Fix UI workflow filter usage for pnpm build

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -21,7 +21,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm typecheck
-      - run: pnpm build --filter apps/*
+      - run: pnpm -r --filter "./apps/*" build
       - uses: actions/upload-artifact@v4
         with:
           name: apps-dist


### PR DESCRIPTION
## Summary
- avoid passing filter arguments to package build scripts by calling pnpm with filter before command in UI workflow

## Testing
- `pre-commit run --files .github/workflows/ui.yml` *(fails: RuntimeError: failed to build image pip)*
- `pnpm -r --filter "./apps/*" build` *(fails: Module level directives cause errors when bundled)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f0006e4832aa6e478c9277c8c25