### PR TITLE
feat(guest): Pay Now (UPI intents + manual verify) with status poll

### DIFF
--- a/apps/guest/src/__tests__/pay.test.tsx
+++ b/apps/guest/src/__tests__/pay.test.tsx
@@ -1,0 +1,99 @@
+import '@testing-library/jest-dom';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PayPage } from '../pages/Pay';
+
+function renderPay() {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <BrowserRouter>
+        <PayPage />
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('pay page', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    // @ts-ignore
+    global.fetch = jest.fn();
+  });
+
+  test('UPI URL contains pa/pn/am', async () => {
+    // @ts-ignore
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [],
+        tax: 0,
+        total: 55,
+        upi: { pa: 'test@upi', pn: 'Test' },
+        onlineUpi: true,
+      }),
+    });
+
+    renderPay();
+    const link = await screen.findByRole('link', { name: /gpay/i });
+    const href = link.getAttribute('href')!;
+    expect(href).toContain('pa=test@upi');
+    expect(href).toContain('pn=Test');
+    expect(href).toContain('am=55');
+  });
+
+  test('status poll switches to success', async () => {
+    jest.useFakeTimers();
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [],
+          tax: 0,
+          total: 55,
+          upi: { pa: 't@upi', pn: 'T' },
+          onlineUpi: true,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: 'pending' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: 'settled' }),
+      });
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    renderPay();
+    await screen.findByText(/total/i);
+    fireEvent.click(screen.getByRole('button', { name: /i've paid/i }));
+    fireEvent.change(screen.getByLabelText(/utr/i), {
+      target: { value: '123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/waiting for verification/i)).toBeInTheDocument()
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/payment successful/i)).toBeInTheDocument()
+    );
+  });
+});

--- a/apps/guest/src/pages/Pay.tsx
+++ b/apps/guest/src/pages/Pay.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Header } from '../components/Header';
+
+interface Item {
+  name: string;
+  qty: number;
+  price: number;
+}
+
+interface Invoice {
+  items: Item[];
+  tax: number;
+  total: number;
+  upi?: { pa: string; pn: string };
+  onlineUpi?: boolean;
+}
+
+export function PayPage() {
+  const { orderId } = useParams();
+  const [invoice, setInvoice] = useState<Invoice | null>(null);
+  const [showUtr, setShowUtr] = useState(false);
+  const [utr, setUtr] = useState('');
+  const [showQr, setShowQr] = useState(false);
+  const [status, setStatus] = useState<'waiting' | 'success'>('waiting');
+
+  useEffect(() => {
+    fetch(`/api/orders/${orderId}`)
+      .then((r) => r.json())
+      .then(setInvoice);
+  }, [orderId]);
+
+  const upiLink = invoice?.upi
+    ? `upi://pay?pa=${invoice.upi.pa}&pn=${encodeURIComponent(
+        invoice.upi.pn
+      )}&am=${invoice.total}&tn=Order%20${orderId}`
+    : '';
+
+  useEffect(() => {
+    let int: NodeJS.Timer | undefined;
+    if (showQr && status !== 'success') {
+      int = setInterval(async () => {
+        const res = await fetch(`/api/orders/${orderId}/payment-status`);
+        const json = await res.json();
+        if (json.status === 'settled') {
+          setStatus('success');
+          clearInterval(int);
+        }
+      }, 1000);
+    }
+    return () => clearInterval(int);
+  }, [showQr, orderId, status]);
+
+  if (!invoice) return (
+    <div>
+      <Header />
+      <p>Loading...</p>
+    </div>
+  );
+
+  if (!invoice.onlineUpi) {
+    return (
+      <div>
+        <Header />
+        <h1>Invoice</h1>
+        <ul>
+          {invoice.items.map((it) => (
+            <li key={it.name}>
+              {it.name} x {it.qty} = {it.price}
+            </li>
+          ))}
+        </ul>
+        <p>Tax: {invoice.tax}</p>
+        <p>Total: {invoice.total}</p>
+        <div data-testid="cashier-qr">
+          <p>Show this screen to cashier</p>
+          <img
+            src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${orderId}`}
+            alt="qr"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Header />
+      <h1>Invoice</h1>
+      <ul>
+        {invoice.items.map((it) => (
+          <li key={it.name}>
+            {it.name} x {it.qty} = {it.price}
+          </li>
+        ))}
+      </ul>
+      <p>Tax: {invoice.tax}</p>
+      <p>Total: {invoice.total}</p>
+      {!showQr ? (
+        <>
+          <a href={upiLink}>PhonePe</a>
+          <a href={upiLink}>GPay</a>
+          <a href={upiLink}>Paytm</a>
+          <button onClick={() => setShowUtr(true)}>I've paid</button>
+        </>
+      ) : (
+        <div data-testid="cashier-qr">
+          <p>Show this screen to cashier</p>
+          <img
+            src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${orderId}`}
+            alt="qr"
+          />
+          <p style={{ color: status === 'success' ? 'green' : undefined }}>
+            {status === 'success'
+              ? 'Payment successful'
+              : 'Waiting for verification'}
+          </p>
+        </div>
+      )}
+      {showUtr && (
+        <div role="dialog">
+          <label>
+            UTR
+            <input
+              value={utr}
+              onChange={(e) => setUtr(e.target.value)}
+            />
+          </label>
+          <button
+            onClick={() => {
+              setShowUtr(false);
+              setShowQr(true);
+            }}
+          >
+            Submit
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/guest/src/routes.tsx
+++ b/apps/guest/src/routes.tsx
@@ -3,6 +3,7 @@ import { QrPage } from './pages/QrPage';
 import { MenuPage } from './pages/MenuPage';
 import { CartPage } from './pages/CartPage';
 import { TrackPage } from './pages/TrackPage';
+import { PayPage } from './pages/Pay';
 import { Health } from './pages/Health';
 
 export function AppRoutes() {
@@ -14,6 +15,7 @@ export function AppRoutes() {
       <Route path="/menu" element={<MenuPage />} />
       <Route path="/cart" element={<CartPage />} />
       <Route path="/track/:orderId" element={<TrackPage />} />
+      <Route path="/pay/:orderId" element={<PayPage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- add Pay page to display invoice, UPI intent buttons, and manual UTR modal
- poll payment status and show QR for cashier
- test UPI url format and payment polling

## Testing
- `npm test --silent 2>&1 | grep -E "Test Suites|Tests:|Snapshots|Time|Ran all test suites"`


------
https://chatgpt.com/codex/tasks/task_e_68b063d7e560832ab75c35f4dc295d3f