### PR TITLE
feat(auth): fetch interceptor + ProtectedRoute for Admin/KDS

### DIFF
--- a/apps/admin/src/components/ProtectedRoute.test.tsx
+++ b/apps/admin/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,20 @@
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { ProtectedRoute } from './ProtectedRoute';
+import * as api from '@neo/api';
+
+describe('ProtectedRoute', () => {
+  test('redirects to login without token', () => {
+    vi.spyOn(api, 'getToken').mockReturnValue(null as any);
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<ProtectedRoute><div>home</div></ProtectedRoute>} />
+          <Route path="/login" element={<div>login</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText('login')).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/components/ProtectedRoute.tsx
+++ b/apps/admin/src/components/ProtectedRoute.tsx
@@ -1,0 +1,21 @@
+import { ReactElement } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { getToken } from '@neo/api';
+import { useAuth } from '../auth';
+
+interface Props {
+  roles?: string[];
+  children: ReactElement;
+}
+
+export function ProtectedRoute({ roles, children }: Props) {
+  const userRoles = useAuth();
+  const location = useLocation();
+  if (!getToken()) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+  if (roles && !roles.some((r) => userRoles.includes(r))) {
+    return <h1>403</h1>;
+  }
+  return children;
+}

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -9,12 +9,11 @@ import './i18n';
 import { router } from './routes';
 import { Workbox } from 'workbox-window';
 import { AuthProvider } from './auth';
-import { addFetchInterceptors } from '@neo/api';
+import { withInterceptors } from '@neo/api';
 
 const qc = new QueryClient();
 
-const fetcher = addFetchInterceptors(window.fetch.bind(window));
-(window as any).fetch = fetcher;
+globalThis.fetch = withInterceptors(globalThis.fetch.bind(globalThis));
 window.addEventListener('unauthorized', () => toast.error('Session expired'));
 
 capturePageView(window.location.pathname);

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -5,29 +5,29 @@ import { Floor } from './pages/Floor';
 import { Billing } from './pages/Billing';
 import { Onboarding } from './pages/Onboarding';
 import { Layout } from './components/Layout';
-import { Protected } from './components/Protected';
+import { ProtectedRoute } from './components/ProtectedRoute';
 
 export const routes: RouteObject[] = [
   { path: '/login', element: <Login /> },
   {
     path: '/',
-    element: (
-      <Protected>
-        <Layout />
-      </Protected>
-    ),
+      element: (
+        <ProtectedRoute roles={['owner', 'manager']}>
+          <Layout />
+        </ProtectedRoute>
+      ),
     children: [
       { index: true, element: <Navigate to="/dashboard" replace /> },
       { path: 'dashboard', element: <Dashboard /> },
       { path: 'floor', element: <Floor /> },
-      {
-        path: 'billing',
-        element: (
-          <Protected roles={['owner']}>
-            <Billing />
-          </Protected>
-        )
-      },
+        {
+          path: 'billing',
+          element: (
+            <ProtectedRoute roles={['owner']}>
+              <Billing />
+            </ProtectedRoute>
+          )
+        },
       { path: 'onboarding', element: <Onboarding /> }
     ]
   }

--- a/apps/kds/src/components/ProtectedRoute.tsx
+++ b/apps/kds/src/components/ProtectedRoute.tsx
@@ -1,0 +1,31 @@
+import { ReactElement } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { getToken, useLicense } from '@neo/api';
+import { LicenseBanner } from '@neo/ui';
+import { useAuth } from '../auth';
+
+interface Props {
+  roles?: string[];
+  children: ReactElement;
+}
+
+export function ProtectedRoute({ roles, children }: Props) {
+  const userRoles = useAuth();
+  const location = useLocation();
+  const { data } = useLicense();
+  const status = data?.status;
+  if (!getToken()) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+  if (roles && !roles.some((r) => userRoles.includes(r))) {
+    return <h1>403</h1>;
+  }
+  return (
+    <>
+      {status && status !== 'ACTIVE' && (
+        <LicenseBanner status={status as 'GRACE' | 'EXPIRED'} daysLeft={data?.daysLeft} renewUrl={data?.renewUrl} />
+      )}
+      {children}
+    </>
+  );
+}

--- a/apps/kds/src/main.tsx
+++ b/apps/kds/src/main.tsx
@@ -8,12 +8,11 @@ import './i18n';
 import { Workbox } from 'workbox-window';
 import { AppRoutes } from './routes';
 import { AuthProvider } from './auth';
-import { addFetchInterceptors } from '@neo/api';
+import { withInterceptors } from '@neo/api';
 
 const qc = new QueryClient();
 
-const fetcher = addFetchInterceptors(window.fetch.bind(window));
-(window as any).fetch = fetcher;
+globalThis.fetch = withInterceptors(globalThis.fetch.bind(globalThis));
 window.addEventListener('unauthorized', () => toast.error('Session expired'));
 
 if ('serviceWorker' in navigator) {

--- a/apps/kds/src/routes.tsx
+++ b/apps/kds/src/routes.tsx
@@ -4,7 +4,7 @@ import { capturePageView } from '@neo/utils';
 import { Expo } from './pages/Expo';
 import { Health } from './pages/Health';
 import { Login } from './pages/Login';
-import { Protected } from './components/Protected';
+import { ProtectedRoute } from './components/ProtectedRoute';
 
 export function AppRoutes() {
   const loc = useLocation();
@@ -15,7 +15,7 @@ export function AppRoutes() {
     <Routes>
       <Route path="/health" element={<Health />} />
       <Route path="/login" element={<Login />} />
-      <Route path="/kds/expo" element={<Protected><Expo /></Protected>} />
+        <Route path="/kds/expo" element={<ProtectedRoute roles={['kitchen', 'manager']}><Expo /></ProtectedRoute>} />
       <Route path="/" element={<Navigate to="/kds/expo" replace />} />
     </Routes>
   );

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -4,6 +4,7 @@ export * from './hooks/ws';
 export * from './hooks/useLicense';
 export { usePageview } from './hooks/usePageview';
 export * from './auth/pin';
+export * from './interceptor';
 export {
   getMenu,
   placeOrder,

--- a/packages/api/src/interceptor.test.ts
+++ b/packages/api/src/interceptor.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect, vi } from 'vitest';
+import { withInterceptors, AuthError } from './interceptor';
+import * as pin from './auth/pin';
+
+function response(status: number, body: any = '') {
+  return new Response(body, { status });
+}
+
+describe('withInterceptors', () => {
+  test('401 -> refresh once -> success', async () => {
+    vi.spyOn(pin, 'getToken').mockReturnValue({ accessToken: 'a', refreshToken: 'r' });
+    vi.spyOn(pin, 'refreshToken').mockResolvedValue(true);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(401))
+      .mockResolvedValueOnce(response(200));
+    const intercepted = withInterceptors(fetchMock as any);
+    const res = await intercepted('/x');
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('401 after refresh -> AuthError + redirect', async () => {
+    vi.spyOn(pin, 'getToken').mockReturnValue({ accessToken: 'a', refreshToken: 'r' });
+    vi.spyOn(pin, 'refreshToken').mockResolvedValue(false);
+    const clearSpy = vi.spyOn(pin, 'clearToken').mockImplementation(() => {});
+    const assignSpy = vi.fn();
+    const dispatchSpy = vi.fn();
+    (globalThis as any).window = { location: { assign: assignSpy }, dispatchEvent: dispatchSpy };
+    const fetchMock = vi.fn().mockResolvedValue(response(401));
+    const intercepted = withInterceptors(fetchMock as any);
+    await expect(intercepted('/y')).rejects.toBeInstanceOf(AuthError);
+    expect(clearSpy).toHaveBeenCalled();
+    expect(dispatchSpy.mock.calls[0][0].type).toBe('unauthorized');
+    expect(assignSpy).toHaveBeenCalledWith('/login');
+  });
+});

--- a/packages/api/src/interceptor.ts
+++ b/packages/api/src/interceptor.ts
@@ -1,0 +1,43 @@
+import { getToken, refreshToken, clearToken } from './auth/pin';
+
+export class AuthError extends Error {}
+
+export function withInterceptors(fetchImpl = fetch) {
+  return async function intercepted(input: RequestInfo | URL, init: RequestInit & { tenantId?: string; _retry?: boolean } = {}) {
+    const { tenantId, _retry, headers, ...rest } = init;
+    const h = new Headers(headers);
+    const tokens = getToken();
+    if (tokens?.accessToken) {
+      h.set('Authorization', `Bearer ${tokens.accessToken}`);
+    }
+    if (tenantId) {
+      h.set('X-Tenant-Id', tenantId);
+    }
+    h.set('X-Request-Id', crypto.randomUUID());
+    const res = await fetchImpl(input, { ...rest, headers: h });
+    if (res.status !== 401 || _retry) {
+      return res;
+    }
+    const refreshed = await refreshToken();
+    if (refreshed) {
+      const retryHeaders = new Headers(headers);
+      const t = getToken();
+      if (t?.accessToken) {
+        retryHeaders.set('Authorization', `Bearer ${t.accessToken}`);
+      }
+      if (tenantId) {
+        retryHeaders.set('X-Tenant-Id', tenantId);
+      }
+      retryHeaders.set('X-Request-Id', crypto.randomUUID());
+      return fetchImpl(input, { ...rest, headers: retryHeaders, _retry: true });
+    }
+    clearToken();
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('unauthorized'));
+      window.location.assign('/login');
+    }
+    throw new AuthError('Unauthorized');
+  };
+}
+
+export type FetchWithInterceptor = ReturnType<typeof withInterceptors>;


### PR DESCRIPTION
## Summary
- add fetch interceptor attaching auth headers, tenant ID, request ID and refresh-once logic
- add ProtectedRoute components for Admin and KDS with role-based access
- wire interceptor and ProtectedRoute into Admin and KDS apps

## Testing
- `npx vitest packages/api/src/interceptor.test.ts packages/api/src/api.test.ts packages/api/src/auth/pin.test.ts`
- `pnpm --filter @neo/admin test`
- `pnpm --filter @neo/kds test`


------
https://chatgpt.com/codex/tasks/task_e_68b178bbeec0832a8e743791c9fd6b03