### PR TITLE
feat(obs): lightweight RUM + error reporting in all apps

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,2 +1,3 @@
 VITE_API_BASE=http://localhost:3000
 VITE_WS_BASE=ws://localhost:3000
+VITE_DISABLE_RUM=1

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -2,12 +2,19 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GlobalErrorBoundary } from '@neo/ui';
+import { capturePageView } from '@neo/utils';
 import './index.css';
 import './i18n';
 import { router } from './routes';
 import { Workbox } from 'workbox-window';
 
 const qc = new QueryClient();
+
+capturePageView(window.location.pathname);
+router.subscribe((state) => {
+  capturePageView(state.location.pathname);
+});
 
 if ('serviceWorker' in navigator) {
   const wb = new Workbox('/sw.js');
@@ -16,8 +23,10 @@ if ('serviceWorker' in navigator) {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={qc}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
-  </React.StrictMode>
+    <GlobalErrorBoundary>
+      <QueryClientProvider client={qc}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </GlobalErrorBoundary>
+  </React.StrictMode>,
 );

--- a/apps/guest/.env.example
+++ b/apps/guest/.env.example
@@ -1,2 +1,3 @@
 VITE_API_BASE=http://localhost:3000
 VITE_WS_BASE=ws://localhost:3000
+VITE_DISABLE_RUM=1

--- a/apps/guest/src/routes.tsx
+++ b/apps/guest/src/routes.tsx
@@ -1,4 +1,6 @@
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { capturePageView } from '@neo/utils';
 import { QrPage } from './pages/QrPage';
 import { MenuPage } from './pages/MenuPage';
 import { CartPage } from './pages/CartPage';
@@ -7,6 +9,10 @@ import { PayPage } from './pages/Pay';
 import { Health } from './pages/Health';
 
 export function AppRoutes() {
+  const loc = useLocation();
+  useEffect(() => {
+    capturePageView(loc.pathname);
+  }, [loc.pathname]);
   return (
     <Routes>
       <Route path="/health" element={<Health />} />

--- a/apps/kds/.env.example
+++ b/apps/kds/.env.example
@@ -1,2 +1,3 @@
 VITE_API_BASE=http://localhost:3000
 VITE_WS_BASE=ws://localhost:3000
+VITE_DISABLE_RUM=1

--- a/apps/kds/src/routes.tsx
+++ b/apps/kds/src/routes.tsx
@@ -1,8 +1,14 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { capturePageView } from '@neo/utils';
 import { Expo } from './pages/Expo';
 import { Health } from './pages/Health';
 
 export function AppRoutes() {
+  const loc = useLocation();
+  useEffect(() => {
+    capturePageView(loc.pathname);
+  }, [loc.pathname]);
   return (
     <Routes>
       <Route path="/health" element={<Health />} />

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -6,7 +6,9 @@ export interface FetchOptions extends RequestInit {
 export async function apiFetch<T>(path: string, opts: FetchOptions = {}): Promise<T> {
   const { idempotencyKey, tenant, headers, ...rest } = opts;
   const h = new Headers(headers);
-  const token = sessionStorage.getItem('token') || localStorage.getItem('token');
+  const token =
+    (typeof sessionStorage !== 'undefined' && sessionStorage.getItem('token')) ||
+    (typeof localStorage !== 'undefined' && localStorage.getItem('token'));
   if (token) h.set('Authorization', `Bearer ${token}`);
   if (tenant) h.set('X-Tenant', tenant);
   if (idempotencyKey) h.set('Idempotency-Key', idempotencyKey);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,8 @@
     "clsx": "^2.0.0",
     "lucide-react": "^0.364.0",
     "sonner": "^1.4.0",
-    "@neo/api": "workspace:*"
+    "@neo/api": "workspace:*",
+    "@neo/utils": "workspace:*"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.0",

--- a/packages/ui/src/components/global-error-boundary.tsx
+++ b/packages/ui/src/components/global-error-boundary.tsx
@@ -1,5 +1,5 @@
 import { Component, ReactNode } from 'react';
-import { apiFetch } from '@neo/api';
+import { captureError } from '@neo/utils';
 import { Button } from './button';
 
 export interface GlobalErrorBoundaryProps {
@@ -21,14 +21,7 @@ export class GlobalErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error) {
-    void apiFetch('/telemetry/error', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        message: error.message,
-        stack: error.stack
-      })
-    }).catch(() => {});
+    captureError(error);
   }
 
   private handleRetry = () => {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,3 +13,5 @@ export function formatGST(gst: number) {
 export function moneyToWords(amount: number) {
   return `${amount} rupees`;
 }
+
+export { capturePageView, captureError } from './rum';

--- a/packages/utils/src/rum.ts
+++ b/packages/utils/src/rum.ts
@@ -1,0 +1,26 @@
+const TELEMETRY_BASE = (import.meta as any).env?.VITE_TELEMETRY_URL || '/telemetry';
+const DISABLE_RUM = (import.meta as any).env?.VITE_DISABLE_RUM === '1';
+
+function post(path: string, data: unknown) {
+  if (DISABLE_RUM) return;
+  try {
+    const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+    navigator.sendBeacon(`${TELEMETRY_BASE}${path}`, blob);
+  } catch {
+    // ignore
+  }
+}
+
+export function capturePageView(route: string) {
+  const nav = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+  const ttfb = nav ? nav.responseStart - nav.requestStart : undefined;
+  const lcpEntries = performance.getEntriesByType('largest-contentful-paint');
+  const lcp = lcpEntries.length ? lcpEntries[lcpEntries.length - 1].startTime : undefined;
+  post('/pageview', { route, ttfb, lcp });
+}
+
+export function captureError(err: unknown, context?: Record<string, unknown>) {
+  const message = err instanceof Error ? err.message : String(err);
+  const stack = err instanceof Error ? err.stack : undefined;
+  post('/error', { message, stack, context });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       '@neo/api':
         specifier: workspace:*
         version: link:../api
+      '@neo/utils':
+        specifier: workspace:*
+        version: link:../utils
       clsx:
         specifier: ^2.0.0
         version: 2.1.1


### PR DESCRIPTION
## Summary
- add rum utilities for page views and errors with opt-out flag
- wire RUM into admin, guest and kds apps
- guard session token lookup for tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06729bfec832ab2bbe333157bcec5