### PR TITLE
feat(admin): harden auth and respect roles

### DIFF
--- a/apps/admin/src/auth.test.ts
+++ b/apps/admin/src/auth.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { useAuth } from './auth';
+
+function createToken() {
+  const payload = { roles: ['owner'], tenants: [], a: String.fromCharCode(190), b: String.fromCharCode(191) };
+  const base64 = Buffer.from(JSON.stringify(payload))
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  return `aaa.${base64}.bbb`;
+}
+
+describe('auth', () => {
+  beforeEach(() => {
+    useAuth.setState({ token: null, roles: [], tenants: [], tenantId: null });
+    sessionStorage.clear();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  test('decodes base64url tokens', async () => {
+    const token = createToken();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ token })
+    }) as any);
+    await useAuth.getState().login('1234');
+    expect(useAuth.getState().roles).toEqual(['owner']);
+  });
+
+  test('logout removes tenantId', () => {
+    localStorage.setItem('tenantId', '1');
+    sessionStorage.setItem('token', 't');
+    useAuth.setState({ token: 't', roles: ['owner'], tenants: [], tenantId: '1' });
+    useAuth.getState().logout();
+    expect(localStorage.getItem('tenantId')).toBeNull();
+    expect(sessionStorage.getItem('token')).toBeNull();
+  });
+});

--- a/apps/admin/src/components/Layout.test.tsx
+++ b/apps/admin/src/components/Layout.test.tsx
@@ -1,0 +1,29 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { Layout } from './Layout';
+import { useAuth } from '../auth';
+
+describe('Layout', () => {
+  beforeEach(() => {
+    useAuth.setState({
+      token: 't',
+      roles: ['manager'],
+      tenants: [{ id: '1', name: 'A' }],
+      tenantId: '1'
+    });
+  });
+
+  test('managers do not see Billing link', () => {
+    render(
+      <MemoryRouter>
+        <Routes>
+          <Route path="*" element={<Layout />}>
+            <Route index element={<div />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.queryByText('Billing')).toBeNull();
+  });
+});

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -2,7 +2,7 @@ import { Link, Outlet, useNavigate } from 'react-router-dom';
 import { useAuth } from '../auth';
 
 export function Layout() {
-  const { tenants, tenantId, setTenant, logout } = useAuth();
+  const { tenants, tenantId, setTenant, logout, roles } = useAuth();
   const navigate = useNavigate();
   const current = tenants.find((t) => t.id === tenantId);
   return (
@@ -11,7 +11,7 @@ export function Layout() {
         <nav className="flex flex-col space-y-2">
           <Link to="/dashboard">Dashboard</Link>
           <Link to="/floor">Floor</Link>
-          <Link to="/billing">Billing</Link>
+          {roles.includes('owner') && <Link to="/billing">Billing</Link>}
           <Link to="/onboarding">Onboarding</Link>
         </nav>
       </aside>

--- a/apps/admin/src/pages/Login.test.tsx
+++ b/apps/admin/src/pages/Login.test.tsx
@@ -1,0 +1,29 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { Login } from './Login';
+import { useAuth } from '../auth';
+
+describe('Login page', () => {
+  beforeEach(() => {
+    useAuth.setState({ token: null, roles: [], tenants: [], tenantId: null });
+    vi.restoreAllMocks();
+  });
+
+  test('shows error when login request fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: 'Invalid PIN' })
+    }) as any);
+    render(
+      <MemoryRouter>
+        <Login />
+      </MemoryRouter>
+    );
+    await userEvent.type(screen.getByPlaceholderText('PIN'), '1');
+    await userEvent.click(screen.getByText('Login'));
+    await screen.findByRole('alert');
+    expect(screen.getByText('Invalid PIN')).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/pages/Login.tsx
+++ b/apps/admin/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../auth';
 
 export function Login() {
   const [pin, setPin] = useState('');
+  const [error, setError] = useState<string | null>(null);
   const login = useAuth((s) => s.login);
   const navigate = useNavigate();
   const location = useLocation();
@@ -12,8 +13,13 @@ export function Login() {
     <form
       onSubmit={async (e) => {
         e.preventDefault();
-        await login(pin);
-        navigate(from, { replace: true });
+        setError(null);
+        try {
+          await login(pin);
+          navigate(from, { replace: true });
+        } catch (err: any) {
+          setError(err.message || 'Login failed');
+        }
       }}
       className="p-4 space-y-2"
     >
@@ -26,6 +32,11 @@ export function Login() {
       <button type="submit" className="block bg-blue-500 text-white p-2">
         Login
       </button>
+      {error && (
+        <div role="alert" className="text-red-500">
+          {error}
+        </div>
+      )}
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- decode base64url tokens and handle login errors in admin auth
- surface login failures and tenant removal in logout
- hide billing link for non-owners

## Testing
- `pnpm --filter @neo/admin test`


------
https://chatgpt.com/codex/tasks/task_e_68b0686e34d0832a888f49be1bd36131