### PR TITLE
test: add MenuEditor tests and export control

### DIFF
--- a/apps/admin/src/pages/MenuEditor.test.tsx
+++ b/apps/admin/src/pages/MenuEditor.test.tsx
@@ -1,0 +1,68 @@
+import { describe, test, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MenuEditor } from './MenuEditor';
+import * as api from '@neo/api';
+
+vi.mock('react-router-dom', async () => {
+  const actual: any = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    unstable_useBlocker: () => ({ state: 'unblocked', proceed: vi.fn(), reset: vi.fn() })
+  };
+});
+
+vi.mock('@neo/api', () => ({
+  getCategories: vi.fn(),
+  createCategory: vi.fn(),
+  getItems: vi.fn(),
+  updateItem: vi.fn(),
+  exportMenuI18n: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('MenuEditor', () => {
+  test('Creating a category renders it in the category list', async () => {
+    render(<MenuEditor />);
+    await userEvent.click(screen.getByText('Add Category'));
+    expect(screen.getByDisplayValue('New Category')).toBeInTheDocument();
+  });
+
+  test("Updating an item's price persists after save", async () => {
+    render(<MenuEditor />);
+    await userEvent.click(screen.getByText('Add Item'));
+    const priceInput = screen.getByDisplayValue('0') as HTMLInputElement;
+    await userEvent.clear(priceInput);
+    await userEvent.type(priceInput, '99');
+    await userEvent.click(screen.getByText('Save'));
+    expect(priceInput).toHaveValue(99);
+    expect(screen.getByText('Save')).toBeDisabled();
+  });
+
+  test('Editing hi tab updates name_i18n["hi"]', async () => {
+    render(<MenuEditor />);
+    await userEvent.click(screen.getByText('Add Item'));
+    const row = screen.getAllByRole('row')[1];
+    const nameCell = within(row).getAllByRole('cell')[1];
+    await userEvent.click(nameCell);
+    await userEvent.click(screen.getByRole('button', { name: 'HI' }));
+    const nameInput = screen.getByPlaceholderText('Name') as HTMLInputElement;
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Namaste');
+    await userEvent.click(screen.getByRole('button', { name: 'EN' }));
+    await userEvent.click(screen.getByRole('button', { name: 'HI' }));
+    expect(screen.getByPlaceholderText('Name')).toHaveValue('Namaste');
+  });
+
+  test('Export button calls exportMenuI18n with selected languages', async () => {
+    render(<MenuEditor />);
+    await userEvent.click(screen.getByLabelText('EN'));
+    await userEvent.click(screen.getByLabelText('HI'));
+    await userEvent.click(screen.getByText('Export'));
+    expect(api.exportMenuI18n).toHaveBeenCalledWith(['en', 'hi']);
+  });
+});

--- a/apps/admin/src/pages/MenuEditor.tsx
+++ b/apps/admin/src/pages/MenuEditor.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Toaster, toast, Button } from '@neo/ui';
 import { unstable_useBlocker as useBlocker } from 'react-router-dom';
+import { exportMenuI18n } from '@neo/api';
 
 interface Category {
   id: string;
@@ -46,6 +47,7 @@ export function MenuEditor() {
   const [selectedItems, setSelectedItems] = useState<Record<string, boolean>>({});
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [dirty, setDirty] = useState(false);
+  const [exportLangs, setExportLangs] = useState<string[]>([]);
 
   const items = itemsMap[selectedCat] || [];
 
@@ -60,6 +62,12 @@ export function MenuEditor() {
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
   }, [dirty]);
+
+  const toggleExportLang = (l: string) => {
+    setExportLangs((prev) =>
+      prev.includes(l) ? prev.filter((x) => x !== l) : [...prev, l]
+    );
+  };
 
   const addCategory = () => {
     const id = `cat-${Date.now()}`;
@@ -259,8 +267,23 @@ export function MenuEditor() {
             ))}
           </tbody>
         </table>
-        <div className="mt-4">
+        <div className="mt-4 flex items-center space-x-4">
           <Button onClick={save} disabled={!dirty}>Save</Button>
+          <div className="flex items-center space-x-2">
+            {LANGS.map((l) => (
+              <label key={l} className="flex items-center space-x-1">
+                <input
+                  type="checkbox"
+                  checked={exportLangs.includes(l)}
+                  onChange={() => toggleExportLang(l)}
+                />
+                <span>{l.toUpperCase()}</span>
+              </label>
+            ))}
+            <Button onClick={() => exportMenuI18n(exportLangs)} disabled={!exportLangs.length}>
+              Export
+            </Button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add export language controls to MenuEditor and wire to API
- test MenuEditor for category creation, item price save, i18n editing, and export

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b15908ac58832aa363531c5974eda4