### PR TITLE
feat: add configurable video streaming backend

### DIFF
--- a/api/app/utils/video_stream.py
+++ b/api/app/utils/video_stream.py
@@ -1,0 +1,36 @@
+"""Abstraction layer for video streaming backends."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import List
+
+from config import get_settings
+
+
+def get_backend() -> str:
+    """Return the configured video backend.
+
+    GStreamer is used when ``USE_GSTREAMER`` is enabled in settings; otherwise
+    FFmpeg is selected.
+    """
+
+    return "gstreamer" if get_settings().use_gstreamer else "ffmpeg"
+
+
+def build_command(source: str, destination: str) -> List[str]:
+    """Return the shell command for streaming ``source`` to ``destination``."""
+
+    if get_backend() == "gstreamer":
+        return ["gst-launch-1.0", source, destination]
+    return ["ffmpeg", "-i", source, destination]
+
+
+def stream_video(source: str, destination: str) -> subprocess.CompletedProcess:
+    """Stream video from ``source`` to ``destination`` using the chosen backend."""
+
+    cmd = build_command(source, destination)
+    return subprocess.run(cmd, check=True)
+
+
+__all__ = ["get_backend", "build_command", "stream_video"]

--- a/config.py
+++ b/config.py
@@ -58,6 +58,7 @@ class Settings(BaseSettings):
     eta_confidence: str = "p50"
     max_queue_factor: float = 1.6
     eta_enabled: bool = False
+    use_gstreamer: bool = False
 
 
 # Cached singleton to avoid repeated file reads

--- a/start_app.py
+++ b/start_app.py
@@ -12,6 +12,7 @@ import uvicorn
 from dotenv import load_dotenv
 
 import config
+from api.app.utils.video_stream import get_backend
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -81,6 +82,8 @@ def main(argv: list[str] | None = None) -> None:
             return
 
     config.get_settings()  # ensure settings are initialized with any override
+    backend = get_backend()
+    print(f"Using {backend} for video streaming")
 
     try:
         uvicorn.run(

--- a/tests/test_video_stream.py
+++ b/tests/test_video_stream.py
@@ -1,0 +1,23 @@
+import importlib
+
+import config
+from api.app.utils import video_stream
+
+
+def _reload_settings():
+    config.get_settings.cache_clear()
+    importlib.reload(video_stream)
+
+
+def test_ffmpeg_backend(monkeypatch):
+    monkeypatch.delenv("USE_GSTREAMER", raising=False)
+    _reload_settings()
+    assert video_stream.get_backend() == "ffmpeg"
+    assert video_stream.build_command("in", "out")[0] == "ffmpeg"
+
+
+def test_gstreamer_backend(monkeypatch):
+    monkeypatch.setenv("USE_GSTREAMER", "1")
+    _reload_settings()
+    assert video_stream.get_backend() == "gstreamer"
+    assert video_stream.build_command("in", "out")[0] == "gst-launch-1.0"


### PR DESCRIPTION
## Summary
- add `use_gstreamer` flag to global settings
- create video_stream util selecting GStreamer or FFmpeg
- initialize video backend in start_app
- test both backends

## Testing
- `pre-commit run --files config.py start_app.py api/app/utils/video_stream.py tests/test_video_stream.py`
- `pytest tests/test_video_stream.py`
- `pytest tests/test_start_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1afbe31a4832ab745c8aa4cd826a9