### PR TITLE
test(e2e): Playwright happy path for guest/kds/admin + CI

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -26,3 +26,32 @@ jobs:
         with:
           name: apps-dist
           path: apps/*/dist
+
+  e2e:
+    needs: build
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Install browsers
+        run: npx playwright install --with-deps
+      - name: Run E2E tests
+        env:
+          BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+          TENANT_ID: ${{ secrets.STAGING_TENANT }}
+          TABLE_CODE: ${{ secrets.STAGING_TABLE }}
+        run: pnpm e2e
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "lint": "pnpm -r lint",
-    "typecheck": "pnpm -r typecheck"
+    "typecheck": "pnpm -r typecheck",
+    "e2e": "playwright test"
   },
   "devDependencies": {
-    "eslint": "^8.57.0",
-    "typescript": "^5.0.0",
+    "@playwright/test": "^1.55.0",
     "@types/react": "^18.2.45",
-    "@types/react-dom": "^18.2.18"
+    "@types/react-dom": "^18.2.18",
+    "eslint": "^8.57.0",
+    "typescript": "^5.0.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test';
+
+const baseURL = process.env.BASE_URL || 'http://localhost:3000';
+const guestBaseURL = process.env.GUEST_BASE_URL || baseURL;
+const kdsBaseURL = process.env.KDS_BASE_URL || baseURL;
+const adminBaseURL = process.env.ADMIN_BASE_URL || baseURL;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  reporter: [['html', { open: 'never' }]],
+  use: {
+    headless: true,
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'guest', use: { baseURL: guestBaseURL } },
+    { name: 'kds', use: { baseURL: kdsBaseURL } },
+    { name: 'admin', use: { baseURL: adminBaseURL } },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.55.0
+        version: 1.55.0
       '@types/react':
         specifier: ^18.2.45
         version: 18.3.24
@@ -1660,6 +1663,11 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@remix-run/router@1.23.0':
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
     engines: {node: '>=14.0.0'}
@@ -2544,6 +2552,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3396,6 +3409,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5506,6 +5529,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
+
   '@remix-run/router@1.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -6674,6 +6701,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7724,6 +7754,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/tests/e2e/happy-path.spec.ts
+++ b/tests/e2e/happy-path.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+const baseURL = process.env.BASE_URL || 'http://localhost:3000';
+const tenant = process.env.TENANT_ID || 'tenant';
+const table = process.env.TABLE_CODE || 'T1';
+
+async function placeGuestOrder(page) {
+  await page.goto(`${baseURL}/qr?tenant=${tenant}&table=${table}`);
+  await page.waitForURL('**/menu');
+  await page.getByRole('button', { name: /add/i }).first().click();
+  await page.goto(`${baseURL}/cart`);
+  await page.getByRole('button', { name: /place order/i }).click();
+  await page.waitForURL('**/track/**');
+  const match = page.url().match(/\/track\/(\w+)/);
+  return match ? match[1] : '';
+}
+
+async function kdsProcess(page, orderId) {
+  await page.goto(`${baseURL}/kds/expo`);
+  await page.getByText(orderId, { exact: false }).first().click();
+  await page.getByRole('button', { name: /Accept/i }).click();
+  await page.getByRole('button', { name: /Ready/i }).click();
+}
+
+async function verifyInvoice(page, orderId) {
+  await page.goto(`${baseURL}/track/${orderId}`);
+  await page.getByRole('button', { name: /Get bill/i }).click();
+  await expect(page.getByText(/invoice/i)).toBeVisible();
+}
+
+test('happy path guest/kds/admin', async ({ browser }) => {
+  const guestContext = await browser.newContext();
+  const guestPage = await guestContext.newPage();
+  const orderId = await placeGuestOrder(guestPage);
+  expect(orderId).not.toBe('');
+
+  const kdsContext = await browser.newContext();
+  const kdsPage = await kdsContext.newPage();
+  await kdsProcess(kdsPage, orderId);
+
+  const trackContext = await browser.newContext();
+  const trackPage = await trackContext.newPage();
+  await verifyInvoice(trackPage, orderId);
+});


### PR DESCRIPTION
## Summary
- add root Playwright config with guest/kds/admin projects
- cover guest cart-to-order, KDS accept/ready, and track invoice flows
- run E2E in CI with headless browser and upload artifacts

## Testing
- `BASE_URL=http://localhost pnpm e2e tests/e2e/happy-path.spec.ts` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68b1614ce748832a9709c664eb1d3faf