### PR TITLE
chore(deploy): Dockerized UI builds + Nginx multi-app config + CI

### DIFF
--- a/.github/workflows/ui_deploy.yml
+++ b/.github/workflows/ui_deploy.yml
@@ -1,0 +1,27 @@
+name: ui-deploy
+
+on:
+  push:
+    tags:
+      - 'ui-*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.ui
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM node:18-alpine AS build
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps apps
+COPY packages packages
+COPY . .
+RUN pnpm install --frozen-lockfile \
+    && pnpm build \
+    && mkdir -p /dist \
+    && mv apps/guest/dist /dist/guest \
+    && mv apps/kds/dist /dist/kds \
+    && mv apps/admin/dist /dist/admin
+
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /dist/guest /usr/share/nginx/html/guest
+COPY --from=build /dist/kds /usr/share/nginx/html/kds
+COPY --from=build /dist/admin /usr/share/nginx/html/admin

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,36 @@
-.PHONY: release-rc stage pilot release-ga prod analyze-hot
+.RECIPEPREFIX := >
+.PHONY: release-rc stage pilot release-ga prod analyze-hot ui-build ui-image ui-run
 
 release-rc:
-	python scripts/release_tag.py --rc
+> python scripts/release_tag.py --rc
 
 stage:
-	python scripts/deploy_blue_green.py --env=staging
-	python scripts/canary_probe.py --env=staging
-	python scripts/weighted_canary_ramp.py --env=staging --steps "5,25,50,100"
+> python scripts/deploy_blue_green.py --env=staging
+> python scripts/canary_probe.py --env=staging
+> python scripts/weighted_canary_ramp.py --env=staging --steps "5,25,50,100"
 
 pilot: release-rc stage
-	python scripts/emit_test_alert.py --env=staging
-	pytest -q
-	npx playwright test
-	python scripts/pdf_smoke.py --env=staging
-	bash scripts/backup_smoke.sh
+> python scripts/emit_test_alert.py --env=staging
+> pytest -q
+> npx playwright test
+> python scripts/pdf_smoke.py --env=staging
+> bash scripts/backup_smoke.sh
 
 release-ga:
-	python scripts/release_tag.py --ga
+> python scripts/release_tag.py --ga
 
 prod:
-        python scripts/deploy_blue_green.py --env=prod
-        python scripts/weighted_canary_ramp.py --env=prod --steps "5,25,50,100"
+> python scripts/deploy_blue_green.py --env=prod
+> python scripts/weighted_canary_ramp.py --env=prod --steps "5,25,50,100"
 
 analyze-hot:
-        python scripts/auto_analyze_hot_tables.py
+> python scripts/auto_analyze_hot_tables.py
+
+ui-build:
+> pnpm -r --filter "./apps/*" build
+
+ui-image:
+> docker build -f Dockerfile.ui -t neo-ui .
+
+ui-run:
+> docker run --rm -p 8080:80 neo-ui

--- a/docs/FRONTEND_DEPLOY.md
+++ b/docs/FRONTEND_DEPLOY.md
@@ -1,0 +1,28 @@
+# Frontend Deployment
+
+This container bundles the `guest`, `kds`, and `admin` apps behind a single Nginx server.
+
+## Environment variables
+Builds read backend endpoints from the following variables:
+
+- `VITE_API_BASE`
+- `VITE_WS_BASE`
+
+Pass them at build time, e.g.
+
+```bash
+docker build -f Dockerfile.ui \
+  --build-arg VITE_API_BASE=https://api.example.com \
+  --build-arg VITE_WS_BASE=wss://ws.example.com \
+  -t neo-ui .
+```
+
+## Rolling restarts
+Deploy new images using rolling restarts to avoid downtime. Replace the running
+container with the updated image one instance at a time so requests continue to
+be served while the new version starts.
+
+## Cache busting
+Static assets are fingerprinted and served with a long cache lifetime. Updating
+the Docker image generates new hashes so clients fetch the latest assets, while
+`index.html` is served with `no-cache` to always load the newest manifest.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,26 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+
+  location /guest {
+    try_files $uri $uri/ /guest/index.html;
+  }
+
+  location /kds {
+    try_files $uri $uri/ /kds/index.html;
+  }
+
+  location /admin {
+    try_files $uri $uri/ /admin/index.html;
+  }
+
+  location ~* /(?:guest|kds|admin)/index\.html$ {
+    add_header Cache-Control "no-cache";
+  }
+
+  location ~* \.(?:js|css|png|jpg|jpeg|gif|svg|ico)$ {
+    expires 1y;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+}


### PR DESCRIPTION
## Summary
- build guest, kds and admin apps and serve via nginx
- add Makefile helpers for building and running the UI image
- add UI deployment workflow and docs

## Testing
- `pre-commit run --files Dockerfile.ui nginx.conf Makefile .github/workflows/ui_deploy.yml docs/FRONTEND_DEPLOY.md`
- `pnpm test` *(fails: No test suite found in file /workspace/neo/packages/api/src/endpoints.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b1705b6378832a97c12d36823f5ef2