### PR TITLE
feat: add global error boundary for apps

### DIFF
--- a/apps/guest/src/main.tsx
+++ b/apps/guest/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster, GlobalErrorBoundary } from '@neo/ui';
 import './index.css';
 import './i18n';
 import { HealthPage } from './pages/HealthPage';
@@ -20,16 +21,19 @@ if ('serviceWorker' in navigator) {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={qc}>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<HealthPage />} />
-          <Route path="/qr" element={<QrPage />} />
-          <Route path="/menu" element={<MenuPage />} />
-          <Route path="/cart" element={<CartPage />} />
-          <Route path="/track/:orderId" element={<TrackPage />} />
-        </Routes>
-      </BrowserRouter>
-    </QueryClientProvider>
+    <GlobalErrorBoundary>
+      <QueryClientProvider client={qc}>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<HealthPage />} />
+            <Route path="/qr" element={<QrPage />} />
+            <Route path="/menu" element={<MenuPage />} />
+            <Route path="/cart" element={<CartPage />} />
+            <Route path="/track/:orderId" element={<TrackPage />} />
+          </Routes>
+        </BrowserRouter>
+      </QueryClientProvider>
+      <Toaster />
+    </GlobalErrorBoundary>
   </React.StrictMode>
 );

--- a/apps/kds/src/main.tsx
+++ b/apps/kds/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster, GlobalErrorBoundary } from '@neo/ui';
 import './index.css';
 import './i18n';
 import { HealthPage } from './pages/HealthPage';
@@ -17,6 +18,7 @@ if ('serviceWorker' in navigator) {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
+    <GlobalErrorBoundary>
       <QueryClientProvider client={qc}>
         <BrowserRouter>
           <Routes>
@@ -25,5 +27,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           </Routes>
         </BrowserRouter>
       </QueryClientProvider>
-    </React.StrictMode>
-  );
+      <Toaster />
+    </GlobalErrorBoundary>
+  </React.StrictMode>
+);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "clsx": "^2.0.0",
     "lucide-react": "^0.364.0",
-    "sonner": "^1.4.0"
+    "sonner": "^1.4.0",
+    "@neo/api": "workspace:*"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.0",

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './button';
+export * from './global-error-boundary';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@neo/api':
+        specifier: workspace:*
+        version: link:../api
       clsx:
         specifier: ^2.0.0
         version: 2.1.1


### PR DESCRIPTION
## Summary
- add `GlobalErrorBoundary` component that reports errors and lets users retry
- wrap guest and kds apps with error boundary and toast

## Testing
- `corepack pnpm --filter @neo/ui lint`
- `corepack pnpm --filter @neo/ui test`
- `corepack pnpm --filter @neo/guest lint`
- `corepack pnpm --filter @neo/guest test`
- `corepack pnpm --filter @neo/kds lint`
- `corepack pnpm --filter @neo/kds test`


------
https://chatgpt.com/codex/tasks/task_e_68b049bd5a20832ab07b96ac8bcfd453