### PR TITLE
feat(ui): add theme provider and tokens helper

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,3 +3,4 @@ export * from './icons';
 export * from './toast';
 export * from './tokens';
 export { SkeletonList } from './components/Skeleton';
+export { ThemeProvider, tokensFromOutlet } from './theme';

--- a/packages/ui/src/theme.tsx
+++ b/packages/ui/src/theme.tsx
@@ -1,0 +1,29 @@
+import { PropsWithChildren, useEffect } from 'react'
+
+import { colors } from './tokens'
+
+export interface ThemeTokens {
+  primary: string
+  accent: string
+  logoURL: string
+}
+
+export function tokensFromOutlet(outlet: any): ThemeTokens {
+  const theme = outlet?.theme ?? {}
+  return {
+    primary: theme.primary ?? colors.primary,
+    accent: theme.accent ?? colors.secondary,
+    logoURL: theme.logoURL ?? ''
+  }
+}
+
+export function ThemeProvider({ theme, children }: PropsWithChildren<{ theme: ThemeTokens }>) {
+  useEffect(() => {
+    const root = document.documentElement
+    root.style.setProperty('--color-primary', theme.primary)
+    root.style.setProperty('--color-accent', theme.accent)
+    root.style.setProperty('--logo-url', theme.logoURL)
+  }, [theme])
+
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- add tokensFromOutlet helper to derive theme colors and logo
- provide ThemeProvider that writes CSS variables for theme tokens
- export theme helper and provider from package entry

## Testing
- `pnpm --filter @neo/ui lint`
- `pnpm --filter @neo/ui test`
- `pnpm --filter @neo/ui typecheck` *(fails: Cannot find module '@neo/api')*
- `pnpm --filter @neo/ui build` *(fails: Could not find a declaration file for module '@neo/api')*

------
https://chatgpt.com/codex/tasks/task_e_68b0688006f8832a9ff66c4e6589d48f