### PR TITLE
feat: derive tenant DSN from sync URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,7 +764,9 @@ The script will print `READY` once the database is available.
 
 To apply migrations for an existing tenant database, provide a DSN template via
 ``--dsn-template`` or the ``POSTGRES_TENANT_DSN_TEMPLATE`` environment variable
-(e.g. ``postgresql+asyncpg://u:p@host:5432/tenant_{tenant_id}``) and run:
+(e.g. ``postgresql+asyncpg://u:p@host:5432/tenant_{tenant_id}``). If neither is
+supplied, a template is derived from ``SYNC_DATABASE_URL`` by appending
+``_<tenant_id>`` to its database name. Run:
 
 ```bash
 POSTGRES_TENANT_DSN_TEMPLATE=postgresql+asyncpg://u:p@host:5432/tenant_{tenant_id} \

--- a/api/tests/test_tenant_dsn_fallback.py
+++ b/api/tests/test_tenant_dsn_fallback.py
@@ -1,0 +1,15 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from api.app.db.tenant import build_dsn
+
+
+def test_build_dsn_uses_sync_url_when_template_missing(monkeypatch):
+    monkeypatch.delenv("POSTGRES_TENANT_DSN_TEMPLATE", raising=False)
+    monkeypatch.setenv("SYNC_DATABASE_URL", "postgresql+asyncpg://u:p@host:5432/main")
+    assert (
+        build_dsn("demo")
+        == "postgresql+asyncpg://u:p@host:5432/main_demo"
+    )


### PR DESCRIPTION
## Summary
- fall back to SYNC_DATABASE_URL when POSTGRES_TENANT_DSN_TEMPLATE is unset
- support tenant migrations without manual DSN template
- document and test DSN fallback logic

## Testing
- `ruff check api/app/db/tenant.py scripts/tenant_migrate.py api/tests/test_tenant_dsn_fallback.py`
- `pytest api/tests/test_tenant_dsn_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b03f7ba244832aa93a699b69c0fef8