### PR TITLE
feat: submit utr to server

### DIFF
--- a/apps/guest/src/pages/Pay.tsx
+++ b/apps/guest/src/pages/Pay.tsx
@@ -127,9 +127,16 @@ export function PayPage() {
             />
           </label>
           <button
-            onClick={() => {
-              setShowUtr(false);
-              setShowQr(true);
+            onClick={async () => {
+              const res = await fetch(`/api/orders/${orderId}/utr`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ orderId, utr }),
+              });
+              if (res.ok) {
+                setShowUtr(false);
+                setShowQr(true);
+              }
             }}
           >
             Submit


### PR DESCRIPTION
## Summary
- post UTR and orderId to /api/orders/{orderId}/utr and only show cashier QR after success
- add test ensuring UTR submission uses correct payload
- update polling test for UTR submission

## Testing
- `pnpm -F @neo/guest test`


------
https://chatgpt.com/codex/tasks/task_e_68b138f88c78832a8afdccd407066894