### PR TITLE
ci: create demo db before migrations

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Migrate and seed demo data
         run: |
           python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head
+          PYTHONPATH=. python scripts/tenant_create_db.py --tenant demo
           PYTHONPATH=. python scripts/tenant_migrate.py --tenant demo
           PYTHONPATH=. python scripts/demo_seed.py --tenant demo --reset
 

--- a/.github/workflows/pdf-smoke.yml
+++ b/.github/workflows/pdf-smoke.yml
@@ -46,6 +46,7 @@ jobs:
           pip install -r api/requirements.txt pillow
       - name: Migrate and seed demo data
         run: |
+          PYTHONPATH=. python scripts/tenant_create_db.py --tenant demo
           PYTHONPATH=. python scripts/tenant_migrate.py --tenant demo
           PYTHONPATH=. python scripts/demo_seed.py --tenant demo --reset
       - name: Start API


### PR DESCRIPTION
## Summary
- create demo tenant database before migrations in a11y and pdf smoke workflows

## Testing
- `pre-commit run --files .github/workflows/a11y.yml .github/workflows/pdf-smoke.yml`
- `pytest -q` *(fails: import file mismatch for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b04aa061d0832a87cb23531b4e936b