### PR TITLE
feat(ui): runtime tenant theming (tokens + logo) wired to all apps

### DIFF
--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -17,7 +17,11 @@ export function Layout() {
       </aside>
       <div className="flex-1 flex flex-col">
         <header className="flex justify-between items-center p-2 border-b">
-          <div>
+          <div className="flex items-center space-x-2">
+            <div
+              className="h-8 w-24 bg-contain bg-no-repeat"
+              style={{ backgroundImage: 'var(--logo-url)' }}
+            />
             {tenants.length > 1 ? (
               <select
                 value={tenantId ?? undefined}

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { GlobalErrorBoundary } from '@neo/ui';
+import { GlobalErrorBoundary, ThemeProvider, tokensFromOutlet } from '@neo/ui';
 import { capturePageView } from '@neo/utils';
 import './index.css';
 import './i18n';
@@ -21,12 +21,20 @@ if ('serviceWorker' in navigator) {
   wb.register();
 }
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <GlobalErrorBoundary>
-      <QueryClientProvider client={qc}>
-        <RouterProvider router={router} />
-      </QueryClientProvider>
-    </GlobalErrorBoundary>
-  </React.StrictMode>,
-);
+async function init() {
+  const outlet = await fetch('/api/outlet/theme').then(r => r.json()).catch(() => ({}));
+  const tokens = tokensFromOutlet(outlet);
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <ThemeProvider theme={tokens}>
+        <GlobalErrorBoundary>
+          <QueryClientProvider client={qc}>
+            <RouterProvider router={router} />
+          </QueryClientProvider>
+        </GlobalErrorBoundary>
+      </ThemeProvider>
+    </React.StrictMode>,
+  );
+}
+
+init();

--- a/apps/admin/src/pages/Onboarding.tsx
+++ b/apps/admin/src/pages/Onboarding.tsx
@@ -1,3 +1,37 @@
+import { useState } from 'react';
+
 export function Onboarding() {
-  return <div>Onboarding</div>;
+  const [color, setColor] = useState('#2563eb');
+  const [logo, setLogo] = useState<string>('');
+
+  const onColor = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setColor(value);
+    document.documentElement.style.setProperty('--color-primary', value);
+  };
+
+  const onLogo = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    setLogo(url);
+    document.documentElement.style.setProperty('--logo-url', `url(${url})`);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block mb-1">Primary Color</label>
+        <input type="color" value={color} onChange={onColor} />
+      </div>
+      <div>
+        <label className="block mb-1">Logo</label>
+        <input type="file" accept="image/*" onChange={onLogo} />
+      </div>
+      <div
+        className="h-24 w-48 border bg-no-repeat bg-contain"
+        style={{ backgroundColor: 'var(--color-primary)', backgroundImage: 'var(--logo-url)' }}
+      />
+    </div>
+  );
 }

--- a/apps/guest/src/components/Header.tsx
+++ b/apps/guest/src/components/Header.tsx
@@ -13,7 +13,11 @@ export function Header() {
   };
 
   return (
-    <header className="p-2 flex justify-end">
+    <header className="p-2 flex items-center justify-between">
+      <div
+        className="h-8 w-24 bg-contain bg-no-repeat"
+        style={{ backgroundImage: 'var(--logo-url)' }}
+      />
       <select aria-label="language" value={lang} onChange={change}>
         <option value="en">EN</option>
         <option value="es">ES</option>

--- a/apps/guest/src/main.tsx
+++ b/apps/guest/src/main.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Toaster, GlobalErrorBoundary } from '@neo/ui';
+import { Toaster, GlobalErrorBoundary, ThemeProvider, tokensFromOutlet } from '@neo/ui';
 import './index.css';
 import './i18n';
 import { AppRoutes } from './routes';
@@ -15,15 +15,23 @@ if ('serviceWorker' in navigator) {
   wb.register();
 }
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <GlobalErrorBoundary>
-      <QueryClientProvider client={qc}>
-        <BrowserRouter>
-          <AppRoutes />
-        </BrowserRouter>
-      </QueryClientProvider>
-      <Toaster />
-    </GlobalErrorBoundary>
-  </React.StrictMode>
-);
+async function init() {
+  const outlet = await fetch('/api/outlet/theme').then(r => r.json()).catch(() => ({}));
+  const tokens = tokensFromOutlet(outlet);
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <ThemeProvider theme={tokens}>
+        <GlobalErrorBoundary>
+          <QueryClientProvider client={qc}>
+            <BrowserRouter>
+              <AppRoutes />
+            </BrowserRouter>
+          </QueryClientProvider>
+          <Toaster />
+        </GlobalErrorBoundary>
+      </ThemeProvider>
+    </React.StrictMode>,
+  );
+}
+
+init();

--- a/apps/kds/src/main.tsx
+++ b/apps/kds/src/main.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Toaster, GlobalErrorBoundary } from '@neo/ui';
+import { Toaster, GlobalErrorBoundary, ThemeProvider, tokensFromOutlet } from '@neo/ui';
 import './index.css';
 import './i18n';
 import { Workbox } from 'workbox-window';
@@ -15,15 +15,23 @@ if ('serviceWorker' in navigator) {
   wb.register();
 }
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <GlobalErrorBoundary>
-      <QueryClientProvider client={qc}>
-        <BrowserRouter>
-          <AppRoutes />
-        </BrowserRouter>
-      </QueryClientProvider>
-      <Toaster />
-    </GlobalErrorBoundary>
-  </React.StrictMode>
-);
+async function init() {
+  const outlet = await fetch('/api/outlet/theme').then(r => r.json()).catch(() => ({}));
+  const tokens = tokensFromOutlet(outlet);
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <ThemeProvider theme={tokens}>
+        <GlobalErrorBoundary>
+          <QueryClientProvider client={qc}>
+            <BrowserRouter>
+              <AppRoutes />
+            </BrowserRouter>
+          </QueryClientProvider>
+          <Toaster />
+        </GlobalErrorBoundary>
+      </ThemeProvider>
+    </React.StrictMode>,
+  );
+}
+
+init();

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,7 @@
     "dev": "tsc -w -p tsconfig.json",
     "lint": "echo lint",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "echo 'no tests'",
+    "test": "vitest run",
     "postinstall": "shadcn-ui init -y || true"
   },
   "peerDependencies": {
@@ -28,6 +28,10 @@
     "postcss": "^8.4.0",
     "autoprefixer": "^10.4.0",
     "shadcn-ui": "latest",
-    "@neo/config": "workspace:*"
+    "@neo/config": "workspace:*",
+    "vite": "^5.1.4",
+    "vitest": "^1.3.0",
+    "@testing-library/react": "^14.0.0",
+    "jsdom": "^20.0.3"
   }
 }

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1,7 +1,9 @@
 :root {
   --color-primary: #2563eb;
+  --color-accent: #64748b;
   --color-secondary: #64748b;
   --color-success: #16a34a;
   --color-warn: #f59e0b;
   --color-error: #dc2626;
+  --logo-url: url('');
 }

--- a/packages/ui/src/theme.test.tsx
+++ b/packages/ui/src/theme.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest'
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react-dom/test-utils'
+import { ThemeProvider, ThemeTokens } from './theme'
+
+function render(theme: ThemeTokens) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(<ThemeProvider theme={theme}><div /></ThemeProvider>)
+  })
+  return root
+}
+
+describe('ThemeProvider', () => {
+  test('updates css vars on theme change', () => {
+    const rootEl = document.documentElement
+    const root = render({ primary: 'red', accent: 'blue', logoURL: 'a.png' })
+    expect(rootEl.style.getPropertyValue('--color-primary')).toBe('red')
+    expect(rootEl.style.getPropertyValue('--color-accent')).toBe('blue')
+    expect(rootEl.style.getPropertyValue('--logo-url')).toBe('url(a.png)')
+    act(() => {
+      root.render(<ThemeProvider theme={{ primary: 'green', accent: 'orange', logoURL: 'b.png' }}><div /></ThemeProvider>)
+    })
+    expect(rootEl.style.getPropertyValue('--color-primary')).toBe('green')
+    expect(rootEl.style.getPropertyValue('--color-accent')).toBe('orange')
+    expect(rootEl.style.getPropertyValue('--logo-url')).toBe('url(b.png)')
+  })
+})

--- a/packages/ui/src/theme.tsx
+++ b/packages/ui/src/theme.tsx
@@ -22,7 +22,8 @@ export function ThemeProvider({ theme, children }: PropsWithChildren<{ theme: Th
     const root = document.documentElement
     root.style.setProperty('--color-primary', theme.primary)
     root.style.setProperty('--color-accent', theme.accent)
-    root.style.setProperty('--logo-url', theme.logoURL)
+    root.style.setProperty('--color-secondary', theme.accent)
+    root.style.setProperty('--logo-url', theme.logoURL ? `url(${theme.logoURL})` : '')
   }, [theme])
 
   return <>{children}</>

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -6,6 +6,7 @@ export default {
     extend: {
       colors: {
         primary: 'var(--color-primary)',
+        accent: 'var(--color-accent)',
         secondary: 'var(--color-secondary)',
         success: 'var(--color-success)',
         warn: 'var(--color-warn)',

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,0 +1,19 @@
+import base from '@neo/config/vite'
+import { defineConfig, mergeConfig } from 'vite'
+import { fileURLToPath, URL } from 'node:url'
+
+export default mergeConfig(
+  base,
+  defineConfig({
+    resolve: {
+      alias: {
+        '@neo/api': fileURLToPath(new URL('../api/src/index.ts', import.meta.url)),
+        '@neo/ui': fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+        '@neo/utils': fileURLToPath(new URL('../utils/src/index.ts', import.meta.url))
+      }
+    },
+    test: {
+      environment: 'jsdom'
+    }
+  })
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,9 +346,15 @@ importers:
       '@neo/config':
         specifier: workspace:*
         version: link:../config
+      '@testing-library/react':
+        specifier: ^14.0.0
+        version: 14.3.1(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       autoprefixer:
         specifier: ^10.4.0
         version: 10.4.21(postcss@8.5.6)
+      jsdom:
+        specifier: ^20.0.3
+        version: 20.0.3
       postcss:
         specifier: ^8.4.0
         version: 8.5.6
@@ -358,6 +364,12 @@ importers:
       tailwindcss:
         specifier: ^3.4.0
         version: 3.4.17
+      vite:
+        specifier: ^5.1.4
+        version: 5.4.19(@types/node@24.3.0)
+      vitest:
+        specifier: ^1.3.0
+        version: 1.6.1(@types/node@24.3.0)(jsdom@20.0.3)
 
   packages/utils:
     devDependencies:


### PR DESCRIPTION
## Summary
- theme provider derives tokens from outlet API and pushes logo/primary/accent vars
- wire all apps to fetch outlet theme and render through ThemeProvider
- admin onboarding step previews theme via color picker and logo upload

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b15971a6d4832a858e7804277b5000