### PR TITLE
chore(deploy): Nginx config for /guest /kds /admin + SPA fallbacks and caching

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -15,7 +15,7 @@ RUN pnpm install --frozen-lockfile \
     && mv apps/admin/dist /dist/admin
 
 FROM nginx:alpine
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY deploy/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY --from=build /dist/guest /usr/share/nginx/html/guest
 COPY --from=build /dist/kds /usr/share/nginx/html/kds
 COPY --from=build /dist/admin /usr/share/nginx/html/admin

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -1,0 +1,27 @@
+events {}
+http {
+  gzip on; gzip_types text/css application/javascript application/json image/svg+xml;
+  server {
+    listen 80;
+    add_header X-Frame-Options SAMEORIGIN;
+    add_header X-Content-Type-Options nosniff;
+    add_header Referrer-Policy strict-origin-when-cross-origin;
+    add_header Strict-Transport-Security "max-age=31536000" always;
+
+    root /usr/share/nginx/html;
+
+    location /guest/ {
+      try_files $uri /guest/index.html;
+    }
+    location /kds/ {
+      try_files $uri /kds/index.html;
+    }
+    location /admin/ {
+      try_files $uri /admin/index.html;
+    }
+
+    # Cache static assets aggressively, not HTML
+    location ~* \.(js|css|png|jpg|svg|woff2?)$ { expires 30d; add_header Cache-Control "public, max-age=2592000"; }
+    location ~* \.html$ { expires -1; add_header Cache-Control "no-store"; }
+  }
+}

--- a/docs/FRONTEND_DEPLOY.md
+++ b/docs/FRONTEND_DEPLOY.md
@@ -1,6 +1,9 @@
 # Frontend Deployment
 
-This container bundles the `guest`, `kds`, and `admin` apps behind a single Nginx server.
+This container bundles the `guest`, `kds`, and `admin` apps behind a single Nginx
+server. Each app is served from its own base path (`/guest`, `/kds`, `/admin`) with
+history API fallbacks so client-side routing works without additional Nginx
+configuration.
 
 ## Environment variables
 Builds read backend endpoints from the following variables:
@@ -22,7 +25,16 @@ Deploy new images using rolling restarts to avoid downtime. Replace the running
 container with the updated image one instance at a time so requests continue to
 be served while the new version starts.
 
-## Cache busting
-Static assets are fingerprinted and served with a long cache lifetime. Updating
-the Docker image generates new hashes so clients fetch the latest assets, while
-`index.html` is served with `no-cache` to always load the newest manifest.
+## Cache busting and caching
+Static assets (`.js`, `.css`, images, fonts) are fingerprinted and served with a
+30‑day cache lifetime. Updating the Docker image generates new hashes so
+clients fetch the latest assets, while HTML files are served with `no-store` to
+always load the newest manifest.
+
+## Changing roots
+Nginx reads its runtime configuration from `deploy/nginx/nginx.conf`, where the
+`root` is set to `/usr/share/nginx/html`. Built apps are copied into
+subdirectories of that root by `Dockerfile.ui`. To serve the apps from different
+paths or to point to a different root, update the `location` blocks or the
+`root` directive in the config and adjust the copy paths in the Dockerfile.
+


### PR DESCRIPTION
## Summary
- add Nginx config with SPA history fallback and caching
- copy new config in Dockerfile
- document base paths, caching and how to customize roots

## Testing
- `pre-commit run --files Dockerfile.ui deploy/nginx/nginx.conf docs/FRONTEND_DEPLOY.md`
- `pytest -q` *(fails: 80 errors in collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b179185530832a9ee4130b84a7f394