### PR TITLE
feat(guest): Pay Now (UPI intents + manual verify) with status poll

### DIFF
--- a/apps/guest/src/__tests__/pay.test.tsx
+++ b/apps/guest/src/__tests__/pay.test.tsx
@@ -67,6 +67,29 @@ describe('pay page', () => {
     expect(href).toContain('am=55');
   });
 
+  test('skip UTR still shows QR', async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [],
+        tax: 0,
+        total: 55,
+        upi: { pa: 't@upi', pn: 'T' },
+        onlineUpi: true,
+      }),
+    });
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    renderPay();
+    await screen.findByText(/total/i);
+    fireEvent.click(screen.getByRole('button', { name: /i've paid/i }));
+    fireEvent.click(screen.getByRole('button', { name: /skip/i }));
+
+    expect(screen.getByTestId('cashier-qr')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   test('posts utr and orderId', async () => {
     jest.useFakeTimers();
     const fetchMock = jest

--- a/apps/guest/src/pages/Pay.tsx
+++ b/apps/guest/src/pages/Pay.tsx
@@ -142,21 +142,31 @@ export function PayPage() {
               onChange={(e) => setUtr(e.target.value)}
             />
           </label>
-          <button
-            onClick={async () => {
-              const res = await fetch(`/api/orders/${orderId}/utr`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ orderId, utr }),
-              });
-              if (res.ok) {
+          <div>
+            <button
+              onClick={async () => {
+                const res = await fetch(`/api/orders/${orderId}/utr`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ orderId, utr }),
+                });
+                if (res.ok) {
+                  setShowUtr(false);
+                  setShowQr(true);
+                }
+              }}
+            >
+              Submit
+            </button>
+            <button
+              onClick={() => {
                 setShowUtr(false);
                 setShowQr(true);
-              }
-            }}
-          >
-            Submit
-          </button>
+              }}
+            >
+              Skip
+            </button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow skipping UTR entry when confirming payment and show cashier QR
- cover skip path with tests alongside existing UPI deep link and payment-status polling

## Testing
- `pnpm --filter @neo/guest test`

------
https://chatgpt.com/codex/tasks/task_e_68b1597e61c0832a9f2ba2918519368a