### PR TITLE
chore: shorten tenant migration revision

### DIFF
--- a/api/alembic_tenant/versions/0012_soft_delete_unique_indexes.py
+++ b/api/alembic_tenant/versions/0012_soft_delete_unique_indexes.py
@@ -1,15 +1,15 @@
 """add deleted_at and partial unique indexes"""
 
 """
-Revision ID: 0012_soft_delete_and_unique_indexes
+Revision ID: 0012_soft_delete_unique_indexes
 Revises: 0011_sales_rollup
 Create Date: 2025-09-20
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
-revision: str = "0012_soft_delete_and_unique_indexes"
+revision: str = "0012_soft_delete_unique_indexes"
 down_revision: str | None = "0011_sales_rollup"
 branch_labels: tuple[str, ...] | None = None
 depends_on: tuple[str, ...] | None = None
@@ -20,7 +20,8 @@ def upgrade() -> None:
     insp = sa.inspect(conn)
     if "deleted_at" not in {c["name"] for c in insp.get_columns("menu_items")}:
         op.add_column(
-            "menu_items", sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True)
+            "menu_items",
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
         )
     if "deleted_at" not in {c["name"] for c in insp.get_columns("tables")}:
         op.add_column(
@@ -51,7 +52,9 @@ def downgrade() -> None:
     if conn.dialect.name == "postgresql":
         with op.get_context().autocommit_block():
             conn.execute(sa.text("DROP INDEX IF EXISTS idx_tables_tenant_code_active"))
-            conn.execute(sa.text("DROP INDEX IF EXISTS idx_menu_items_tenant_sku_active"))
+            conn.execute(
+                sa.text("DROP INDEX IF EXISTS idx_menu_items_tenant_sku_active")
+            )
     for table in ("tables", "menu_items"):
         insp = sa.inspect(conn)
         if "deleted_at" in {c["name"] for c in insp.get_columns(table)}:

--- a/api/alembic_tenant/versions/0013_coupon_caps_windows.py
+++ b/api/alembic_tenant/versions/0013_coupon_caps_windows.py
@@ -2,22 +2,26 @@
 
 """
 Revision ID: 0013_coupon_caps_windows
-Revises: 0012_soft_delete_and_unique_indexes
+Revises: 0012_soft_delete_unique_indexes
 Create Date: 2025-09-25
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision: str = "0013_coupon_caps_windows"
-down_revision: str | None = "0012_soft_delete_and_unique_indexes"
+down_revision: str | None = "0012_soft_delete_unique_indexes"
 branch_labels: tuple[str, ...] | None = None
 depends_on: tuple[str, ...] | None = None
 
 
 def upgrade() -> None:
-    op.add_column("coupons", sa.Column("valid_from", sa.DateTime(timezone=True), nullable=True))
-    op.add_column("coupons", sa.Column("valid_to", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "coupons", sa.Column("valid_from", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column(
+        "coupons", sa.Column("valid_to", sa.DateTime(timezone=True), nullable=True)
+    )
     op.add_column("coupons", sa.Column("per_day_cap", sa.Integer(), nullable=True))
     op.add_column("coupons", sa.Column("per_guest_cap", sa.Integer(), nullable=True))
     op.add_column("coupons", sa.Column("per_outlet_cap", sa.Integer(), nullable=True))
@@ -25,10 +29,16 @@ def upgrade() -> None:
     op.create_table(
         "coupon_usage",
         sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("coupon_id", sa.Integer(), sa.ForeignKey("coupons.id"), nullable=False),
+        sa.Column(
+            "coupon_id", sa.Integer(), sa.ForeignKey("coupons.id"), nullable=False
+        ),
         sa.Column("guest_id", sa.Integer(), nullable=True),
         sa.Column("outlet_id", sa.Integer(), nullable=True),
-        sa.Column("used_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column(
+            "used_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- rename tenant migration 0012 and shorten revision ID
- update subsequent migration down_revision to new ID

## Testing
- `pre-commit run --files api/alembic_tenant/versions/0012_soft_delete_unique_indexes.py api/alembic_tenant/versions/0013_coupon_caps_windows.py`
- `alembic -c api/alembic.ini upgrade head` *(fails: Name or service not known)*
- `python -m api.onboard_tenant` *(fails: No module named 'app')*
- `pytest` *(fails: import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ac58ab04832aa2a18c810e20d1cd