### PR TITLE
ci: build PWA before lighthouse preview

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -6,7 +6,7 @@
         "http://localhost:5174/",
         "http://localhost:5175/"
       ],
-      "startServerCommand": "pnpm --filter pwa preview --port 5173",
+      "startServerCommand": "pnpm --filter pwa build && pnpm --filter pwa preview --port 5173",
       "numberOfRuns": 1,
       "output": ["html"],
       "reportFilenamePattern": "%%PATHNAME%%-lighthouse.%%EXTENSION%%",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,11 +15,13 @@
     "zod": "^3.22.2"
   },
   "peerDependencies": {
-    "react": "^18.0.0"
+    "react": "^18.0.0",
+    "@tanstack/react-query": "^5.40.1"
   },
   "devDependencies": {
     "@neo/config": "workspace:*",
     "tsx": "^4.7.0",
-    "vitest": "^1.3.0"
+    "vitest": "^1.3.0",
+    "@tanstack/react-query": "^5.40.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
       '@neo/config':
         specifier: workspace:*
         version: link:../config
+      '@tanstack/react-query':
+        specifier: ^5.40.1
+        version: 5.85.5(react@18.3.1)
       tsx:
         specifier: ^4.7.0
         version: 4.20.5


### PR DESCRIPTION
## Summary
- build PWA before running Lighthouse preview to prevent missing dist errors
- add React Query peer dependency in API package for test resolution

## Testing
- `pnpm test`
- `npx -y @lhci/cli autorun --config=lighthouserc.json` *(fails: Chrome not installed)*
- `pytest` *(fails: 7 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a0cdaf54832a9cd5528fca3aef62