### PR TITLE
chore: enable lighthouse server and build PWA

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -6,6 +6,7 @@
         "http://localhost:5174/",
         "http://localhost:5175/"
       ],
+      "startServerCommand": "pnpm --filter pwa preview --port 5173",
       "numberOfRuns": 1,
       "output": ["html"],
       "reportFilenamePattern": "%%PATHNAME%%-lighthouse.%%EXTENSION%%",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+  - 'pwa'

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -26,6 +26,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
-    <script src="/static/js/pwa_update.js"></script>
   </body>
 </html>

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "preview": "vite preview",
     "lint": "eslint . && prettier --check src",
     "format": "prettier --write src",
     "test": "jest"

--- a/pwa/src/main.jsx
+++ b/pwa/src/main.jsx
@@ -58,4 +58,26 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('/static/sw.js')
+  navigator.serviceWorker.addEventListener('message', (event) => {
+    if (event.data?.type === 'UPDATE_READY') {
+      const banner = document.createElement('div')
+      banner.textContent = 'New version available '
+      const button = document.createElement('button')
+      button.textContent = 'Refresh'
+      button.addEventListener('click', () => {
+        navigator.serviceWorker.controller?.postMessage('SKIP_WAITING')
+        window.location.reload()
+      })
+      banner.appendChild(button)
+      banner.style.position = 'fixed'
+      banner.style.bottom = '1rem'
+      banner.style.right = '1rem'
+      banner.style.padding = '0.5rem 1rem'
+      banner.style.background = '#333'
+      banner.style.color = '#fff'
+      banner.style.borderRadius = '0.25rem'
+      banner.style.zIndex = '1000'
+      document.body.appendChild(banner)
+    }
+  })
 }

--- a/pwa/tsconfig.json
+++ b/pwa/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@neo/config/tsconfig.json",
+  "extends": "../packages/config/tsconfig.json",
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- start PWA preview automatically for Lighthouse CI
- include PWA in pnpm workspace and add preview script
- fix PWA tsconfig and service worker for production build

## Testing
- `pnpm build` (in pwa)
- `pnpm dlx @lhci/cli@0.14.0 autorun --config=lighthouserc.json` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b043285658832aa3240778804fde9b