### PR TITLE
test(ui): Playwright visual regression for guest/kds/admin key screens

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -95,3 +95,30 @@ jobs:
           KDS_BASE_URL: ${{ secrets.STAGING_KDS_URL }}
           ADMIN_BASE_URL: ${{ secrets.STAGING_ADMIN_URL }}
         run: npx playwright test tests/a11y/a11y.spec.ts
+
+  vr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: npx playwright install --with-deps
+      - name: Run visual regression tests
+        env:
+          BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+          GUEST_BASE_URL: ${{ secrets.STAGING_GUEST_URL }}
+          KDS_BASE_URL: ${{ secrets.STAGING_KDS_URL }}
+          ADMIN_BASE_URL: ${{ secrets.STAGING_ADMIN_URL }}
+        run: npx playwright test -c playwright.vr.config.ts
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-vr-report
+          path: playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,5 @@ node_modules
 *.tsbuildinfo
 dist
 build
+
+tests/vr/__snapshots__/

--- a/playwright.vr.config.ts
+++ b/playwright.vr.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.BASE_URL || 'http://localhost:3000';
+
+export default defineConfig({
+  testDir: './tests/vr',
+  reporter: [['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    headless: true,
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'Desktop Chrome', use: { ...devices['Desktop Chrome'] } },
+    { name: 'Moto G4', use: { ...devices['Moto G4'] } },
+  ],
+});

--- a/tests/vr/admin_dashboard.spec.ts
+++ b/tests/vr/admin_dashboard.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+const adminBaseURL = process.env.ADMIN_BASE_URL || process.env.BASE_URL || 'http://localhost:3000';
+
+// Visual regression for admin dashboard KPI cards with mocked SSE
+// Masks dynamic timestamps and counters
+
+test('admin dashboard snapshot', async ({ page }) => {
+  await page.route('**/sse/**', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: 'data: {"kpi": 42}\n\n',
+    });
+  });
+  await page.goto(`${adminBaseURL}/admin/dashboard`);
+  const kpis = page.locator('[data-testid="kpi-cards"]');
+  const mask = [
+    page.locator('[data-testid="timestamp"]'),
+    page.locator('[data-testid="counter"]'),
+  ];
+  const screenshot = await kpis.screenshot({ mask });
+  expect(screenshot).toMatchSnapshot('admin-dashboard.png');
+});

--- a/tests/vr/guest_menu.spec.ts
+++ b/tests/vr/guest_menu.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+const guestBaseURL = process.env.GUEST_BASE_URL || process.env.BASE_URL || 'http://localhost:3000';
+
+// Visual regression for guest menu screen
+// Masks dynamic timestamps and counters
+
+test('guest menu snapshot', async ({ page }) => {
+  await page.goto(`${guestBaseURL}/guest/menu`);
+  const mask = [
+    page.locator('[data-testid="timestamp"]'),
+    page.locator('[data-testid="counter"]'),
+  ];
+  const screenshot = await page.screenshot({ mask });
+  expect(screenshot).toMatchSnapshot('guest-menu.png');
+});

--- a/tests/vr/kds_expo.spec.ts
+++ b/tests/vr/kds_expo.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+const kdsBaseURL = process.env.KDS_BASE_URL || process.env.BASE_URL || 'http://localhost:3000';
+
+// Visual regression for KDS expo columns with mocked tickets
+// Masks dynamic timestamps and counters
+
+test('kds expo snapshot', async ({ page }) => {
+  await page.route('**/tickets**', route => {
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ tickets: [{ id: 1, item: 'Mock item' }] }),
+    });
+  });
+  await page.goto(`${kdsBaseURL}/kds/expo`);
+  const columns = page.locator('[data-testid="kds-columns"]');
+  const mask = [
+    page.locator('[data-testid="timestamp"]'),
+    page.locator('[data-testid="counter"]'),
+  ];
+  const screenshot = await columns.screenshot({ mask });
+  expect(screenshot).toMatchSnapshot('kds-expo.png');
+});


### PR DESCRIPTION
## Summary
- add Playwright VR config with desktop and Moto G4 devices
- snapshot tests for guest menu, KDS expo, and admin dashboard
- run VR tests in CI and ignore generated snapshots

## Testing
- `npx playwright test -c playwright.vr.config.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a84cb930832a96432f16dd787a2c