### PR TITLE
chore(kds): memoize filters and add zone test

### DIFF
--- a/apps/kds/src/pages/Expo.test.tsx
+++ b/apps/kds/src/pages/Expo.test.tsx
@@ -98,6 +98,21 @@ describe('Expo', () => {
     expect(screen.getByTestId('ticket-2')).toBeInTheDocument();
   });
 
+  test('Zone filter narrows tickets', async () => {
+    apiFetch.mockResolvedValueOnce({
+      tickets: [
+        { id: '1', table: 'T1', items: [], status: 'NEW', age_s: 0, promise_s: 300, zone: 'A' },
+        { id: '2', table: 'T2', items: [], status: 'NEW', age_s: 0, promise_s: 300, zone: 'B' }
+      ]
+    });
+    render(<Expo />);
+    await screen.findByTestId('ticket-1');
+    await screen.findByTestId('ticket-2');
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'A');
+    expect(screen.getByTestId('ticket-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('ticket-2')).not.toBeInTheDocument();
+  });
+
   test('Search query filters tickets', async () => {
     apiFetch.mockResolvedValueOnce({
       tickets: [

--- a/apps/kds/src/pages/Expo.tsx
+++ b/apps/kds/src/pages/Expo.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { apiFetch, useWS } from '@neo/api';
 import { WS_BASE } from '../env';
 import { PinModal } from '../components/PinModal';
@@ -122,16 +122,23 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
   };
   const allStatuses: Status[] = ['NEW', 'PREPARING', 'READY', 'PICKED'];
   const columns: Status[] = statusFilter === 'ALL' ? allStatuses : [statusFilter];
-  const zones = Array.from(new Set(tickets.map((t) => t.zone).filter(Boolean))) as string[];
-  const filteredTickets = tickets.filter((t) => {
-    const matchStatus = statusFilter === 'ALL' ? true : t.status === statusFilter;
-    const q = searchQuery.toLowerCase();
-    const matchSearch = q
-      ? t.table.toLowerCase().includes(q) || t.items.some((i) => i.name.toLowerCase().includes(q))
-      : true;
-    const matchZone = zone ? t.zone === zone : true;
-    return matchStatus && matchSearch && matchZone;
-  });
+  const zones = useMemo(
+    () => Array.from(new Set(tickets.map((t) => t.zone).filter(Boolean))) as string[],
+    [tickets]
+  );
+  const filteredTickets = useMemo(
+    () =>
+      tickets.filter((t) => {
+        const matchStatus = statusFilter === 'ALL' ? true : t.status === statusFilter;
+        const q = searchQuery.toLowerCase();
+        const matchSearch = q
+          ? t.table.toLowerCase().includes(q) || t.items.some((i) => i.name.toLowerCase().includes(q))
+          : true;
+        const matchZone = zone ? t.zone === zone : true;
+        return matchStatus && matchSearch && matchZone;
+      }),
+    [tickets, statusFilter, searchQuery, zone]
+  );
   return (
     <div className="p-4 space-y-4">
       {offline && (


### PR DESCRIPTION
## Summary
- memoize zone and ticket filtering in KDS Expo
- add tests for zone filtering alongside status and search

## Testing
- `pnpm test apps/kds` *(fails: no tests in some workspaces)*
- `pnpm --filter @neo/kds test`


------
https://chatgpt.com/codex/tasks/task_e_68b1359a743c832a84048e3aba27dd3e