### PR TITLE
feat(ui): use captureError for telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Reference `ASSETLINKS_HOST` secret via env in TWA workflow to fix invalid conditional.
 
 - Correct sales register and GST summary exports to emit expected CSV headers and values.
+- Replace `/telemetry/error` fetch with SSR-safe `captureError` in the global error boundary.
 
 ## v1.0.0 - 2025-08-26
 

--- a/packages/ui/src/components/global-error-boundary.tsx
+++ b/packages/ui/src/components/global-error-boundary.tsx
@@ -21,7 +21,9 @@ export class GlobalErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error) {
-    captureError(error);
+    if (typeof window !== 'undefined') {
+      captureError(error);
+    }
   }
 
   private handleRetry = () => {

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@neo/config/tsconfig",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": true
   }
 }


### PR DESCRIPTION
## Summary
- report global errors via `captureError` and guard for SSR
- generate declaration files for utils package
- document switch in changelog

## Testing
- `pnpm --filter @neo/utils test`
- `pnpm --filter @neo/ui test`
- `pnpm --filter @neo/utils build`
- `pnpm --filter @neo/ui build`


------
https://chatgpt.com/codex/tasks/task_e_68b13b68613c832a9a9e209f24e25cf6