### PR TITLE
feat(admin): menu editor CRUD with inline i18n and CSV import/export links

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "lint": "echo lint",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "echo 'no tests'"
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
@@ -36,6 +36,10 @@
     "typescript": "^5.0.0",
     "vite": "^5.1.4",
     "workbox-precaching": "^7.0.0",
-    "workbox-routing": "^7.0.0"
+    "workbox-routing": "^7.0.0",
+    "vitest": "^1.3.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/jest-dom": "^6.1.5"
   }
 }

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './index.css';
 import './i18n';
 import { Health } from './pages/Health';
+import { MenuEditor } from './pages/MenuEditor';
 import { Workbox } from 'workbox-window';
 
 const qc = new QueryClient();
@@ -21,6 +22,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         <Routes>
           <Route path="/health" element={<Health />} />
           <Route path="/" element={<Health />} />
+          <Route path="/menu" element={<MenuEditor />} />
         </Routes>
       </BrowserRouter>
     </QueryClientProvider>

--- a/apps/admin/src/pages/MenuEditor.test.tsx
+++ b/apps/admin/src/pages/MenuEditor.test.tsx
@@ -1,0 +1,104 @@
+import { describe, test, beforeEach, vi, expect } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MenuEditor } from './MenuEditor';
+
+const cats = [{ id: 'c1', name: 'Drinks', sort_order: 0 }];
+const items = [
+  {
+    id: 'i1',
+    category_id: 'c1',
+    name: 'Tea',
+    price: 10,
+    active: true,
+    sort_order: 0,
+    name_i18n: {},
+    desc_i18n: {}
+  }
+];
+
+vi.mock('@neo/api', () => ({
+  getCategories: vi.fn(() => Promise.resolve([...cats])),
+  createCategory: vi.fn(async ({ name }: any) => {
+    const cat = { id: `c${cats.length + 1}`, name, sort_order: cats.length };
+    cats.push(cat);
+    return cat;
+  }),
+  getItems: vi.fn(async (catId: string) =>
+    Promise.resolve(items.filter((i) => i.category_id === catId))
+  ),
+  updateItem: vi.fn(async (id: string, body: any) => {
+    const idx = items.findIndex((i) => i.id === id);
+    items[idx] = { ...items[idx], ...body };
+    return items[idx];
+  }),
+  exportI18nCSV: vi.fn(async () => {})
+}));
+
+beforeEach(() => {
+  cats.length = 1;
+  cats[0] = { id: 'c1', name: 'Drinks', sort_order: 0 };
+  items.length = 1;
+  items[0] = {
+    id: 'i1',
+    category_id: 'c1',
+    name: 'Tea',
+    price: 10,
+    active: true,
+    sort_order: 0,
+    name_i18n: {},
+    desc_i18n: {}
+  };
+  vi.clearAllMocks();
+  cleanup();
+});
+
+describe('MenuEditor', () => {
+  test('Create category appears in list', async () => {
+    render(<MenuEditor />);
+    await screen.findByText('Drinks');
+    vi.spyOn(window, 'prompt').mockReturnValue('Snacks');
+    await userEvent.click(screen.getByText('Add Category'));
+    await screen.findByText('Snacks');
+  });
+
+  test('Update item price persists', async () => {
+    render(<MenuEditor />);
+    await screen.findByText('Drinks');
+    const itemRow = await screen.findByTestId('item-i1');
+    await userEvent.click(within(itemRow).getByText('Edit'));
+    const priceInput = screen.getByDisplayValue('10');
+    await userEvent.clear(priceInput);
+    await userEvent.type(priceInput, '12');
+    await userEvent.click(screen.getByText('Save'));
+    await screen.findByText('12');
+  });
+
+  test("i18n tab save updates name_i18n['hi']", async () => {
+    render(<MenuEditor />);
+    await screen.findByText('Drinks');
+    const itemRow = await screen.findByTestId('item-i1');
+    await userEvent.click(within(itemRow).getByText('Edit'));
+    await userEvent.click(screen.getByTestId('lang-hi'));
+    const nameInput = screen.getByPlaceholderText('Name');
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Chai');
+    await userEvent.click(screen.getByText('Save'));
+    const api = await import('@neo/api');
+    expect(api.updateItem).toHaveBeenCalledWith(
+      'i1',
+      expect.objectContaining({ name_i18n: { hi: 'Chai' } })
+    );
+  });
+
+  test('CSV export called with selected langs', async () => {
+    const api = await import('@neo/api');
+    render(<MenuEditor />);
+    await screen.findByText('Drinks');
+    const hiCb = screen.getByLabelText('hi');
+    await userEvent.click(hiCb);
+    await userEvent.click(screen.getByText('Export CSV'));
+    expect(api.exportI18nCSV).toHaveBeenCalledWith(['en', 'hi']);
+  });
+});
+

--- a/apps/admin/src/pages/MenuEditor.tsx
+++ b/apps/admin/src/pages/MenuEditor.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from 'react';
+import {
+  getCategories,
+  createCategory,
+  getItems,
+  updateItem,
+  exportI18nCSV,
+  Category,
+  Item
+} from '@neo/api';
+
+const LANGS = ['en', 'hi'];
+
+export function MenuEditor() {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [currentCat, setCurrentCat] = useState<string | null>(null);
+  const [items, setItems] = useState<Item[]>([]);
+  const [editing, setEditing] = useState<Item | null>(null);
+  const [lang, setLang] = useState<string>('en');
+  const [exportLangs, setExportLangs] = useState<string[]>(['en']);
+
+  useEffect(() => {
+    getCategories().then((c) => {
+      setCategories(c);
+      if (c.length && !currentCat) {
+        setCurrentCat(c[0].id);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (currentCat) {
+      getItems(currentCat).then(setItems);
+    }
+  }, [currentCat]);
+
+  const addCategory = async () => {
+    const name = window.prompt('Category name?');
+    if (!name) return;
+    const cat = await createCategory({ name });
+    setCategories((c) => [...c, cat]);
+  };
+
+  const saveItem = async () => {
+    if (!editing) return;
+    const updated = await updateItem(editing.id, editing);
+    setItems((list) => list.map((i) => (i.id === updated.id ? updated : i)));
+    setEditing(null);
+  };
+
+  const toggleExportLang = (l: string, on: boolean) => {
+    setExportLangs((cur) =>
+      on ? [...cur, l] : cur.filter((x) => x !== l)
+    );
+  };
+
+  return (
+    <div className="flex gap-4">
+      <div className="w-1/4">
+        <button onClick={addCategory}>Add Category</button>
+        <ul data-testid="cat-list">
+          {categories.map((c) => (
+            <li key={c.id}>
+              <button onClick={() => setCurrentCat(c.id)}>{c.name}</button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="flex-1">
+        <div className="mb-2">
+          {LANGS.map((l) => (
+            <label key={l} className="mr-2">
+              <input
+                type="checkbox"
+                checked={exportLangs.includes(l)}
+                onChange={(e) => toggleExportLang(l, e.target.checked)}
+              />
+              <span>{l}</span>
+            </label>
+          ))}
+          <button onClick={() => exportI18nCSV(exportLangs)}>Export CSV</button>
+        </div>
+        <table className="w-full text-left">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Price</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((it) => (
+              <tr key={it.id} data-testid={`item-${it.id}`}>
+                <td>{it.name_i18n?.[lang] || it.name}</td>
+                <td>
+                  {editing?.id === it.id ? (
+                    <input
+                      value={editing.price}
+                      onChange={(e) =>
+                        setEditing({ ...editing, price: Number(e.target.value) })
+                      }
+                    />
+                  ) : (
+                    it.price
+                  )}
+                </td>
+                <td>
+                  <button onClick={() => { setEditing({ ...it }); setLang('en'); }}>Edit</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {editing && (
+          <div className="mt-4" data-testid="edit-form">
+            <div className="mb-2">
+              {LANGS.map((l) => (
+                <button
+                  key={l}
+                  onClick={() => setLang(l)}
+                  data-testid={`lang-${l}`}
+                  className={
+                    lang === l ? 'font-bold mr-2' : 'mr-2'
+                  }
+                >
+                  {l}
+                </button>
+              ))}
+            </div>
+            <input
+              placeholder="Name"
+              value={editing.name_i18n?.[lang] || ''}
+              onChange={(e) =>
+                setEditing({
+                  ...editing,
+                  name_i18n: { ...editing.name_i18n, [lang]: e.target.value }
+                })
+              }
+            />
+            <button onClick={saveItem}>Save</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MenuEditor;
+

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,2 +1,19 @@
-import config from '@neo/config/vite';
-export default config;
+import base from '@neo/config/vite';
+import { defineConfig, mergeConfig } from 'vite';
+import { fileURLToPath, URL } from 'node:url';
+
+export default mergeConfig(
+  base,
+  defineConfig({
+    resolve: {
+      alias: {
+        '@neo/api': fileURLToPath(new URL('../../packages/api/src/index.ts', import.meta.url))
+      }
+    },
+    test: {
+      environment: 'jsdom',
+      setupFiles: './vitest.setup.ts'
+    }
+  })
+);
+

--- a/apps/admin/vitest.setup.ts
+++ b/apps/admin/vitest.setup.ts
@@ -1,0 +1,2 @@
+import '@testing-library/jest-dom/vitest';
+

--- a/packages/api/src/api.test.ts
+++ b/packages/api/src/api.test.ts
@@ -4,6 +4,7 @@ import { apiFetch, idempotency } from './api';
 
 test('apiFetch injects auth, tenant and idempotency headers', async () => {
   const calls: RequestInit[] = [];
+  globalThis.sessionStorage = { getItem: () => 'secret-token' } as any;
   globalThis.localStorage = { getItem: () => 'secret-token' } as any;
   globalThis.fetch = async (_: RequestInfo | URL, init?: RequestInit) => {
     calls.push(init!);
@@ -25,6 +26,7 @@ test('apiFetch injects auth, tenant and idempotency headers', async () => {
 });
 
 test('apiFetch parses error json message', async () => {
+  globalThis.sessionStorage = { getItem: () => null } as any;
   globalThis.localStorage = { getItem: () => null } as any;
   globalThis.fetch = async () =>
     new Response(JSON.stringify({ message: 'fail' }), {

--- a/packages/api/src/endpoints.ts
+++ b/packages/api/src/endpoints.ts
@@ -60,3 +60,96 @@ export interface AdminBilling {
 export function adminBilling() {
   return apiFetch<AdminBilling>('/admin/billing');
 }
+
+// Menu editor endpoints
+export interface Category {
+  id: string;
+  name: string;
+  sort_order: number;
+}
+
+export interface Item {
+  id: string;
+  category_id: string;
+  name: string;
+  price: number;
+  active: boolean;
+  sort_order: number;
+  name_i18n?: Record<string, string>;
+  desc_i18n?: Record<string, string>;
+  image?: string;
+}
+
+export function getCategories() {
+  return apiFetch<Category[]>('/menu/categories');
+}
+
+export function createCategory(body: Partial<Category>) {
+  return apiFetch<Category>('/menu/categories', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+export function updateCategory(id: string, body: Partial<Category>) {
+  return apiFetch<Category>(`/menu/categories/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+export function deleteCategory(id: string) {
+  return apiFetch<void>(`/menu/categories/${id}`, { method: 'DELETE' });
+}
+
+export function getItems(categoryId: string) {
+  return apiFetch<Item[]>(`/menu/categories/${categoryId}/items`);
+}
+
+export function createItem(categoryId: string, body: Partial<Item>) {
+  return apiFetch<Item>(`/menu/categories/${categoryId}/items`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+export function updateItem(id: string, body: Partial<Item>) {
+  return apiFetch<Item>(`/menu/items/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+export function deleteItem(id: string) {
+  return apiFetch<void>(`/menu/items/${id}`, { method: 'DELETE' });
+}
+
+export function uploadImage(file: File) {
+  const form = new FormData();
+  form.append('file', file);
+  return apiFetch<{ url: string }>('/upload', {
+    method: 'POST',
+    body: form
+  });
+}
+
+export function exportI18nCSV(langs: string[]) {
+  return apiFetch<Blob>('/menu/i18n/export', {
+    method: 'POST',
+    body: JSON.stringify({ langs }),
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+export function importI18nCSV(file: File) {
+  const form = new FormData();
+  form.append('file', file);
+  return apiFetch<void>('/menu/i18n/import', {
+    method: 'POST',
+    body: form
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,15 @@ importers:
       '@neo/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@testing-library/jest-dom':
+        specifier: ^6.1.5
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^14.0.0
+        version: 14.3.1(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.4.3
+        version: 14.6.1(@testing-library/dom@9.3.4)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.7.0(vite@5.4.19(@types/node@24.3.0))
@@ -87,6 +96,9 @@ importers:
       vite:
         specifier: ^5.1.4
         version: 5.4.19(@types/node@24.3.0)
+      vitest:
+        specifier: ^1.3.0
+        version: 1.6.1(@types/node@24.3.0)(jsdom@20.0.3)
       workbox-precaching:
         specifier: ^7.0.0
         version: 7.3.0


### PR DESCRIPTION
## Summary
- add menu editor page with category list, item editor and i18n tabs
- expose menu CRUD and CSV endpoints in api package
- test menu editor flows for category create, item update, i18n save and CSV export

## Testing
- `pnpm -F @neo/api test`
- `pnpm -F @neo/admin test`


------
https://chatgpt.com/codex/tasks/task_e_68b063d17d88832a8fd7a07917337ff8