### PR TITLE
fix: use env in deploy workflow conditions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
   deploy-staging:
     needs: build-and-push
-    if: ${{ secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    if: ${{ env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -100,7 +100,7 @@ jobs:
 
   deploy-prod:
     needs: manual-approval
-    if: ${{ secrets.KUBE_CONFIG_PROD != '' && secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    if: ${{ env.KUBE_CONFIG_PROD != '' && env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: prod
     env:


### PR DESCRIPTION
## Summary
- avoid invalid secret context by using env vars in deploy workflow checks

## Testing
- `pre-commit run --files .github/workflows/deploy.yml`
- `pytest -q` *(fails: Directory '/workspace/neo/apps/guest/dist' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b17c927450832aab6afb2a386d51f4