### PR TITLE
Handle invoice fetch errors on Pay page

### DIFF
--- a/apps/guest/src/__tests__/pay.test.tsx
+++ b/apps/guest/src/__tests__/pay.test.tsx
@@ -36,6 +36,16 @@ describe('pay page', () => {
     global.fetch = jest.fn();
   });
 
+  test('shows error message when invoice fetch fails', async () => {
+    // @ts-ignore
+    global.fetch.mockRejectedValueOnce(new Error('Network'));
+
+    renderPay();
+
+    const msg = await screen.findByText(/failed to load invoice/i);
+    expect(msg).toBeInTheDocument();
+  });
+
   test('UPI URL contains pa/pn/am', async () => {
     // @ts-ignore
     global.fetch.mockResolvedValueOnce({

--- a/apps/guest/src/pages/Pay.tsx
+++ b/apps/guest/src/pages/Pay.tsx
@@ -19,15 +19,21 @@ interface Invoice {
 export function PayPage() {
   const { orderId } = useParams();
   const [invoice, setInvoice] = useState<Invoice | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [showUtr, setShowUtr] = useState(false);
   const [utr, setUtr] = useState('');
   const [showQr, setShowQr] = useState(false);
   const [status, setStatus] = useState<'waiting' | 'success'>('waiting');
 
   useEffect(() => {
+    setError(null);
     fetch(`/api/orders/${orderId}`)
-      .then((r) => r.json())
-      .then(setInvoice);
+      .then((r) => {
+        if (!r.ok) throw new Error('Failed to fetch');
+        return r.json();
+      })
+      .then(setInvoice)
+      .catch(() => setError('Failed to load invoice'));
   }, [orderId]);
 
   const upiLink = invoice?.upi
@@ -50,6 +56,14 @@ export function PayPage() {
     }
     return () => clearInterval(int);
   }, [showQr, orderId, status]);
+
+  if (error)
+    return (
+      <div>
+        <Header />
+        <p>Failed to load invoice.</p>
+      </div>
+    );
 
   if (!invoice) return (
     <div>


### PR DESCRIPTION
## Summary
- handle fetch failures by setting an error state
- display error message when invoice can't be loaded
- cover failed invoice fetch with a test

## Testing
- `pnpm --filter @neo/guest test`

------
https://chatgpt.com/codex/tasks/task_e_68b13b6e8584832a94ed519c1da43510