### PR TITLE
fix: reference env vars in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
   deploy-staging:
     needs: build-and-push
-    if: secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    if: env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -100,7 +100,7 @@ jobs:
 
   deploy-prod:
     needs: manual-approval
-    if: secrets.KUBE_CONFIG_PROD != '' && secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    if: env.KUBE_CONFIG_PROD != '' && env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     environment: prod
     env:


### PR DESCRIPTION
## Summary
- reference env variables for deploy-staging and deploy-prod gating checks

## Testing
- `pnpm test`
- `pytest` *(fails: import file mismatch in tests/test_alembic_env.py and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b1362a4398832a83d415dd4b1f7b38