### PR TITLE
fix: reference secrets directly in deploy workflow conditions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,9 @@ jobs:
           git config user.email "github-actions@github.com"
           git push origin HEAD:deploy --force
 
-  deploy-staging:
-    needs: build-and-push
-    if: ${{ env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    deploy-staging:
+      needs: build-and-push
+      if: ${{ secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -98,9 +98,9 @@ jobs:
       - name: Awaiting approval
         run: echo "Manual approval required to deploy to production"
 
-  deploy-prod:
-    needs: manual-approval
-    if: ${{ env.KUBE_CONFIG_PROD != '' && env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    deploy-prod:
+      needs: manual-approval
+      if: ${{ secrets.KUBE_CONFIG_PROD != '' && secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: prod
     env:


### PR DESCRIPTION
## Summary
- use secrets.KUBE_CONFIG_STAGING for deploy-staging condition
- use secrets.KUBE_CONFIG_PROD and secrets.KUBE_CONFIG_STAGING for deploy-prod condition

## Testing
- `npm test` *(fails: Failed to resolve import "@tanstack/react-query" from "../../packages/api/src/hooks/useLicense.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68b19aa60d4c832aa0c0e563861c8e67