### PR TITLE
feat(kds): add keyboard navigation

### DIFF
--- a/apps/kds/src/pages/Expo.tsx
+++ b/apps/kds/src/pages/Expo.tsx
@@ -28,6 +28,7 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
   const [statusFilter, setStatusFilter] = useState<Status | 'ALL'>('ALL');
   const [searchQuery, setSearchQuery] = useState('');
   const [zone, setZone] = useState<string | undefined>();
+  const [order, setOrder] = useState<string[]>([]);
 
   const fetchTickets = useCallback(async () => {
     try {
@@ -59,6 +60,14 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
   });
 
   useEffect(() => {
+    setOrder((prev) => {
+      const existing = prev.filter((id) => tickets.some((t) => t.id === id));
+      const newIds = tickets.map((t) => t.id).filter((id) => !existing.includes(id));
+      return [...existing, ...newIds];
+    });
+  }, [tickets]);
+
+  useEffect(() => {
     let timer: NodeJS.Timeout | undefined;
     if (!connected) {
       timer = setTimeout(() => setOffline(true), offlineMs);
@@ -88,29 +97,6 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
     }
   };
 
-  const onKey = useCallback(
-    (e: KeyboardEvent) => {
-      if (!focused) return;
-      const t = tickets.find((x) => x.id === focused);
-      if (!t) return;
-      if (e.key === 'a' || e.key === 'A') {
-        if (t.status === 'NEW') action(t.id, 'PREPARING', `/kds/tickets/${t.id}/accept`);
-      } else if (e.key === 'r' || e.key === 'R') {
-        if (t.status === 'PREPARING') action(t.id, 'READY', `/kds/tickets/${t.id}/ready`);
-      } else if (e.key === 'p' || e.key === 'P') {
-        if (t.status === 'READY') action(t.id, 'PICKED', `/kds/tickets/${t.id}/picked`);
-      } else if (e.key === 'z' || e.key === 'Z') {
-        if (t.status === 'PICKED') action(t.id, 'READY', `/kds/tickets/${t.id}/undo`);
-      }
-    },
-    [focused, tickets]
-  );
-
-  useEffect(() => {
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onKey]);
-
   const formatAge = (age_s: number) => {
     const m = Math.floor(age_s / 60);
     return `${m}m`;
@@ -126,9 +112,13 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
     () => Array.from(new Set(tickets.map((t) => t.zone).filter(Boolean))) as string[],
     [tickets]
   );
+  const orderedTickets = useMemo(
+    () => [...tickets].sort((a, b) => order.indexOf(a.id) - order.indexOf(b.id)),
+    [tickets, order]
+  );
   const filteredTickets = useMemo(
     () =>
-      tickets.filter((t) => {
+      orderedTickets.filter((t) => {
         const matchStatus = statusFilter === 'ALL' ? true : t.status === statusFilter;
         const q = searchQuery.toLowerCase();
         const matchSearch = q
@@ -137,8 +127,63 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
         const matchZone = zone ? t.zone === zone : true;
         return matchStatus && matchSearch && matchZone;
       }),
-    [tickets, statusFilter, searchQuery, zone]
+    [orderedTickets, statusFilter, searchQuery, zone]
   );
+  const columnTickets = useMemo(() => {
+    const map: Record<Status, Ticket[]> = { NEW: [], PREPARING: [], READY: [], PICKED: [] };
+    filteredTickets.forEach((t) => {
+      map[t.status].push(t);
+    });
+    return map;
+  }, [filteredTickets]);
+  const onKey = useCallback(
+    (e: KeyboardEvent) => {
+      if (!focused) return;
+      const t = tickets.find((x) => x.id === focused);
+      if (!t) return;
+      if (e.key === 'a' || e.key === 'A') {
+        if (t.status === 'NEW') action(t.id, 'PREPARING', `/kds/tickets/${t.id}/accept`);
+      } else if (e.key === 'r' || e.key === 'R') {
+        if (t.status === 'PREPARING') action(t.id, 'READY', `/kds/tickets/${t.id}/ready`);
+      } else if (e.key === 'p' || e.key === 'P') {
+        if (t.status === 'READY') action(t.id, 'PICKED', `/kds/tickets/${t.id}/picked`);
+      } else if (e.key === 'z' || e.key === 'Z') {
+        if (t.status === 'PICKED') action(t.id, 'READY', `/kds/tickets/${t.id}/undo`);
+      } else if (e.key === 'ArrowDown') {
+        const list = columnTickets[t.status];
+        const idx = list.findIndex((x) => x.id === t.id);
+        if (idx < list.length - 1) setFocused(list[idx + 1].id);
+      } else if (e.key === 'ArrowUp') {
+        const list = columnTickets[t.status];
+        const idx = list.findIndex((x) => x.id === t.id);
+        if (idx > 0) setFocused(list[idx - 1].id);
+      } else if (e.key === 'ArrowRight') {
+        const colIdx = columns.indexOf(t.status);
+        if (colIdx >= 0 && colIdx < columns.length - 1) {
+          const nextCol = columns[colIdx + 1];
+          const idx = columnTickets[t.status].findIndex((x) => x.id === t.id);
+          const dest = columnTickets[nextCol];
+          if (dest.length) setFocused(dest[Math.min(idx, dest.length - 1)].id);
+        }
+      } else if (e.key === 'ArrowLeft') {
+        const colIdx = columns.indexOf(t.status);
+        if (colIdx > 0) {
+          const prevCol = columns[colIdx - 1];
+          const idx = columnTickets[t.status].findIndex((x) => x.id === t.id);
+          const dest = columnTickets[prevCol];
+          if (dest.length) setFocused(dest[Math.min(idx, dest.length - 1)].id);
+        }
+      } else if (e.key === 'Enter') {
+        window.location.assign(`/kds/tickets/${t.id}`);
+      }
+    },
+    [focused, tickets, columns, columnTickets]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onKey]);
   return (
     <div className="p-4 space-y-4">
       {offline && (
@@ -184,9 +229,7 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
           <div key={col}>
             <h3 className="font-semibold mb-2">{col.charAt(0) + col.slice(1).toLowerCase()}</h3>
             <ul className="space-y-2">
-              {filteredTickets
-                .filter((t) => t.status === col)
-                .map((t) => (
+              {columnTickets[col].map((t) => (
                   <li
                     key={t.id}
                     data-testid={`ticket-${t.id}`}


### PR DESCRIPTION
## Summary
- enable arrow-key navigation and enter-to-open on Expo tickets
- track ticket order for deterministic focus movement
- test keyboard navigation and detail open actions

## Testing
- `pnpm test apps/kds` *(fails: pwa test: No tests found)*
- `pnpm --filter @neo/kds test`


------
https://chatgpt.com/codex/tasks/task_e_68b15947a730832aa198f46be2efc885