### PR TITLE
Gracefully handle missing SPA directories

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -257,9 +257,21 @@ root_dir = Path(__file__).resolve().parent.parent.parent / "apps"
 guest_spa = root_dir / "guest" / "dist"
 admin_spa = root_dir / "admin" / "dist"
 kds_spa = root_dir / "kds" / "dist"
-app.mount("/guest", StaticFiles(directory=guest_spa, html=True), name="guest")
-app.mount("/admin", StaticFiles(directory=admin_spa, html=True), name="admin")
-app.mount("/kds", StaticFiles(directory=kds_spa, html=True), name="kds")
+
+if guest_spa.exists():
+    app.mount("/guest", StaticFiles(directory=guest_spa, html=True), name="guest")
+else:
+    logging.warning("Guest SPA not found at %s; skipping mount", guest_spa)
+
+if admin_spa.exists():
+    app.mount("/admin", StaticFiles(directory=admin_spa, html=True), name="admin")
+else:
+    logging.warning("Admin SPA not found at %s; skipping mount", admin_spa)
+
+if kds_spa.exists():
+    app.mount("/kds", StaticFiles(directory=kds_spa, html=True), name="kds")
+else:
+    logging.warning("KDS SPA not found at %s; skipping mount", kds_spa)
 
 
 init_tracing(app)


### PR DESCRIPTION
## Summary
- avoid runtime errors when SPA builds are absent by conditionally mounting guest, admin and kds apps

## Testing
- `pre-commit run --files api/app/main.py`
- `pytest tests/test_start_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b17df39014832a989a4bc114a85800