### PR TITLE
feat(support): admin support center + tickets + NPS feedback with diagnostics & notifications

### DIFF
--- a/api/app/models_master.py
+++ b/api/app/models_master.py
@@ -230,6 +230,20 @@ class SupportTicket(Base):
     created_at = Column(DateTime, server_default=func.now())
 
 
+class FeedbackNPS(Base):
+    """Net Promoter Score feedback from owners."""
+
+    __tablename__ = "feedback_nps"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant = Column(String, nullable=True)
+    user = Column(String, nullable=True)
+    score = Column(Integer, nullable=False)
+    comment = Column(String, nullable=True)
+    feature_request = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime, server_default=func.now())
+
+
 class Device(Base):
     """Registered staff devices."""
 
@@ -252,5 +266,6 @@ __all__ = [
     "TwoFactorBackupCode",
     "PrepStats",
     "SupportTicket",
+    "FeedbackNPS",
     "Device",
 ]

--- a/api/tests/test_support_feedback.py
+++ b/api/tests/test_support_feedback.py
@@ -1,0 +1,35 @@
+"""Tests for NPS feedback API."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from api.app.auth import create_access_token  # noqa: E402
+from api.app.db import SessionLocal  # noqa: E402
+from api.app.models_master import FeedbackNPS  # noqa: E402
+from api.app.routes_support import router as support_router  # noqa: E402
+
+app = FastAPI()
+app.include_router(support_router)
+
+
+def test_support_feedback() -> None:
+    client = TestClient(app)
+    token = create_access_token({"sub": "owner@example.com", "role": "owner"})
+    resp = client.post(
+        "/support/feedback",
+        headers={"Authorization": f"Bearer {token}", "X-Tenant-ID": "demo"},
+        json={"score": 9, "comment": "Great", "feature_request": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == "thanks"
+    with SessionLocal() as session:
+        rows = session.query(FeedbackNPS).all()
+        assert len(rows) == 1
+        assert rows[0].score == 9
+        assert rows[0].feature_request is True

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,16 @@
+# Support Workflows
+
+This document outlines how owners can reach the support team and how operators handle requests.
+
+## Workflows
+- Owners file tickets or submit feedback from the admin portal.
+- Staff respond through the support console.
+
+## SLAs
+Support aims to acknowledge requests within one business day and resolve critical issues within 72 hours.
+
+## FAQ Management
+Add Markdown files under `docs/faq/` to surface them in the admin support center.
+
+## Diagnostics
+When owners opt in, requests include basic context such as tenant, user and environment. Sensitive values like secrets or tokens are removed before storage.


### PR DESCRIPTION
## Summary
- store NPS feedback via new `FeedbackNPS` model
- expose `/support/feedback` endpoint for owners to send scores and comments
- document support workflows and diagnostics in SUPPORT.md

## Testing
- `pre-commit run --files api/app/models_master.py api/app/routes_support.py api/tests/test_support_feedback.py docs/SUPPORT.md`
- `pytest -q` *(fails: tests/test_alembic_env.py etc. missing environment variables)*
- `pre-commit run --files api/tests/test_support_feedback.py`
- `pytest api/tests/test_support_feedback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1a599d10c832aa561e41c0c94f577