### PR TITLE
ci: add lighthouse and accessibility gates

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -27,6 +27,24 @@ jobs:
           name: apps-dist
           path: apps/*/dist
 
+  lighthouse:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lighthouse audit
+        uses: treosh/lighthouse-ci-action@v11
+        env:
+          GUEST_URL: ${{ secrets.STAGING_GUEST_URL }}
+          KDS_URL: ${{ secrets.STAGING_KDS_URL }}
+          ADMIN_URL: ${{ secrets.STAGING_ADMIN_URL }}
+        with:
+          configPath: ./lighthouserc.json
+          urls: |
+            ${{ env.GUEST_URL }}/menu
+            ${{ env.KDS_URL }}/kds/expo
+            ${{ env.ADMIN_URL }}/dashboard
+
   e2e:
     needs: build
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
@@ -55,3 +73,25 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report
+
+  a11y:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: npx playwright install --with-deps
+      - name: Run accessibility tests
+        env:
+          BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+          GUEST_BASE_URL: ${{ secrets.STAGING_GUEST_URL }}
+          KDS_BASE_URL: ${{ secrets.STAGING_KDS_URL }}
+          ADMIN_BASE_URL: ${{ secrets.STAGING_ADMIN_URL }}
+        run: npx playwright test tests/a11y/a11y.spec.ts

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -10,8 +10,11 @@ export function Layout() {
   const status = data?.status;
   return (
     <div className="flex h-screen">
+      <a href="#main" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
       <aside className="w-48 bg-gray-100 p-4 space-y-2">
-        <nav className="flex flex-col space-y-2">
+        <nav className="flex flex-col space-y-2" aria-label="Primary">
           <Link to="/dashboard">Dashboard</Link>
           <Link to="/floor">Floor</Link>
           {roles.includes('owner') && <Link to="/billing">Billing</Link>}
@@ -38,7 +41,7 @@ export function Layout() {
             Logout
           </button>
         </header>
-        <main className="flex-1 overflow-auto p-4">
+        <main id="main" className="flex-1 overflow-auto p-4">
           <Outlet />
         </main>
       </div>

--- a/apps/guest/src/components/Header.tsx
+++ b/apps/guest/src/components/Header.tsx
@@ -13,15 +13,17 @@ export function Header() {
   };
 
   return (
-    <header className="p-2 flex items-center justify-between">
-      <div
-        className="h-8 w-24 bg-contain bg-no-repeat"
-        style={{ backgroundImage: 'var(--logo-url)' }}
-      />
-      <select aria-label="language" value={lang} onChange={change}>
-        <option value="en">EN</option>
-        <option value="es">ES</option>
-      </select>
+    <header className="p-2">
+      <nav className="flex items-center justify-between" aria-label="Primary">
+        <div
+          className="h-8 w-24 bg-contain bg-no-repeat"
+          style={{ backgroundImage: 'var(--logo-url)' }}
+        />
+        <select aria-label="language" value={lang} onChange={change}>
+          <option value="en">EN</option>
+          <option value="es">ES</option>
+        </select>
+      </nav>
     </header>
   );
 }

--- a/apps/guest/src/components/Layout.tsx
+++ b/apps/guest/src/components/Layout.tsx
@@ -7,12 +7,17 @@ export function Layout() {
   const { data } = useLicense();
   const status = data?.status;
   return (
-    <div>
+    <>
+      <a href="#main" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
       <PoorConnectionBanner />
       {status && (
         <LicenseBanner status={status} daysLeft={data?.daysLeft} renewUrl={data?.renewUrl} />
       )}
-      <Outlet />
-    </div>
+      <main id="main">
+        <Outlet />
+      </main>
+    </>
   );
 }

--- a/apps/guest/src/pages/MenuPage.tsx
+++ b/apps/guest/src/pages/MenuPage.tsx
@@ -56,6 +56,7 @@ export function MenuPage() {
               <div key={item.id}>
                 <span>{item.name_i18n[lang] || item.name_i18n.en}</span>
                 <button
+                  aria-label={`add ${item.name_i18n[lang] || item.name_i18n.en} to cart`}
                   onClick={() =>
                     add({ id: item.id, name: item.name_i18n.en, qty: 1 })
                   }

--- a/apps/kds/src/pages/Expo.tsx
+++ b/apps/kds/src/pages/Expo.tsx
@@ -255,75 +255,85 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
   };
 
   return (
-    <div
-      className="p-4 space-y-4 dark:bg-gray-900 dark:text-white"
-      style={{ fontSize: `${fontScale}%` }}
-    >
-      <div className="flex justify-end space-x-2">
-        <button
-          aria-label="Fullscreen"
-          onClick={() => setFullscreen(!fullscreen)}
-          className="border px-2 py-1 rounded"
-        >
-          {fullscreen ? '🡼' : '⛶'}
-        </button>
-        <button
-          data-testid="settings-btn"
-          aria-label="Settings"
-          onClick={() => setShowSettings((s) => !s)}
-          className="border px-2 py-1 rounded"
-        >
-          ⚙️
-        </button>
-      </div>
-      {offline && (
-        <div
-          data-testid="offline"
-          className="fixed top-2 right-2 bg-red-600 text-white px-2 py-1 rounded"
-        >
-          Offline
-        </div>
-      )}
-      <SettingsDrawer open={showSettings} onClose={() => setShowSettings(false)} />
-      <div className="flex space-x-2">
-        {(['ALL', ...allStatuses] as const).map((s) => (
+    <>
+      <a href="#main" className="sr-only focus:not-sr-only">
+        Skip to content
+      </a>
+      <header
+        className="p-4 dark:bg-gray-900 dark:text-white"
+        style={{ fontSize: `${fontScale}%` }}
+      >
+        <div className="flex justify-end space-x-2">
           <button
-            key={s}
-            className={`px-2 py-1 border rounded ${statusFilter === s ? 'bg-blue-500 text-white' : ''}`}
-            onClick={() => setStatusFilter(s)}
+            aria-label="Fullscreen"
+            onClick={() => setFullscreen(!fullscreen)}
+            className="border px-2 py-1 rounded"
           >
-            {s === 'ALL' ? 'All' : s.charAt(0) + s.slice(1).toLowerCase()}
+            {fullscreen ? '🡼' : '⛶'}
           </button>
-        ))}
-      </div>
-      <div className="flex space-x-2">
-        <input
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          placeholder="Search"
-          className="border p-1 rounded"
-        />
-        {zones.length > 0 && (
-          <select
-            value={zone ?? ''}
-            onChange={(e) => setZone(e.target.value || undefined)}
-            className="border p-1 rounded"
+          <button
+            data-testid="settings-btn"
+            aria-label="Settings"
+            onClick={() => setShowSettings((s) => !s)}
+            className="border px-2 py-1 rounded"
           >
-            <option value="">All Zones</option>
-            {zones.map((z) => (
-              <option key={z} value={z}>
-                {z}
-              </option>
-            ))}
-          </select>
+            ⚙️
+          </button>
+        </div>
+        {offline && (
+          <div
+            data-testid="offline"
+            className="fixed top-2 right-2 bg-red-600 text-white px-2 py-1 rounded"
+          >
+            Offline
+          </div>
         )}
-      </div>
-      <div className="grid grid-cols-4 gap-4">
-        {columns.map((col) => (
-          <div key={col}>
-            <h3 className="font-semibold mb-2">{col.charAt(0) + col.slice(1).toLowerCase()}</h3>
-            <ul className="space-y-2">
-              {columnTickets[col].map((t) => (
+      </header>
+      <SettingsDrawer open={showSettings} onClose={() => setShowSettings(false)} />
+      <main
+        id="main"
+        className="p-4 space-y-4 dark:bg-gray-900 dark:text-white"
+        style={{ fontSize: `${fontScale}%` }}
+      >
+        <nav className="flex space-x-2" aria-label="Ticket status">
+          {(['ALL', ...allStatuses] as const).map((s) => (
+            <button
+              key={s}
+              className={`px-2 py-1 border rounded ${statusFilter === s ? 'bg-blue-500 text-white' : ''}`}
+              onClick={() => setStatusFilter(s)}
+            >
+              {s === 'ALL' ? 'All' : s.charAt(0) + s.slice(1).toLowerCase()}
+            </button>
+          ))}
+        </nav>
+        <div className="flex space-x-2">
+          <input
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search"
+            className="border p-1 rounded"
+          />
+          {zones.length > 0 && (
+            <select
+              value={zone ?? ''}
+              onChange={(e) => setZone(e.target.value || undefined)}
+              className="border p-1 rounded"
+            >
+              <option value="">All Zones</option>
+              {zones.map((z) => (
+                <option key={z} value={z}>
+                  {z}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+        <div className="grid grid-cols-4 gap-4">
+          {columns.map((col) => (
+            <div key={col}>
+              <h3 className="font-semibold mb-2">{col.charAt(0) + col.slice(1).toLowerCase()}</h3>
+              <ul className="space-y-2">
+                {columnTickets[col].map((t) => (
                   <li
                     key={t.id}
                     data-testid={`ticket-${t.id}`}
@@ -347,11 +357,12 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
                     </ul>
                   </li>
                 ))}
-            </ul>
-          </div>
-        ))}
-      </div>
-    </div>
+              </ul>
+            </div>
+          ))}
+        </div>
+      </main>
+    </>
   );
 }
 

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,26 +1,29 @@
 {
   "ci": {
-    "collect": {
-      "url": [
-        "http://localhost:5173/",
-        "http://localhost:5174/",
-        "http://localhost:5175/"
-      ],
-      "startServerCommand": "pnpm --filter pwa preview --port 5173",
-      "numberOfRuns": 1,
-      "output": ["html"],
-      "reportFilenamePattern": "%%PATHNAME%%-lighthouse.%%EXTENSION%%",
-      "chromeFlags": "--no-sandbox",
-      "settings": {
-        "budgetsPath": "budgets.json"
-      }
-    },
     "assert": {
-      "budgetsFile": "budgets.json"
-    },
-    "upload": {
-      "target": "filesystem",
-      "outputDir": "./lighthouse"
+      "assertMatrix": [
+        {
+          "matchingUrlPattern": "guest/menu",
+          "assertions": {
+            "categories:performance": ["error", { "minScore": 0.90 }],
+            "total-blocking-time": ["error", { "maxNumericValue": 200, "aggregationMethod": "median" }],
+            "largest-contentful-paint": ["error", { "maxNumericValue": 2500, "aggregationMethod": "median" }],
+            "installable-manifest": "error"
+          }
+        },
+        {
+          "matchingUrlPattern": "kds/expo",
+          "assertions": {
+            "categories:performance": ["error", { "minScore": 0.85 }]
+          }
+        },
+        {
+          "matchingUrlPattern": "admin/dashboard",
+          "assertions": {
+            "categories:performance": ["error", { "minScore": 0.85 }]
+          }
+        }
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "eslint": "^8.57.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@axe-core/playwright": "^4.9.1"
   }
 }

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -2,8 +2,9 @@
   --color-primary: #2563eb;
   --color-accent: #64748b;
   --color-secondary: #64748b;
-  --color-success: #16a34a;
-  --color-warn: #f59e0b;
-  --color-error: #dc2626;
+  --color-success: #15803d;
+  --color-warn: #b45309;
+  --color-danger: #b91c1c;
+  --color-error: #b91c1c;
   --logo-url: url('');
 }

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -1,7 +1,8 @@
 export const colors = {
   primary: '#2563eb',
   secondary: '#64748b',
-  success: '#16a34a',
-  warn: '#f59e0b',
-  error: '#dc2626'
+  success: '#15803d',
+  warn: '#b45309',
+  danger: '#b91c1c',
+  error: '#b91c1c'
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.9.1
+        version: 4.10.2(playwright-core@1.55.0)
       '@playwright/test':
         specifier: ^1.55.0
         version: 1.55.0
@@ -471,6 +474,11 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@axe-core/playwright@4.10.2':
+    resolution: {integrity: sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -2047,6 +2055,10 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axe-core@4.10.3:
+    resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
+    engines: {node: '>=4'}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -4281,6 +4293,11 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
 
+  '@axe-core/playwright@4.10.2(playwright-core@1.55.0)':
+    dependencies:
+      axe-core: 4.10.3
+      playwright-core: 1.55.0
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -5951,6 +5968,8 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.10.3: {}
 
   babel-jest@29.7.0(@babel/core@7.28.3):
     dependencies:

--- a/tests/a11y/a11y.spec.ts
+++ b/tests/a11y/a11y.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const guestBase = process.env.GUEST_BASE_URL || process.env.BASE_URL || '';
+const kdsBase = process.env.KDS_BASE_URL || process.env.BASE_URL || '';
+const adminBase = process.env.ADMIN_BASE_URL || process.env.BASE_URL || '';
+
+test('guest menu has no serious accessibility violations', async ({ page }) => {
+  await page.goto(`${guestBase}/menu`);
+  const results = await new AxeBuilder({ page }).analyze();
+  const serious = results.violations.filter(v => v.impact === 'serious' || v.impact === 'critical');
+  expect(serious).toEqual([]);
+});
+
+test('kds expo has no serious accessibility violations', async ({ page }) => {
+  await page.goto(`${kdsBase}/kds/expo`);
+  const results = await new AxeBuilder({ page }).analyze();
+  const serious = results.violations.filter(v => v.impact === 'serious' || v.impact === 'critical');
+  expect(serious).toEqual([]);
+});
+
+test('admin dashboard has no serious accessibility violations', async ({ page }) => {
+  await page.goto(`${adminBase}/dashboard`);
+  const results = await new AxeBuilder({ page }).analyze();
+  const serious = results.violations.filter(v => v.impact === 'serious' || v.impact === 'critical');
+  expect(serious).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- enforce performance budgets via Lighthouse CI on guest, kds, and admin previews
- add axe-based accessibility checks for key pages and basic semantic fixes
- improve UI color tokens for WCAG AA contrast

## Testing
- `pnpm -r --filter ./apps/guest --filter ./apps/kds --filter ./apps/admin --filter ./packages/ui lint`
- `pnpm -r --filter ./apps/guest --filter ./apps/kds --filter ./apps/admin --filter ./packages/ui --filter ./packages/utils typecheck` (fails: Cannot find module '@neo/utils')
- `pnpm typecheck` (fails: packages/api missing deps)
- `GUEST_BASE_URL=https://example.com KDS_BASE_URL=https://example.com ADMIN_BASE_URL=https://example.com npx playwright test --config=playwright.config.ts tests/a11y/a11y.spec.ts` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b1a2cb65d8832abaf683785b333789