### PR TITLE
fix: correct deploy workflow structure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,9 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git push origin HEAD:deploy --force
-
-    deploy-staging:
-      needs: build-and-push
-      if: ${{ secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+  deploy-staging:
+    needs: build-and-push
+    if: ${{ secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -98,9 +97,9 @@ jobs:
       - name: Awaiting approval
         run: echo "Manual approval required to deploy to production"
 
-    deploy-prod:
-      needs: manual-approval
-      if: ${{ secrets.KUBE_CONFIG_PROD != '' && secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+  deploy-prod:
+    needs: manual-approval
+    if: ${{ secrets.KUBE_CONFIG_PROD != '' && secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: prod
     env:


### PR DESCRIPTION
## Summary
- split deploy workflow into distinct jobs for build, staging, approval, and production

## Testing
- `pre-commit run --files .github/workflows/deploy.yml`
- `pytest` *(fails: tests/test_alembic_env.py, tests/test_analytics_outlets.py, tests/test_export_streaming.py, tests/test_kds_expo.py, tests/test_rum_vitals.py, tests/test_slo_metrics.py, tests/test_time_skew.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b182d60c832aa4ea6ee85416079c