### PR TITLE
refactor(guest): use setInterval return type

### DIFF
--- a/apps/guest/src/pages/Pay.tsx
+++ b/apps/guest/src/pages/Pay.tsx
@@ -43,7 +43,7 @@ export function PayPage() {
     : '';
 
   useEffect(() => {
-    let int: NodeJS.Timer | undefined;
+    let int: ReturnType<typeof setInterval> | undefined;
     if (showQr && status !== 'success') {
       int = setInterval(async () => {
         const res = await fetch(`/api/orders/${orderId}/payment-status`);
@@ -54,7 +54,9 @@ export function PayPage() {
         }
       }, 1000);
     }
-    return () => clearInterval(int);
+    return () => {
+      if (int) clearInterval(int);
+    };
   }, [showQr, orderId, status]);
 
   if (error)


### PR DESCRIPTION
## Summary
- use `ReturnType<typeof setInterval>` for polling timer in PayPage
- guard interval cleanup

## Testing
- `pnpm -F @neo/guest test`
- `pnpm -F @neo/guest typecheck` *(fails: Cannot find module '@neo/ui' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b157edfd04832aaddb129a63782b5d