### PR TITLE
feat(guest): show skeletons and toast errors

### DIFF
--- a/apps/guest/src/__tests__/guest.test.tsx
+++ b/apps/guest/src/__tests__/guest.test.tsx
@@ -12,6 +12,8 @@ jest.mock(
   () => ({
     EmptyState: () => null,
     ShoppingCart: () => null,
+    SkeletonList: () => null,
+    toast: { error: jest.fn() },
   }),
   { virtual: true }
 );

--- a/apps/guest/src/components/CartSkeleton.tsx
+++ b/apps/guest/src/components/CartSkeleton.tsx
@@ -1,0 +1,5 @@
+import { SkeletonList } from '@neo/ui';
+
+export function CartSkeleton() {
+  return <SkeletonList />;
+}

--- a/apps/guest/src/components/MenuSkeleton.tsx
+++ b/apps/guest/src/components/MenuSkeleton.tsx
@@ -1,0 +1,5 @@
+import { SkeletonList } from '@neo/ui';
+
+export function MenuSkeleton() {
+  return <SkeletonList />;
+}

--- a/apps/guest/src/hooks/useLicense.ts
+++ b/apps/guest/src/hooks/useLicense.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
-export function useLicense() {
+export function useLicense(options?: UseQueryOptions<{ status: string }>) {
   return useQuery<{ status: string }>({
     queryKey: ['license'],
     queryFn: async () => {
@@ -8,5 +8,6 @@ export function useLicense() {
       if (!res.ok) throw new Error('license');
       return res.json();
     },
+    ...options,
   });
 }

--- a/apps/guest/src/i18n.ts
+++ b/apps/guest/src/i18n.ts
@@ -11,6 +11,9 @@ const resources = {
       tip: 'Tip',
       empty_cart: 'Your cart is empty',
       empty_menu: 'No items available',
+      error_menu: 'Failed to load menu',
+      error_cart: 'Failed to load cart',
+      error_order: 'Failed to place order',
     },
   },
   es: {
@@ -22,6 +25,9 @@ const resources = {
       tip: 'Propina',
       empty_cart: 'Tu carrito está vacío',
       empty_menu: 'No hay artículos disponibles',
+      error_menu: 'Error al cargar el menú',
+      error_cart: 'Error al cargar el carrito',
+      error_order: 'Error al realizar el pedido',
     },
   },
 };

--- a/apps/guest/src/pages/MenuPage.tsx
+++ b/apps/guest/src/pages/MenuPage.tsx
@@ -1,7 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Header } from '../components/Header';
-import { SkeletonList, EmptyState, Utensils } from '@neo/ui';
+import { EmptyState, Utensils, toast } from '@neo/ui';
+import { MenuSkeleton } from '../components/MenuSkeleton';
 import { useCartStore } from '../store/cart';
 
 interface Item {
@@ -22,7 +23,11 @@ const fetchMenu = async (): Promise<{ categories: Category[] }> => {
 
 export function MenuPage() {
   const { t, i18n } = useTranslation();
-  const { data, isPending } = useQuery({ queryKey: ['menu'], queryFn: fetchMenu });
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['menu'],
+    queryFn: fetchMenu,
+    onError: () => toast.error(t('error_menu')),
+  });
   const add = useCartStore((s) => s.add);
   const lang = i18n.language;
   const items = data?.categories?.flatMap((c) => c.items) ?? [];
@@ -32,7 +37,12 @@ export function MenuPage() {
       <Header />
       <h1>{t('menu')}</h1>
       {isPending ? (
-        <SkeletonList />
+        <MenuSkeleton />
+      ) : isError ? (
+        <EmptyState
+          message={t('error_menu')}
+          icon={<Utensils className="w-12 h-12 mx-auto" />}
+        />
       ) : items.length === 0 ? (
         <EmptyState
           message={t('empty_menu')}


### PR DESCRIPTION
## Summary
- add menu and cart skeleton components
- toast network and order errors
- handle loading and error states with TanStack Query

## Testing
- `pnpm --filter @neo/guest test`

------
https://chatgpt.com/codex/tasks/task_e_68b05c816d10832ab838cbcf21fd9855