### PR TITLE
feat: serve SPA static files

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -2,6 +2,9 @@
   "urls": [
     "http://localhost:8000/help/qr",
     "http://localhost:8000/help/network",
-    "http://localhost:8000/help/printing"
+    "http://localhost:8000/help/printing",
+    "http://localhost:8000/guest",
+    "http://localhost:8000/admin",
+    "http://localhost:8000/kds"
   ]
 }


### PR DESCRIPTION
## Summary
- mount built guest, admin and kds SPAs in FastAPI
- extend Pa11y checks to cover guest, admin and kds routes

## Testing
- `pre-commit run --files api/app/main.py .pa11yci`
- `pytest` *(fails: tests/test_alembic_env.py ... tests/test_time_skew.py)*
- `npx -y pa11y-ci -c .pa11yci` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b13c93520c832ab699db1ef9326ecd