### PR TITLE
Serve accessible 401 error page for admin

### DIFF
--- a/api/app/middlewares/error_pages.py
+++ b/api/app/middlewares/error_pages.py
@@ -19,7 +19,7 @@ class HTMLErrorPagesMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
         accept = request.headers.get("accept", "")
-        if "text/html" in accept and response.status_code in {403, 404, 500}:
+        if "text/html" in accept and response.status_code in {401, 403, 404, 500}:
             error_file = self.static_dir / "errors" / f"{response.status_code}.html"
             if error_file.is_file():
                 return FileResponse(error_file, status_code=response.status_code)

--- a/static/errors/401.html
+++ b/static/errors/401.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>401 Unauthorized</title>
+  <style>
+    body { color: #000; background: #fff; }
+    a:focus, button:focus { outline: 2px solid #005fcc; }
+  </style>
+</head>
+<body>
+  <h1>401 Unauthorized</h1>
+  <p>You must authenticate to access this resource.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend HTMLErrorPagesMiddleware to serve static pages for 401 responses
- add dedicated 401.html error template to provide title and language metadata

## Testing
- `pre-commit run --files api/app/middlewares/error_pages.py static/errors/401.html`
- `npx --yes pa11y-ci -c pa11y-ci-local.json` *(fails to run default script; server started manually)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a02505f4832aac530093fcfe0ba4