### PR TITLE
refactor: validate prod secrets in workflow

### DIFF
--- a/.github/workflows/synthetic_monitor.yml
+++ b/.github/workflows/synthetic_monitor.yml
@@ -98,14 +98,10 @@ jobs:
         run: exit 1
 
   prod:
-    if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
+    if: >
+      (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
       github.ref == 'refs/heads/main' &&
-      !github.event.pull_request.head.repo.fork &&
-      secrets.API_BASE_URL != '' &&
-      secrets.SYN_TENANT_ID != '' &&
-      secrets.SYN_TABLE_CODE != '' &&
-      secrets.AUTH_TOKEN != '' &&
-      secrets.SYN_ENABLED_PROD == 'true' }}
+      !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     environment: prod
     env:
@@ -132,6 +128,10 @@ jobs:
           done
           if (( ${#missing[@]} )); then
             echo "Missing required secrets: ${missing[*]}" >&2
+            exit 1
+          fi
+          if [[ "$SYN_ENABLED_PROD" != "true" ]]; then
+            echo "SYN_ENABLED_PROD must be 'true'" >&2
             exit 1
           fi
       - name: Sanity check


### PR DESCRIPTION
## Summary
- simplify `prod` job `if` expression to only use `github` context
- validate required secrets via `Guard` step, including `SYN_ENABLED_PROD`

## Testing
- `/tmp/actionlint .github/workflows/synthetic_monitor.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b13636b020832a8cbbbceab17a6474