### PR TITLE
chore(pwa): format files with Prettier

### DIFF
--- a/pwa/src/Troubleshoot.jsx
+++ b/pwa/src/Troubleshoot.jsx
@@ -32,12 +32,12 @@ export default function Troubleshoot() {
             {results.printer.ok ? 'Pass' : 'Fail'} {results.printer.next}
           </li>
           <li>
-            <strong>Time skew:</strong>{' '}
-            {results.time.ok ? 'Pass' : 'Fail'} {results.time.next}
+            <strong>Time skew:</strong> {results.time.ok ? 'Pass' : 'Fail'}{' '}
+            {results.time.next}
           </li>
           <li>
-            <strong>DNS/latency:</strong>{' '}
-            {results.dns.ok ? 'Pass' : 'Fail'} {results.dns.next}
+            <strong>DNS/latency:</strong> {results.dns.ok ? 'Pass' : 'Fail'}{' '}
+            {results.dns.next}
           </li>
           <li>
             <strong>Software version:</strong>{' '}

--- a/pwa/src/components/ConsentBanner.jsx
+++ b/pwa/src/components/ConsentBanner.jsx
@@ -19,10 +19,7 @@ export default function ConsentBanner() {
 
   const save = () => {
     try {
-      localStorage.setItem(
-        'guestConsent',
-        JSON.stringify({ analytics, wa })
-      )
+      localStorage.setItem('guestConsent', JSON.stringify({ analytics, wa }))
     } catch (e) {
       /* ignore */
     }
@@ -30,7 +27,7 @@ export default function ConsentBanner() {
       apiFetch('/g/consent', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ allow_analytics: analytics, allow_wa: wa })
+        body: JSON.stringify({ allow_analytics: analytics, allow_wa: wa }),
       })
     } catch (e) {
       /* ignore */
@@ -61,10 +58,7 @@ export default function ConsentBanner() {
         />
         Allow WhatsApp notifications
       </label>
-      <button
-        className="bg-blue-600 px-2 py-1 rounded"
-        onClick={save}
-      >
+      <button className="bg-blue-600 px-2 py-1 rounded" onClick={save}>
         Save
       </button>
     </div>

--- a/pwa/src/components/Integrations.jsx
+++ b/pwa/src/components/Integrations.jsx
@@ -18,11 +18,13 @@ export default function Integrations() {
     const url = urls[type] || ''
     apiFetch(`/admin/integrations/${type}/probe`, {
       method: 'POST',
-      body: JSON.stringify({ url })
+      body: JSON.stringify({ url }),
     })
       .then((res) => res.json())
       .then((json) => setReports({ ...reports, [type]: json.data }))
-      .catch((err) => setReports({ ...reports, [type]: { error: err.message } }))
+      .catch((err) =>
+        setReports({ ...reports, [type]: { error: err.message } }),
+      )
   }
 
   if (error) return <p className="text-danger">{error}</p>
@@ -43,7 +45,9 @@ export default function Integrations() {
                 type="url"
                 placeholder="Webhook URL"
                 value={urls[item.type] || ''}
-                onChange={(e) => setUrls({ ...urls, [item.type]: e.target.value })}
+                onChange={(e) =>
+                  setUrls({ ...urls, [item.type]: e.target.value })
+                }
                 className="flex-1 border p-1 text-sm"
               />
               <button

--- a/pwa/src/components/LimitsUsageWidget.jsx
+++ b/pwa/src/components/LimitsUsageWidget.jsx
@@ -6,11 +6,7 @@ function Bar({ label, usage }) {
   const used = usage.used
   const percent = limit ? Math.min((used / limit) * 100, 100) : 0
   const color =
-    percent >= 100
-      ? 'bg-danger'
-      : percent >= 80
-        ? 'bg-warning'
-        : 'bg-success'
+    percent >= 100 ? 'bg-danger' : percent >= 80 ? 'bg-warning' : 'bg-success'
   return (
     <div className="mb-4">
       <div className="flex justify-between text-sm mb-1">

--- a/pwa/src/components/OpsWidget.jsx
+++ b/pwa/src/components/OpsWidget.jsx
@@ -22,10 +22,26 @@ export default function OpsWidget() {
     <div className="mb-6">
       <h3 className="text-lg font-semibold mb-2">Ops</h3>
       <div className="text-sm space-y-1">
-        <div className="flex justify-between"><span>Uptime</span><span>{data.uptime}</span></div>
-        <div className="flex justify-between"><span>Webhook Success</span><span>{pct(data.webhook_success_rate)}%</span></div>
-        <div className="flex justify-between"><span>Breaker Open Time</span><span>{seconds(data.breaker_open_time)}</span></div>
-        <div className="flex justify-between"><span>Median KOT Prep</span><span>{data.median_kot_prep_time ? seconds(data.median_kot_prep_time) : 'N/A'}</span></div>
+        <div className="flex justify-between">
+          <span>Uptime</span>
+          <span>{data.uptime}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Webhook Success</span>
+          <span>{pct(data.webhook_success_rate)}%</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Breaker Open Time</span>
+          <span>{seconds(data.breaker_open_time)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Median KOT Prep</span>
+          <span>
+            {data.median_kot_prep_time
+              ? seconds(data.median_kot_prep_time)
+              : 'N/A'}
+          </span>
+        </div>
       </div>
     </div>
   )

--- a/pwa/src/components/OwnerSlaWidget.jsx
+++ b/pwa/src/components/OwnerSlaWidget.jsx
@@ -25,7 +25,11 @@ export default function OwnerSlaWidget() {
 
   // Webhook success thresholds: >=99% green, >=95% yellow, otherwise red
   const webhookColor = (v) =>
-    v >= 0.99 ? 'text-green-600' : v >= 0.95 ? 'text-yellow-600' : 'text-red-600'
+    v >= 0.99
+      ? 'text-green-600'
+      : v >= 0.95
+        ? 'text-yellow-600'
+        : 'text-red-600'
 
   // Median prep time thresholds: <10min green, <15min yellow, else red
   const prepColor = (v) =>

--- a/pwa/src/components/PilotTelemetryWidget.jsx
+++ b/pwa/src/components/PilotTelemetryWidget.jsx
@@ -22,14 +22,38 @@ export default function PilotTelemetryWidget() {
     <div className="mb-6">
       <h3 className="text-lg font-semibold mb-2">Pilot Telemetry</h3>
       <div className="text-sm space-y-1">
-        <div className="flex justify-between"><span>Orders/min</span><span>{data.orders_per_min.toFixed(1)}</span></div>
-        <div className="flex justify-between"><span>Avg Prep</span><span>{secs(data.avg_prep_s)}</span></div>
-        <div className="flex justify-between"><span>Breaker Open</span><span>{pct(data.webhook_breaker_open_pct)}</span></div>
-        <div className="flex justify-between"><span>Oldest KOT</span><span>{secs(data.kot_queue_oldest_s)}</span></div>
-        <div className="flex justify-between"><span>95p Latency</span><span>{Math.round(data.p95_latency_ms)}ms</span></div>
-        <div className="flex justify-between"><span>Error Rate (5m)</span><span>{pct(data.error_rate_5m * 100)}</span></div>
-        <div className="flex justify-between"><span>SSE Clients</span><span>{data.sse_clients}</span></div>
-        <div className="flex justify-between"><span>Timestamp</span><span>{new Date(data.timestamp * 1000).toLocaleTimeString()}</span></div>
+        <div className="flex justify-between">
+          <span>Orders/min</span>
+          <span>{data.orders_per_min.toFixed(1)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Avg Prep</span>
+          <span>{secs(data.avg_prep_s)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Breaker Open</span>
+          <span>{pct(data.webhook_breaker_open_pct)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Oldest KOT</span>
+          <span>{secs(data.kot_queue_oldest_s)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>95p Latency</span>
+          <span>{Math.round(data.p95_latency_ms)}ms</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Error Rate (5m)</span>
+          <span>{pct(data.error_rate_5m * 100)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>SSE Clients</span>
+          <span>{data.sse_clients}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Timestamp</span>
+          <span>{new Date(data.timestamp * 1000).toLocaleTimeString()}</span>
+        </div>
       </div>
     </div>
   )

--- a/pwa/src/components/StatusPill.jsx
+++ b/pwa/src/components/StatusPill.jsx
@@ -14,10 +14,15 @@ export default function StatusPill() {
     state === 'ok'
       ? 'bg-green-500'
       : state === 'degraded'
-      ? 'bg-amber-500'
-      : state === 'outage'
-      ? 'bg-red-500'
-      : 'bg-gray-400'
+        ? 'bg-amber-500'
+        : state === 'outage'
+          ? 'bg-red-500'
+          : 'bg-gray-400'
 
-  return <span data-testid="status-pill" className={`inline-block w-3 h-3 rounded-full ${color}`}></span>
+  return (
+    <span
+      data-testid="status-pill"
+      className={`inline-block w-3 h-3 rounded-full ${color}`}
+    ></span>
+  )
 }

--- a/pwa/src/pages/Billing.jsx
+++ b/pwa/src/pages/Billing.jsx
@@ -13,11 +13,7 @@ export default function Billing() {
   }, [])
 
   if (error) {
-    return (
-      <div className="p-4 text-red-500">
-        {error}
-      </div>
-    )
+    return <div className="p-4 text-red-500">{error}</div>
   }
   if (!info) {
     return <div className="p-4">Loading...</div>
@@ -33,9 +29,7 @@ export default function Billing() {
       <h2 className="mb-4 text-xl font-bold">Billing</h2>
       <p>Plan: {info.plan || 'unknown'}</p>
       {info.next_renewal && (
-        <p>
-          Next renewal: {new Date(info.next_renewal).toLocaleDateString()}
-        </p>
+        <p>Next renewal: {new Date(info.next_renewal).toLocaleDateString()}</p>
       )}
       {info.pay_url && (
         <a
@@ -50,4 +44,3 @@ export default function Billing() {
     </div>
   )
 }
-

--- a/pwa/src/pages/ExpoDashboard.jsx
+++ b/pwa/src/pages/ExpoDashboard.jsx
@@ -41,7 +41,6 @@ export default function ExpoDashboard() {
       const idx = parseInt(e.key, 10)
       if (!isNaN(idx) && idx > 0 && idx <= orders.length) {
         markPicked(orders[idx - 1].order_id)
-
       }
     }
     window.addEventListener('keydown', handler)
@@ -62,7 +61,6 @@ export default function ExpoDashboard() {
                 <span className="font-semibold">
                   Table {o.table}
                   {o.allergen_badges.length > 0 && (
-
                     <span className="ml-2 rounded bg-red-100 px-1 text-red-800 text-xs">
                       Allergy
                     </span>
@@ -70,13 +68,11 @@ export default function ExpoDashboard() {
                 </span>
                 <span className="text-sm text-gray-600">
                   {Math.round(o.age_s / 60)}m
-
                 </span>
               </div>
               <button
                 className="mt-2 bg-blue-600 text-white px-2 py-1 rounded"
                 onClick={() => markPicked(o.order_id)}
-
               >
                 Picked
               </button>

--- a/pwa/src/pages/GuestOrder.jsx
+++ b/pwa/src/pages/GuestOrder.jsx
@@ -66,10 +66,7 @@ export default function GuestOrder() {
         {ops.map((op) => (
           <li key={op.op_id} className="mb-1">
             {op.items[0].item_id} x {op.items[0].qty}{' '}
-            <span
-              className={op.synced ? 'text-success' : 'text-warning'}
-            >
-
+            <span className={op.synced ? 'text-success' : 'text-warning'}>
               {op.synced ? 'synced' : 'pending'}
             </span>
           </li>

--- a/pwa/src/pages/OwnerOnboardingWizard.jsx
+++ b/pwa/src/pages/OwnerOnboardingWizard.jsx
@@ -31,7 +31,7 @@ export default function OwnerOnboardingWizard() {
   function persist(nextStep, nextData) {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ step: nextStep, data: nextData })
+      JSON.stringify({ step: nextStep, data: nextData }),
     )
   }
 

--- a/pwa/src/pages/__tests__/CashierDashboard.test.jsx
+++ b/pwa/src/pages/__tests__/CashierDashboard.test.jsx
@@ -9,7 +9,7 @@ import * as api from '../../api'
 describe('CashierDashboard', () => {
   beforeEach(() => {
     global.fetch = jest.fn(() =>
-      Promise.resolve({ json: () => Promise.resolve({ state: 'ok' }) })
+      Promise.resolve({ json: () => Promise.resolve({ state: 'ok' }) }),
     )
     global.crypto = { randomUUID: () => 'test-key' }
     api.apiFetch.mockImplementation((url) => {
@@ -17,7 +17,9 @@ describe('CashierDashboard', () => {
         return Promise.resolve({ json: () => Promise.resolve({ orders: [] }) })
       }
       if (url.startsWith('/invoices')) {
-        return Promise.resolve({ json: () => Promise.resolve({ invoices: [{ invoice_id: 1 }] }) })
+        return Promise.resolve({
+          json: () => Promise.resolve({ invoices: [{ invoice_id: 1 }] }),
+        })
       }
       return Promise.resolve({ json: () => Promise.resolve({}) })
     })
@@ -33,7 +35,7 @@ describe('CashierDashboard', () => {
     render(
       <ThemeProvider>
         <CashierDashboard />
-      </ThemeProvider>
+      </ThemeProvider>,
     )
     await screen.findByText(/Cashier Dashboard/)
     expect(screen.getByRole('link', { name: /terms/i })).toBeInTheDocument()
@@ -47,10 +49,14 @@ describe('CashierDashboard', () => {
         return Promise.resolve({ json: () => Promise.resolve({ orders: [] }) })
       }
       if (url.startsWith('/invoices')) {
-        return Promise.resolve({ json: () => Promise.resolve({ invoices: [{ invoice_id: 1 }] }) })
+        return Promise.resolve({
+          json: () => Promise.resolve({ invoices: [{ invoice_id: 1 }] }),
+        })
       }
       if (url === '/payments/1/refund') {
-        return Promise.resolve({ json: () => Promise.resolve({ data: { refunded: true } }) })
+        return Promise.resolve({
+          json: () => Promise.resolve({ data: { refunded: true } }),
+        })
       }
       return Promise.resolve({ json: () => Promise.resolve({}) })
     })
@@ -60,7 +66,7 @@ describe('CashierDashboard', () => {
     render(
       <ThemeProvider>
         <CashierDashboard />
-      </ThemeProvider>
+      </ThemeProvider>,
     )
 
     const refundButton = await screen.findByRole('button', { name: /refund/i })
@@ -73,12 +79,13 @@ describe('CashierDashboard', () => {
         '/payments/1/refund',
         expect.objectContaining({
           method: 'POST',
-          headers: expect.objectContaining({ 'Idempotency-Key': expect.any(String) }),
-        })
+          headers: expect.objectContaining({
+            'Idempotency-Key': expect.any(String),
+          }),
+        }),
       )
     })
 
     expect(await screen.findByText(/Key:/i)).toBeInTheDocument()
   })
 })
-

--- a/pwa/src/pages/__tests__/ExpoDashboard.test.jsx
+++ b/pwa/src/pages/__tests__/ExpoDashboard.test.jsx
@@ -1,32 +1,42 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { apiFetch } from '../../api';
-import ExpoDashboard from '../ExpoDashboard';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { apiFetch } from '../../api'
+import ExpoDashboard from '../ExpoDashboard'
 
-jest.mock('../../api', () => ({ apiFetch: jest.fn() }));
-jest.mock('../../contexts/ThemeContext', () => ({ useTheme: () => ({ logo: null }) }));
+jest.mock('../../api', () => ({ apiFetch: jest.fn() }))
+jest.mock('../../contexts/ThemeContext', () => ({
+  useTheme: () => ({ logo: null }),
+}))
 
 const sampleOrders = [
   { order_id: 1, table: '1', age_s: 30, allergen_badges: [] },
   { order_id: 2, table: '2', age_s: 45, allergen_badges: [] },
-];
+]
 
 describe('ExpoDashboard hotkeys', () => {
   beforeEach(() => {
-    apiFetch.mockReset();
+    apiFetch.mockReset()
     apiFetch
       .mockResolvedValueOnce({ json: async () => ({ tickets: sampleOrders }) })
       .mockResolvedValueOnce({ json: async () => ({}) })
-      .mockResolvedValueOnce({ json: async () => ({ tickets: [sampleOrders[0]] }) });
-  });
+      .mockResolvedValueOnce({
+        json: async () => ({ tickets: [sampleOrders[0]] }),
+      })
+  })
 
   it('pressing P picks last order', async () => {
-    render(<ExpoDashboard />);
-    await screen.findByText('Table 1');
-    await screen.findByText('Table 2');
+    render(<ExpoDashboard />)
+    await screen.findByText('Table 1')
+    await screen.findByText('Table 2')
 
-    fireEvent.keyDown(window, { key: 'P' });
+    fireEvent.keyDown(window, { key: 'P' })
 
-    await waitFor(() => expect(apiFetch).toHaveBeenCalledWith('/kds/expo/2/picked', { method: 'POST' }));
-    await waitFor(() => expect(screen.queryByText('Table 2')).not.toBeInTheDocument());
-  });
-});
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith('/kds/expo/2/picked', {
+        method: 'POST',
+      }),
+    )
+    await waitFor(() =>
+      expect(screen.queryByText('Table 2')).not.toBeInTheDocument(),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- format pwa components and pages with Prettier to satisfy lint

## Testing
- `pnpm lint`
- `pnpm test` *(fails: @neo/admin test: vitest run)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a21a8d50832aa2f528b7a04f4618