### PR TITLE
feat(ui): runtime tenant theming (tokens + logo) wired to all apps

### DIFF
--- a/apps/admin/src/components/Header.tsx
+++ b/apps/admin/src/components/Header.tsx
@@ -1,0 +1,10 @@
+import { useTheme } from '@neo/ui';
+
+export function Header() {
+  const { logoURL } = useTheme();
+  return (
+    <header className="p-2">
+      {logoURL && <img src={logoURL} alt="logo" className="h-6" />}
+    </header>
+  );
+}

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { ThemeProvider, tokensFromOutlet } from '@neo/ui';
 import './index.css';
 import './i18n';
 import { Health } from './pages/Health';
+import { Onboarding } from './pages/Onboarding';
+import { Header } from './components/Header';
 import { Workbox } from 'workbox-window';
+import { API_BASE } from './env';
 
 const qc = new QueryClient();
 
@@ -14,15 +18,29 @@ if ('serviceWorker' in navigator) {
   wb.register();
 }
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <QueryClientProvider client={qc}>
+function App() {
+  const { data: outlet } = useQuery({
+    queryKey: ['outlet'],
+    queryFn: () => fetch(`${API_BASE}/outlet`).then((r) => r.json())
+  });
+  return (
+    <ThemeProvider theme={tokensFromOutlet(outlet)}>
       <BrowserRouter>
+        <Header />
         <Routes>
           <Route path="/health" element={<Health />} />
+          <Route path="/onboarding" element={<Onboarding />} />
           <Route path="/" element={<Health />} />
         </Routes>
       </BrowserRouter>
+    </ThemeProvider>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={qc}>
+      <App />
     </QueryClientProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/apps/admin/src/pages/Onboarding.tsx
+++ b/apps/admin/src/pages/Onboarding.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { ThemeProvider } from '@neo/ui';
+import { Header } from '../components/Header';
+
+export function Onboarding() {
+  const [primary, setPrimary] = useState('#2563eb');
+  const [logo, setLogo] = useState<string | undefined>();
+
+  const onLogo = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setLogo(URL.createObjectURL(file));
+    }
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="space-y-2">
+        <label className="block">Primary Color</label>
+        <input type="color" value={primary} onChange={(e) => setPrimary(e.target.value)} />
+      </div>
+      <div className="space-y-2">
+        <label className="block">Logo</label>
+        <input type="file" accept="image/*" onChange={onLogo} />
+      </div>
+      <div className="border p-4">
+        <ThemeProvider theme={{ primary, accent: '#64748b', logoURL: logo }}>
+          <Header />
+          <button className="bg-primary text-white px-2 py-1">Preview Button</button>
+        </ThemeProvider>
+      </div>
+    </div>
+  );
+}

--- a/apps/guest/src/__tests__/guest.test.tsx
+++ b/apps/guest/src/__tests__/guest.test.tsx
@@ -14,6 +14,8 @@ jest.mock(
     ShoppingCart: () => null,
     SkeletonList: () => null,
     toast: { error: jest.fn() },
+    useTheme: () => ({ logoURL: '' }),
+    ThemeProvider: ({ children }: any) => children,
   }),
   { virtual: true }
 );

--- a/apps/guest/src/__tests__/pay.test.tsx
+++ b/apps/guest/src/__tests__/pay.test.tsx
@@ -9,6 +9,11 @@ import {
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PayPage } from '../pages/Pay';
+jest.mock(
+  '@neo/ui',
+  () => ({ useTheme: () => ({ logoURL: '' }), ThemeProvider: ({ children }: any) => children }),
+  { virtual: true }
+);
 
 function renderPay() {
   const qc = new QueryClient();

--- a/apps/guest/src/components/Header.tsx
+++ b/apps/guest/src/components/Header.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useTheme } from '@neo/ui';
 import { setLanguage } from '../i18n';
 
 export function Header() {
   const { i18n } = useTranslation();
   const [lang, setLang] = useState(i18n.language);
+  const { logoURL } = useTheme();
 
   const change = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const l = e.target.value;
@@ -13,7 +15,8 @@ export function Header() {
   };
 
   return (
-    <header className="p-2 flex justify-end">
+    <header className="p-2 flex justify-between items-center">
+      {logoURL && <img src={logoURL} alt="logo" className="h-6" />}
       <select aria-label="language" value={lang} onChange={change}>
         <option value="en">EN</option>
         <option value="es">ES</option>

--- a/apps/guest/src/main.tsx
+++ b/apps/guest/src/main.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Toaster, GlobalErrorBoundary } from '@neo/ui';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { Toaster, GlobalErrorBoundary, ThemeProvider, tokensFromOutlet } from '@neo/ui';
 import './index.css';
 import './i18n';
 import { AppRoutes } from './routes';
 import { Workbox } from 'workbox-window';
+import { API_BASE } from './env';
 
 const qc = new QueryClient();
 
@@ -15,15 +16,27 @@ if ('serviceWorker' in navigator) {
   wb.register();
 }
 
+function App() {
+  const { data: outlet } = useQuery({
+    queryKey: ['outlet'],
+    queryFn: () => fetch(`${API_BASE}/outlet`).then((r) => r.json())
+  });
+  return (
+    <ThemeProvider theme={tokensFromOutlet(outlet)}>
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
+    </ThemeProvider>
+  );
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <GlobalErrorBoundary>
       <QueryClientProvider client={qc}>
-        <BrowserRouter>
-          <AppRoutes />
-        </BrowserRouter>
+        <App />
       </QueryClientProvider>
       <Toaster />
     </GlobalErrorBoundary>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/apps/kds/src/main.tsx
+++ b/apps/kds/src/main.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Toaster, GlobalErrorBoundary } from '@neo/ui';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { Toaster, GlobalErrorBoundary, ThemeProvider, tokensFromOutlet } from '@neo/ui';
 import './index.css';
 import './i18n';
 import { Workbox } from 'workbox-window';
 import { AppRoutes } from './routes';
+import { API_BASE } from './env';
 
 const qc = new QueryClient();
 
@@ -15,15 +16,27 @@ if ('serviceWorker' in navigator) {
   wb.register();
 }
 
+function App() {
+  const { data: outlet } = useQuery({
+    queryKey: ['outlet'],
+    queryFn: () => fetch(`${API_BASE}/outlet`).then((r) => r.json())
+  });
+  return (
+    <ThemeProvider theme={tokensFromOutlet(outlet)}>
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
+    </ThemeProvider>
+  );
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <GlobalErrorBoundary>
       <QueryClientProvider client={qc}>
-        <BrowserRouter>
-          <AppRoutes />
-        </BrowserRouter>
+        <App />
       </QueryClientProvider>
       <Toaster />
     </GlobalErrorBoundary>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,7 @@
     "dev": "tsc -w -p tsconfig.json",
     "lint": "echo lint",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "echo 'no tests'",
+    "test": "vitest run",
     "postinstall": "shadcn-ui init -y || true"
   },
   "peerDependencies": {
@@ -27,6 +27,8 @@
     "postcss": "^8.4.0",
     "autoprefixer": "^10.4.0",
     "shadcn-ui": "latest",
-    "@neo/config": "workspace:*"
+    "@neo/config": "workspace:*",
+    "vitest": "^1.3.0",
+    "@testing-library/react": "^14.0.0"
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,4 +2,5 @@ export * from './components';
 export * from './icons';
 export * from './toast';
 export * from './tokens';
+export * from './theme';
 export { SkeletonList } from './components/Skeleton';

--- a/packages/ui/src/theme.test.tsx
+++ b/packages/ui/src/theme.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import { describe, expect, test, afterEach } from 'vitest';
+import React from 'react';
+import { ThemeProvider } from './theme';
+
+describe('ThemeProvider', () => {
+  afterEach(() => {
+    document.documentElement.style.removeProperty('--color-primary');
+  });
+
+  test('updates css vars on change', () => {
+    const { rerender } = render(
+      <ThemeProvider theme={{ primary: '#111111', accent: '#222222' }}>
+        <div />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe(
+      '#111111'
+    );
+    rerender(
+      <ThemeProvider theme={{ primary: '#333333', accent: '#222222' }}>
+        <div />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.style.getPropertyValue('--color-primary')).toBe(
+      '#333333'
+    );
+  });
+});

--- a/packages/ui/src/theme.tsx
+++ b/packages/ui/src/theme.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useEffect } from 'react';
+
+export interface ThemeTokens {
+  primary: string;
+  accent: string;
+  logoURL?: string;
+}
+
+const defaultTheme: ThemeTokens = {
+  primary: '#2563eb',
+  accent: '#64748b',
+  logoURL: undefined
+};
+
+const ThemeContext = createContext<ThemeTokens>(defaultTheme);
+
+export function tokensFromOutlet(outlet: any): ThemeTokens {
+  return {
+    primary: outlet?.theme?.primary || defaultTheme.primary,
+    accent: outlet?.theme?.accent || defaultTheme.accent,
+    logoURL: outlet?.theme?.logoURL || defaultTheme.logoURL
+  };
+}
+
+export function ThemeProvider({ theme, children }: { theme: ThemeTokens; children: React.ReactNode }) {
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty('--color-primary', theme.primary);
+    root.style.setProperty('--color-accent', theme.accent);
+  }, [theme.primary, theme.accent]);
+  return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -1,6 +1,6 @@
 export const colors = {
-  primary: '#2563eb',
-  secondary: '#64748b',
+  primary: 'var(--color-primary, #2563eb)',
+  accent: 'var(--color-accent, #64748b)',
   success: '#16a34a',
   warn: '#f59e0b',
   error: '#dc2626'

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
       '@neo/config':
         specifier: workspace:*
         version: link:../config
+      '@testing-library/react':
+        specifier: ^14.0.0
+        version: 14.3.1(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       autoprefixer:
         specifier: ^10.4.0
         version: 10.4.21(postcss@8.5.6)
@@ -333,6 +336,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.0
         version: 3.4.17
+      vitest:
+        specifier: ^1.3.0
+        version: 1.6.1(@types/node@24.3.0)(jsdom@20.0.3)
 
   packages/utils:
     devDependencies:


### PR DESCRIPTION
## Summary
- add ThemeProvider with runtime tokens + logo
- wire ThemeProvider into admin, guest, kds apps
- provide onboarding preview for theme configuration

## Testing
- `pnpm test` *(fails: @neo/api tests)*
- `pnpm --filter @neo/guest test`
- `pnpm --filter @neo/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68b063c66bcc832abbd6aa4b0e296105