### PR TITLE
refactor(ui): inline tailwind colors with css vars

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1,0 +1,7 @@
+:root {
+  --color-primary: #2563eb;
+  --color-secondary: #64748b;
+  --color-success: #16a34a;
+  --color-warn: #f59e0b;
+  --color-error: #dc2626;
+}

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,11 +1,16 @@
 import type { Config } from 'tailwindcss';
-import { colors } from './src/tokens';
 
 export default {
   content: ['../**/*.{ts,tsx}'],
   theme: {
     extend: {
-      colors
+      colors: {
+        primary: 'var(--color-primary)',
+        secondary: 'var(--color-secondary)',
+        success: 'var(--color-success)',
+        warn: 'var(--color-warn)',
+        error: 'var(--color-error)'
+      }
     }
   },
   plugins: []


### PR DESCRIPTION
## Summary
- inline Tailwind color extension with CSS variable references
- set default CSS variable values to avoid undefined colors

## Testing
- `pnpm --filter @neo/ui test`
- `pnpm --filter @neo/ui build` *(fails: Cannot find module '@neo/utils')*
- `pre-commit run --files packages/ui/tailwind.config.ts packages/ui/src/index.css` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1355257c0832aa1a039f4217cbeb4