### PR TITLE
feat: add SkeletonList and loading indicators

### DIFF
--- a/apps/guest/src/pages/MenuPage.tsx
+++ b/apps/guest/src/pages/MenuPage.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Header } from '../components/Header';
+import { SkeletonList } from '@neo/ui';
 import { useCartStore } from '../store/cart';
 
 interface Item {
@@ -21,7 +22,7 @@ const fetchMenu = async (): Promise<{ categories: Category[] }> => {
 
 export function MenuPage() {
   const { t, i18n } = useTranslation();
-  const { data } = useQuery({ queryKey: ['menu'], queryFn: fetchMenu });
+  const { data, isPending } = useQuery({ queryKey: ['menu'], queryFn: fetchMenu });
   const add = useCartStore((s) => s.add);
   const lang = i18n.language;
 
@@ -29,23 +30,27 @@ export function MenuPage() {
     <div>
       <Header />
       <h1>{t('menu')}</h1>
-      {data?.categories?.map((cat) => (
-        <div key={cat.id}>
-          <h2>{cat.name_i18n[lang] || cat.name_i18n.en}</h2>
-          {cat.items.map((item) => (
-            <div key={item.id}>
-              <span>{item.name_i18n[lang] || item.name_i18n.en}</span>
-              <button
-                onClick={() =>
-                  add({ id: item.id, name: item.name_i18n.en, qty: 1 })
-                }
-              >
-                +
-              </button>
-            </div>
-          ))}
-        </div>
-      ))}
+      {isPending ? (
+        <SkeletonList />
+      ) : (
+        data?.categories?.map((cat) => (
+          <div key={cat.id}>
+            <h2>{cat.name_i18n[lang] || cat.name_i18n.en}</h2>
+            {cat.items.map((item) => (
+              <div key={item.id}>
+                <span>{item.name_i18n[lang] || item.name_i18n.en}</span>
+                <button
+                  onClick={() =>
+                    add({ id: item.id, name: item.name_i18n.en, qty: 1 })
+                  }
+                >
+                  +
+                </button>
+              </div>
+            ))}
+          </div>
+        ))
+      )}
     </div>
   );
 }

--- a/apps/kds/src/pages/ExpoPage.tsx
+++ b/apps/kds/src/pages/ExpoPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { apiFetch, useWS } from '@neo/api';
+import { SkeletonList } from '@neo/ui';
 import { WS_BASE, TENANT_ID } from '../env';
 import { PinModal } from '../components/PinModal';
 import { Snackbar } from '../components/Snackbar';
@@ -20,6 +21,7 @@ export function ExpoPage() {
   const [showPin, setShowPin] = useState(false);
   const [pending, setPending] = useState<(() => void) | null>(null);
   const [toast, setToast] = useState<{ msg: string; type?: 'success' | 'error' } | null>(null);
+  const [loading, setLoading] = useState(true);
 
   const fetchTickets = useCallback(async () => {
     try {
@@ -41,6 +43,8 @@ export function ExpoPage() {
       setReady(expo.orders || []);
     } catch (err) {
       setToast({ msg: (err as Error).message, type: 'error' });
+    } finally {
+      setLoading(false);
     }
   }, []);
 
@@ -176,59 +180,63 @@ export function ExpoPage() {
     <div className="p-4 space-y-4">
       {offline && <div className="bg-red-600 text-white p-2 text-center">Offline</div>}
       <h2 className="text-xl font-bold">Expo</h2>
-      <div className="grid grid-cols-4 gap-4">
-        <div>
-          <h3 className="font-semibold mb-2">New</h3>
-          <ul className="space-y-2">
-            {newTickets.map((t) => (
-              <li key={t.order_id} className="border p-2 rounded">
-                <div className="flex justify-between">
-                  <span>Table {t.table}</span>
-                </div>
-              </li>
-            ))}
-          </ul>
+      {loading ? (
+        <SkeletonList count={4} />
+      ) : (
+        <div className="grid grid-cols-4 gap-4">
+          <div>
+            <h3 className="font-semibold mb-2">New</h3>
+            <ul className="space-y-2">
+              {newTickets.map((t) => (
+                <li key={t.order_id} className="border p-2 rounded">
+                  <div className="flex justify-between">
+                    <span>Table {t.table}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">Preparing</h3>
+            <ul className="space-y-2">
+              {preparing.map((t) => (
+                <li key={t.order_id} className="border p-2 rounded">
+                  <div className="flex justify-between">
+                    <span>Table {t.table}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">Ready</h3>
+            <ul className="space-y-2">
+              {ready.map((t) => (
+                <li key={t.order_id} className="border p-2 rounded">
+                  <div className="flex justify-between">
+                    <span>Table {t.table}</span>
+                    <span className="text-sm text-gray-600" title={`ETA ${formatEta(t.age_s)}`}>
+                      {formatAge(t.age_s)}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">Picked</h3>
+            <ul className="space-y-2">
+              {picked.map((t) => (
+                <li key={t.order_id} className="border p-2 rounded text-gray-500">
+                  <div className="flex justify-between">
+                    <span>Table {t.table}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
-        <div>
-          <h3 className="font-semibold mb-2">Preparing</h3>
-          <ul className="space-y-2">
-            {preparing.map((t) => (
-              <li key={t.order_id} className="border p-2 rounded">
-                <div className="flex justify-between">
-                  <span>Table {t.table}</span>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <h3 className="font-semibold mb-2">Ready</h3>
-          <ul className="space-y-2">
-            {ready.map((t) => (
-              <li key={t.order_id} className="border p-2 rounded">
-                <div className="flex justify-between">
-                  <span>Table {t.table}</span>
-                  <span className="text-sm text-gray-600" title={`ETA ${formatEta(t.age_s)}`}>
-                    {formatAge(t.age_s)}
-                  </span>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <h3 className="font-semibold mb-2">Picked</h3>
-          <ul className="space-y-2">
-            {picked.map((t) => (
-              <li key={t.order_id} className="border p-2 rounded text-gray-500">
-                <div className="flex justify-between">
-                  <span>Table {t.table}</span>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
+      )}
       {showPin && <PinModal open={showPin} onClose={() => setShowPin(false)} onSuccess={afterLogin} />}
       {toast && <Snackbar message={toast.msg} type={toast.type} onClose={() => setToast(null)} />}
     </div>

--- a/packages/ui/src/components/Skeleton.tsx
+++ b/packages/ui/src/components/Skeleton.tsx
@@ -1,0 +1,16 @@
+import clsx from 'clsx';
+
+export interface SkeletonListProps {
+  count?: number;
+  className?: string;
+}
+
+export function SkeletonList({ count = 3, className }: SkeletonListProps) {
+  return (
+    <ul className={clsx('animate-pulse space-y-2', className)}>
+      {Array.from({ length: count }).map((_, i) => (
+        <li key={i} className="h-6 bg-gray-200 rounded" />
+      ))}
+    </ul>
+  );
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './button';
 export * from './global-error-boundary';
+export * from './Skeleton';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,3 +2,4 @@ export * from './components';
 export * from './icons';
 export * from './toast';
 export * from './tokens';
+export { SkeletonList } from './components/Skeleton';


### PR DESCRIPTION
## Summary
- add SkeletonList component to UI package and export
- display SkeletonList while menu or tickets are loading

## Testing
- `pnpm test`
- `cd apps/guest && pnpm dev`
- `cd apps/kds && pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68b04b1b1e64832a87d600bb4311ad0a