### PR TITLE
feat(guest): centralize route configuration

### DIFF
--- a/apps/guest/src/main.tsx
+++ b/apps/guest/src/main.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster, GlobalErrorBoundary } from '@neo/ui';
 import './index.css';
 import './i18n';
-import { Health } from './pages/Health';
-import { QrPage } from './pages/QrPage';
-import { MenuPage } from './pages/MenuPage';
-import { CartPage } from './pages/CartPage';
-import { TrackPage } from './pages/TrackPage';
+import { AppRoutes } from './routes';
 import { Workbox } from 'workbox-window';
 
 const qc = new QueryClient();
@@ -24,14 +20,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <GlobalErrorBoundary>
       <QueryClientProvider client={qc}>
         <BrowserRouter>
-          <Routes>
-            <Route path="/health" element={<Health />} />
-            <Route path="/" element={<QrPage />} />
-            <Route path="/qr" element={<QrPage />} />
-            <Route path="/menu" element={<MenuPage />} />
-            <Route path="/cart" element={<CartPage />} />
-            <Route path="/track/:orderId" element={<TrackPage />} />
-          </Routes>
+          <AppRoutes />
         </BrowserRouter>
       </QueryClientProvider>
       <Toaster />

--- a/apps/guest/src/routes.tsx
+++ b/apps/guest/src/routes.tsx
@@ -1,0 +1,19 @@
+import { Routes, Route } from 'react-router-dom';
+import { QrPage } from './pages/QrPage';
+import { MenuPage } from './pages/MenuPage';
+import { CartPage } from './pages/CartPage';
+import { TrackPage } from './pages/TrackPage';
+import { Health } from './pages/Health';
+
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/health" element={<Health />} />
+      <Route path="/" element={<QrPage />} />
+      <Route path="/qr" element={<QrPage />} />
+      <Route path="/menu" element={<MenuPage />} />
+      <Route path="/cart" element={<CartPage />} />
+      <Route path="/track/:orderId" element={<TrackPage />} />
+    </Routes>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable AppRoutes component for guest pages
- simplify main entry to consume new route module

## Testing
- `pnpm --filter @neo/guest test`


------
https://chatgpt.com/codex/tasks/task_e_68b059df27d4832aba05565f165eee01