### PR TITLE
ci: install pnpm in lighthouse workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -41,6 +41,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Install pnpm
+        run: corepack enable && corepack prepare pnpm@latest --activate
+      - name: Verify pnpm installation
+        run: pnpm --version
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
## Summary
- enable corepack and install pnpm in lighthouse workflow
- verify pnpm setup before running Lighthouse CI

## Testing
- `pre-commit run --files .github/workflows/lighthouse.yml`
- `pnpm --version`
- `lhci autorun --config=lighthouserc.json` *(fails: chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_e_68b13ee25fd0832a8b07283236c080e1