### PR TITLE
feat(admin): shell + RBAC + dashboard + floor live + billing entry

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "lint": "echo lint",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "echo 'no tests'"
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
@@ -35,6 +35,10 @@
     "tailwindcss": "^3.4.0",
     "typescript": "^5.0.0",
     "vite": "^5.1.4",
+    "vitest": "^1.3.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/jest-dom": "^6.1.5",
     "workbox-precaching": "^7.0.0",
     "workbox-routing": "^7.0.0"
   }

--- a/apps/admin/src/auth.ts
+++ b/apps/admin/src/auth.ts
@@ -1,0 +1,63 @@
+import { create } from 'zustand';
+
+interface Tenant { id: string; name: string }
+
+interface AuthState {
+  token: string | null;
+  roles: string[];
+  tenants: Tenant[];
+  tenantId: string | null;
+  login: (pin: string) => Promise<void>;
+  logout: () => void;
+  setTenant: (id: string) => void;
+}
+
+function decodeToken(token: string) {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return payload;
+  } catch {
+    return {};
+  }
+}
+
+export const useAuth = create<AuthState>((set) => ({
+  token: null,
+  roles: [],
+  tenants: [],
+  tenantId: null,
+  async login(pin: string) {
+    const res = await fetch('/admin/login-pin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pin })
+    });
+    const { token } = await res.json();
+    sessionStorage.setItem('token', token);
+    const payload = decodeToken(token);
+    const roles: string[] = payload.roles || [];
+    const tenants: Tenant[] = payload.tenants || [];
+    let tenantId = localStorage.getItem('tenantId') || tenants[0]?.id || null;
+    if (tenantId) localStorage.setItem('tenantId', tenantId);
+    set({ token, roles, tenants, tenantId });
+  },
+  logout() {
+    sessionStorage.removeItem('token');
+    set({ token: null, roles: [], tenants: [], tenantId: null });
+  },
+  setTenant(id: string) {
+    localStorage.setItem('tenantId', id);
+    set({ tenantId: id });
+  }
+}));
+
+if (typeof window !== 'undefined') {
+  const token = sessionStorage.getItem('token');
+  if (token) {
+    const payload = decodeToken(token);
+    const roles: string[] = payload.roles || [];
+    const tenants: Tenant[] = payload.tenants || [];
+    const tenantId = localStorage.getItem('tenantId') || tenants[0]?.id || null;
+    useAuth.setState({ token, roles, tenants, tenantId });
+  }
+}

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -1,0 +1,51 @@
+import { Link, Outlet, useNavigate } from 'react-router-dom';
+import { useAuth } from '../auth';
+
+export function Layout() {
+  const { tenants, tenantId, setTenant, logout } = useAuth();
+  const navigate = useNavigate();
+  const current = tenants.find((t) => t.id === tenantId);
+  return (
+    <div className="flex h-screen">
+      <aside className="w-48 bg-gray-100 p-4 space-y-2">
+        <nav className="flex flex-col space-y-2">
+          <Link to="/dashboard">Dashboard</Link>
+          <Link to="/floor">Floor</Link>
+          <Link to="/billing">Billing</Link>
+          <Link to="/onboarding">Onboarding</Link>
+        </nav>
+      </aside>
+      <div className="flex-1 flex flex-col">
+        <header className="flex justify-between items-center p-2 border-b">
+          <div>
+            {tenants.length > 1 ? (
+              <select
+                value={tenantId ?? undefined}
+                onChange={(e) => setTenant(e.target.value)}
+              >
+                {tenants.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <span>{current?.name}</span>
+            )}
+          </div>
+          <button
+            onClick={() => {
+              logout();
+              navigate('/login');
+            }}
+          >
+            Logout
+          </button>
+        </header>
+        <main className="flex-1 overflow-auto p-4">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/ProtectedRoute.tsx
+++ b/apps/admin/src/components/ProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import { ReactElement } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../auth';
+
+interface Props {
+  roles?: string[];
+  children: ReactElement;
+}
+
+export function ProtectedRoute({ roles, children }: Props) {
+  const { token, roles: userRoles } = useAuth();
+  const location = useLocation();
+  if (!token) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+  if (roles && !roles.some((r) => userRoles.includes(r))) {
+    return <Navigate to="/dashboard" replace />;
+  }
+  return children;
+}

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './index.css';
 import './i18n';
-import { Health } from './pages/Health';
+import { router } from './routes';
 import { Workbox } from 'workbox-window';
 
 const qc = new QueryClient();
@@ -17,12 +17,7 @@ if ('serviceWorker' in navigator) {
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/health" element={<Health />} />
-          <Route path="/" element={<Health />} />
-        </Routes>
-      </BrowserRouter>
+      <RouterProvider router={router} />
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/apps/admin/src/pages/Billing.tsx
+++ b/apps/admin/src/pages/Billing.tsx
@@ -1,0 +1,12 @@
+export function Billing() {
+  return (
+    <button
+      onClick={() => {
+        window.location.href = '/admin/billing';
+      }}
+      className="bg-blue-500 text-white p-2"
+    >
+      Manage subscription
+    </button>
+  );
+}

--- a/apps/admin/src/pages/Dashboard.test.tsx
+++ b/apps/admin/src/pages/Dashboard.test.tsx
@@ -1,0 +1,48 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { Dashboard } from './Dashboard';
+import { useAuth } from '../auth';
+
+const sources: any[] = [];
+class MockEventSource {
+  onmessage: ((ev: any) => void) | null = null;
+  onopen: ((ev: any) => void) | null = null;
+  constructor(public url: string) {
+    sources.push(this);
+    setTimeout(() => this.onopen?.({}), 0);
+  }
+  close() {}
+}
+
+beforeEach(() => {
+  (global as any).EventSource = MockEventSource as any;
+  useAuth.setState({
+    token: 't',
+    roles: ['owner'],
+    tenants: [{ id: '1', name: 'A' }],
+    tenantId: '1'
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  sources.length = 0;
+});
+
+describe('Dashboard', () => {
+  test('SSE updates KPI values', async () => {
+    render(<Dashboard />);
+    const es = sources[0];
+    es.onmessage?.({
+      data: JSON.stringify({
+        orders_today: 5,
+        sales: 123,
+        prep_p50: 10,
+        eta_sla_pct: 90,
+        webhook_breaker_pct: 2
+      })
+    });
+    await screen.findByText('Orders Today: 5');
+    screen.getByText('Sales ₹: 123');
+  });
+});

--- a/apps/admin/src/pages/Floor.tsx
+++ b/apps/admin/src/pages/Floor.tsx
@@ -1,0 +1,5 @@
+export function Floor() {
+  return (
+    <iframe src="/floor" title="floor" className="w-full h-full border-0" />
+  );
+}

--- a/apps/admin/src/pages/Login.tsx
+++ b/apps/admin/src/pages/Login.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../auth';
+
+export function Login() {
+  const [pin, setPin] = useState('');
+  const login = useAuth((s) => s.login);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as any)?.from?.pathname || '/dashboard';
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        await login(pin);
+        navigate(from, { replace: true });
+      }}
+      className="p-4 space-y-2"
+    >
+      <input
+        value={pin}
+        onChange={(e) => setPin(e.target.value)}
+        placeholder="PIN"
+        className="border p-2"
+      />
+      <button type="submit" className="block bg-blue-500 text-white p-2">
+        Login
+      </button>
+    </form>
+  );
+}

--- a/apps/admin/src/pages/Onboarding.tsx
+++ b/apps/admin/src/pages/Onboarding.tsx
@@ -1,0 +1,3 @@
+export function Onboarding() {
+  return <div>Onboarding</div>;
+}

--- a/apps/admin/src/routes.test.tsx
+++ b/apps/admin/src/routes.test.tsx
@@ -1,0 +1,38 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { routes } from './routes';
+import { useAuth } from './auth';
+import { afterEach } from 'vitest';
+
+const ES = global.EventSource;
+
+beforeEach(() => {
+  cleanup();
+  useAuth.setState({ token: null, roles: [], tenants: [], tenantId: null });
+  (global as any).EventSource = class {
+    onmessage: any = null;
+    onopen: any = null;
+    close() {}
+  };
+});
+
+afterEach(() => {
+  (global as any).EventSource = ES;
+});
+
+describe('route guards', () => {
+  test('blocks non-owners from /billing', async () => {
+    useAuth.setState({
+      token: 't',
+      roles: ['manager'],
+      tenants: [{ id: '1', name: 'A' }],
+      tenantId: '1'
+    });
+    const router = createMemoryRouter(routes, { initialEntries: ['/billing'] });
+    render(<RouterProvider router={router} />);
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/dashboard');
+    });
+  });
+});

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -1,0 +1,36 @@
+import { createBrowserRouter, Navigate, RouteObject } from 'react-router-dom';
+import { Login } from './pages/Login';
+import { Dashboard } from './pages/Dashboard';
+import { Floor } from './pages/Floor';
+import { Billing } from './pages/Billing';
+import { Onboarding } from './pages/Onboarding';
+import { Layout } from './components/Layout';
+import { ProtectedRoute } from './components/ProtectedRoute';
+
+export const routes: RouteObject[] = [
+  { path: '/login', element: <Login /> },
+  {
+    path: '/',
+    element: (
+      <ProtectedRoute>
+        <Layout />
+      </ProtectedRoute>
+    ),
+    children: [
+      { index: true, element: <Navigate to="/dashboard" replace /> },
+      { path: 'dashboard', element: <Dashboard /> },
+      { path: 'floor', element: <Floor /> },
+      {
+        path: 'billing',
+        element: (
+          <ProtectedRoute roles={['owner']}>
+            <Billing />
+          </ProtectedRoute>
+        )
+      },
+      { path: 'onboarding', element: <Onboarding /> }
+    ]
+  }
+];
+
+export const router = createBrowserRouter(routes);

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "extends": "@neo/config/tsconfig",
   "include": ["src"],
+  "exclude": ["src/**/*.test.tsx"],
   "compilerOptions": {
-    "types": ["vite/client"]
+    "types": ["vite/client", "@testing-library/jest-dom"],
+    "paths": {
+      "@neo/api": ["../../packages/api/src"],
+      "@neo/ui": ["../../packages/ui/src"],
+      "@neo/utils": ["../../packages/utils/src"]
+    }
   }
 }

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,2 +1,20 @@
-import config from '@neo/config/vite';
-export default config;
+import base from '@neo/config/vite';
+import { defineConfig, mergeConfig } from 'vite';
+import { fileURLToPath, URL } from 'node:url';
+
+export default mergeConfig(
+  base,
+  defineConfig({
+    resolve: {
+      alias: {
+        '@neo/api': fileURLToPath(new URL('../../packages/api/src/index.ts', import.meta.url)),
+        '@neo/ui': fileURLToPath(new URL('../../packages/ui/src/index.ts', import.meta.url)),
+        '@neo/utils': fileURLToPath(new URL('../../packages/utils/src/index.ts', import.meta.url))
+      }
+    },
+    test: {
+      environment: 'jsdom',
+      setupFiles: './vitest.setup.ts'
+    }
+  })
+);

--- a/apps/admin/vitest.setup.ts
+++ b/apps/admin/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,15 @@ importers:
       '@neo/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@testing-library/jest-dom':
+        specifier: ^6.1.5
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^14.0.0
+        version: 14.3.1(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.4.3
+        version: 14.6.1(@testing-library/dom@9.3.4)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.7.0(vite@5.4.19(@types/node@24.3.0))
@@ -87,6 +96,9 @@ importers:
       vite:
         specifier: ^5.1.4
         version: 5.4.19(@types/node@24.3.0)
+      vitest:
+        specifier: ^1.3.0
+        version: 1.6.1(@types/node@24.3.0)(jsdom@20.0.3)
       workbox-precaching:
         specifier: ^7.0.0
         version: 7.3.0


### PR DESCRIPTION
## Summary
- scaffold admin app routing and layout with sidebar, login, and protected sections
- add auth store with PIN login, role guard, and tenant switching
- implement dashboard KPIs via SSE, floor live iframe, and billing link

## Testing
- `pnpm --filter @neo/admin lint`
- `pnpm --filter @neo/admin typecheck`
- `pnpm --filter @neo/admin test`


------
https://chatgpt.com/codex/tasks/task_e_68b063b720ec832ab13ebc21caf8b7c7