### PR TITLE
feat(support): owner Support Center + staff console, FAQ, emails, diagnostics (redacted) + tests

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -194,6 +194,7 @@ from .routes_sandbox_bootstrap import router as sandbox_bootstrap_router
 from .routes_security import router as security_router
 from .routes_slo import router as slo_router
 from .routes_staff import router as staff_router
+from .routes_staff_support import router as staff_support_router
 from .routes_status_json import router as status_json_router
 from .routes_support import router as support_router
 from .routes_support_bundle import router as support_bundle_router
@@ -988,6 +989,7 @@ app.include_router(troubleshoot_router)
 app.include_router(help_router)
 app.include_router(support_router)
 app.include_router(admin_support_router)
+app.include_router(staff_support_router)
 app.include_router(support_console_router)
 app.include_router(admin_webhooks_router)
 app.include_router(print_test_router)

--- a/api/app/routes_staff_support.py
+++ b/api/app/routes_staff_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
@@ -8,6 +9,7 @@ from sqlalchemy import func, select
 from .auth import User, role_required
 from .db import SessionLocal
 from .models_master import SupportMessage, SupportTicket
+from .providers import email_stub
 from .utils.responses import ok
 
 router = APIRouter()
@@ -102,6 +104,11 @@ async def staff_reply_ticket(
         session.add(msg)
         ticket.updated_at = func.now()
         session.commit()
+    email_stub.send(
+        "support.email_agent_reply",
+        {"subject": ticket.subject, "body": payload.message},
+        "ops@",
+    )
     return ok({"status": "sent"})
 
 

--- a/apps/admin/src/diagnostics.ts
+++ b/apps/admin/src/diagnostics.ts
@@ -1,0 +1,46 @@
+const logs: string[] = [];
+(['log', 'warn', 'error'] as const).forEach((level) => {
+  const orig = console[level];
+  console[level] = (...args: any[]) => {
+    logs.push(args.join(' '));
+    if (logs.length > 20) logs.shift();
+    orig(...args);
+  };
+});
+
+interface ApiErr { path: string; status: number }
+const apiErrors: ApiErr[] = [];
+const origFetch = window.fetch;
+window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const res = await origFetch(input, init);
+  if (!res.ok) {
+    const url = typeof input === 'string' ? input : (input as any).url;
+    apiErrors.push({ path: url, status: res.status });
+    if (apiErrors.length > 10) apiErrors.shift();
+  }
+  return res;
+};
+
+const secretRe = /(?:bearer|token|authorization|utr|upi|card)/gi;
+
+function redact(data: any): any {
+  if (typeof data === 'string') return data.replace(secretRe, '****');
+  if (Array.isArray(data)) return data.map(redact);
+  if (data && typeof data === 'object') {
+    const out: any = {};
+    for (const k in data) out[k] = redact(data[k]);
+    return out;
+  }
+  return data;
+}
+
+export function collectDiagnostics(route: string) {
+  return redact({
+    app: 'admin',
+    appVersion: (import.meta as any).env.VITE_APP_VERSION || 'dev',
+    userAgent: navigator.userAgent,
+    route,
+    logs: [...logs],
+    errors: [...apiErrors],
+  });
+}

--- a/apps/admin/src/pages/StaffSupport.tsx
+++ b/apps/admin/src/pages/StaffSupport.tsx
@@ -1,0 +1,108 @@
+import { useState, useEffect } from 'react';
+
+export function StaffSupport() {
+  const [tickets, setTickets] = useState<any[]>([]);
+  const [current, setCurrent] = useState<any | null>(null);
+  const [status, setStatus] = useState('');
+  const [tenant, setTenant] = useState('');
+  const [msg, setMsg] = useState('');
+  const [internal, setInternal] = useState(false);
+  const [canned, setCanned] = useState<any[]>([]);
+
+  const load = () => {
+    const params = new URLSearchParams();
+    if (status) params.set('status', status);
+    if (tenant) params.set('tenant', tenant);
+    fetch('/staff/support?' + params.toString())
+      .then((r) => r.json())
+      .then((r) => setTickets(r.data || []));
+  };
+
+  useEffect(() => { load(); }, [status, tenant]);
+
+  const open = async (id: string) => {
+    const r = await fetch(`/staff/support/${id}`);
+    const d = await r.json();
+    setCurrent(d.data);
+  };
+
+  const send = async () => {
+    if (!current) return;
+    await fetch(`/staff/support/${current.id}/reply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: msg, internal }),
+    });
+    setMsg('');
+    open(current.id);
+  };
+
+  const close = async () => {
+    if (!current) return;
+    await fetch(`/staff/support/${current.id}/close`, { method: 'POST' });
+    open(current.id);
+  };
+
+  const reopen = async () => {
+    if (!current) return;
+    await fetch(`/staff/support/${current.id}/reopen`, { method: 'POST' });
+    open(current.id);
+  };
+
+  useEffect(() => {
+    import('../../../docs/faq/meta.json').then((m) => setCanned(m.default));
+  }, []);
+
+  const insert = async (id: string) => {
+    const files = import.meta.glob('../../../docs/faq/*.md', { as: 'raw' });
+    const loader = files[`../../../docs/faq/${id}.md`];
+    if (loader) {
+      const content = await (loader as () => Promise<string>)();
+      setMsg((m) => m + '\n' + content);
+    }
+  };
+
+  return (
+    <div className="flex">
+      <div className="w-1/3">
+        <input placeholder="status" value={status} onChange={(e) => setStatus(e.target.value)} />
+        <input placeholder="tenant" value={tenant} onChange={(e) => setTenant(e.target.value)} />
+        <button onClick={load}>Filter</button>
+        <ul>
+          {tickets.map((t) => (
+            <li key={t.id}>
+              <button onClick={() => open(t.id)}>{t.subject}</button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="flex-1">
+        {current && (
+          <div>
+            <h3>{current.subject}</h3>
+            <button onClick={close}>Close</button>
+            <button onClick={reopen}>Reopen</button>
+            <ul>
+              {current.messages.map((m: any) => (
+                <li key={m.id}>
+                  <b>{m.author}:</b> {m.body} {m.internal ? '(internal)' : ''}
+                </li>
+              ))}
+            </ul>
+            <select onChange={(e) => insert(e.target.value)} value="">
+              <option value="">Canned reply</option>
+              {canned.map((c: any) => (
+                <option key={c.id} value={c.id}>{c.title}</option>
+              ))}
+            </select>
+            <textarea value={msg} onChange={(e) => setMsg(e.target.value)} />
+            <label>
+              <input type="checkbox" checked={internal} onChange={(e) => setInternal(e.target.checked)} /> internal
+            </label>
+            <button onClick={send}>Send</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/pages/Support.tsx
+++ b/apps/admin/src/pages/Support.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { collectDiagnostics } from '../diagnostics';
 
 interface FaqEntry {
   title: string;
@@ -9,21 +10,77 @@ export function Support() {
   const [tab, setTab] = useState<'faq' | 'contact' | 'tickets' | 'feedback'>('faq');
   const [faqs, setFaqs] = useState<FaqEntry[]>([]);
   const [selected, setSelected] = useState(0);
+  const [subject, setSubject] = useState('');
+  const [message, setMessage] = useState('');
+  const [channel, setChannel] = useState<'email' | 'whatsapp'>('email');
+  const [includeDiag, setIncludeDiag] = useState(false);
+  const [tickets, setTickets] = useState<any[]>([]);
+  const [current, setCurrent] = useState<any | null>(null);
+  const [reply, setReply] = useState('');
+  const [score, setScore] = useState(0);
+  const [comment, setComment] = useState('');
+  const [thanks, setThanks] = useState(false);
 
   useEffect(() => {
-    const files = import.meta.glob('../../../docs/faq/*.md', { as: 'raw' });
     const load = async () => {
+      const meta = await import('../../../../docs/faq/meta.json');
       const entries: FaqEntry[] = [];
-      for (const path in files) {
-        const loader = files[path] as () => Promise<string>;
-        const content = await loader();
-        const title = content.split('\n')[0].replace(/^#\s*/, '') || path;
-        entries.push({ title, content });
+      for (const item of meta.default) {
+        const md = await import(`../../../../docs/faq/${item.id}.md?raw`);
+        entries.push({ title: item.title, content: md.default });
       }
       setFaqs(entries);
     };
     load();
   }, []);
+
+  useEffect(() => {
+    if (tab === 'tickets') {
+      fetch('/support/tickets')
+        .then((r) => r.json())
+        .then((r) => setTickets(r.data || []));
+    }
+  }, [tab]);
+
+  const submitTicket = async () => {
+    const payload: any = { subject, message, channel, attachments: [] };
+    if (includeDiag) payload.includeDiagnostics = true, payload.diagnostics = collectDiagnostics(window.location.pathname);
+    await fetch('/support/tickets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    setSubject('');
+    setMessage('');
+    setIncludeDiag(false);
+    setTab('tickets');
+  };
+
+  const openTicket = async (id: string) => {
+    const r = await fetch(`/support/tickets/${id}`);
+    const data = await r.json();
+    setCurrent(data.data);
+  };
+
+  const sendReply = async () => {
+    if (!current) return;
+    await fetch(`/support/tickets/${current.id}/reply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: reply }),
+    });
+    setReply('');
+    openTicket(current.id);
+  };
+
+  const submitFeedback = async () => {
+    await fetch('/support/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ score, comment }),
+    });
+    setThanks(true);
+  };
 
   return (
     <div>
@@ -50,13 +107,105 @@ export function Support() {
             {faqs.length === 0 && <li>No FAQs</li>}
           </ul>
           <div className="flex-1 border-l pl-4">
-            {faqs.length === 0 ? <p>Loading...</p> : <pre>{faqs[selected]?.content}</pre>}
+            {faqs.length === 0 ? (
+              <p>Loading...</p>
+            ) : (
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: faqs[selected]?.content
+                    .replace(/^# (.*$)/gim, '<h1>$1</h1>')
+                    .replace(/^## (.*$)/gim, '<h2>$1</h2>')
+                    .replace(/\n/g, '<br/>'),
+                }}
+              />
+            )}
           </div>
         </div>
       )}
-      {tab === 'contact' && <p>Contact form coming soon.</p>}
-      {tab === 'tickets' && <p>Tickets view coming soon.</p>}
-      {tab === 'feedback' && <p>Feedback form coming soon.</p>}
+      {tab === 'contact' && (
+        <div className="space-y-2">
+          <input
+            placeholder="Subject"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+          />
+          <textarea
+            placeholder="Message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+          <select value={channel} onChange={(e) => setChannel(e.target.value as any)}>
+            <option value="email">email</option>
+            <option value="whatsapp">whatsapp</option>
+          </select>
+          <label>
+            <input
+              type="checkbox"
+              checked={includeDiag}
+              onChange={(e) => setIncludeDiag(e.target.checked)}
+            />
+            Include diagnostics
+          </label>
+          <button onClick={submitTicket}>Submit</button>
+        </div>
+      )}
+      {tab === 'tickets' && (
+        <div className="flex">
+          <ul className="w-48 mr-4">
+            {tickets.map((t) => (
+              <li key={t.id}>
+                <button onClick={() => openTicket(t.id)}>{t.subject}</button>
+              </li>
+            ))}
+            {tickets.length === 0 && <li>No tickets</li>}
+          </ul>
+          <div className="flex-1">
+            {current ? (
+              <div>
+                <h3>{current.subject}</h3>
+                <ul>
+                  {current.messages.map((m: any) => (
+                    <li key={m.id}>
+                      <b>{m.author}:</b> {m.body}
+                    </li>
+                  ))}
+                </ul>
+                <textarea
+                  placeholder="Reply"
+                  value={reply}
+                  onChange={(e) => setReply(e.target.value)}
+                />
+                <button onClick={sendReply}>Send</button>
+              </div>
+            ) : (
+              <p>Select a ticket</p>
+            )}
+          </div>
+        </div>
+      )}
+      {tab === 'feedback' && (
+        <div className="space-y-2">
+          {thanks ? (
+            <p>Thanks!</p>
+          ) : (
+            <>
+              <input
+                type="number"
+                min={0}
+                max={10}
+                value={score}
+                onChange={(e) => setScore(parseInt(e.target.value))}
+              />
+              <textarea
+                placeholder="Comment"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+              />
+              <button onClick={submitFeedback}>Submit</button>
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -7,6 +7,7 @@ import { Onboarding } from './pages/Onboarding';
 import { Support } from './pages/Support';
 import { Layout } from './components/Layout';
 import { ProtectedRoute } from './components/ProtectedRoute';
+import { StaffSupport } from './pages/StaffSupport';
 
 export const routes: RouteObject[] = [
   { path: '/login', element: <Login /> },
@@ -33,6 +34,16 @@ export const routes: RouteObject[] = [
         { path: 'support', element: <Support /> }
       ]
     }
-  ];
+  },
+  {
+    path: '/staff',
+    element: (
+      <ProtectedRoute roles={['super_admin', 'support']}>
+        <Layout />
+      </ProtectedRoute>
+    ),
+    children: [{ path: 'support', element: <StaffSupport /> }],
+  }
+];
 
 export const router = createBrowserRouter(routes);

--- a/apps/admin/tests/support.ui.spec.tsx
+++ b/apps/admin/tests/support.ui.spec.tsx
@@ -1,0 +1,49 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../src/diagnostics', () => ({ collectDiagnostics: () => ({}) }));
+import { Support } from '../src/pages/Support';
+
+describe('Support UI', () => {
+  beforeEach(() => {
+    (global.fetch as any) = vi.fn(async (url: any, opts: any) => {
+      if (url === '/support/tickets' && opts?.method === 'POST') {
+        return { ok: true, json: async () => ({ data: { id: '1' } }) } as any;
+      }
+      if (url === '/support/tickets') {
+        return { ok: true, json: async () => ({ data: [{ id: '1', subject: 'Bug' }] }) } as any;
+      }
+      if (url === '/support/tickets/1') {
+        return { ok: true, json: async () => ({ data: { id: '1', subject: 'Bug', messages: [{ id: 'm1', author: 'owner', body: 'Issue' }] } }) } as any;
+      }
+      if (url === '/support/tickets/1/reply') {
+        return { ok: true, json: async () => ({ data: { status: 'sent' } }) } as any;
+      }
+      if (url === '/support/feedback') {
+        return { ok: true, json: async () => ({}) } as any;
+      }
+      return { ok: true, json: async () => ({}) } as any;
+    });
+  });
+
+  test('create ticket, reply thread, render FAQ', async () => {
+    render(
+      <MemoryRouter>
+        <Support />
+      </MemoryRouter>
+    );
+    await screen.findAllByText('Getting Started');
+    await userEvent.click(screen.getByText('CONTACT'));
+    await userEvent.type(screen.getByPlaceholderText('Subject'), 'Bug');
+    await userEvent.type(screen.getByPlaceholderText('Message'), 'Issue');
+    await userEvent.click(screen.getByText('Submit'));
+    await screen.findByText('Bug');
+    await userEvent.click(screen.getByText('Bug'));
+    await screen.findByText('Issue');
+    await userEvent.type(screen.getByPlaceholderText('Reply'), 'Thanks');
+    await userEvent.click(screen.getByText('Send'));
+    expect(fetch).toHaveBeenCalledWith('/support/tickets/1/reply', expect.anything());
+  });
+});

--- a/docs/faq/billing-faq.md
+++ b/docs/faq/billing-faq.md
@@ -1,0 +1,2 @@
+# Billing FAQ
+Billing questions answered.

--- a/docs/faq/getting-started.md
+++ b/docs/faq/getting-started.md
@@ -1,0 +1,2 @@
+# Getting Started
+Some intro text.

--- a/docs/faq/kds-tips.md
+++ b/docs/faq/kds-tips.md
@@ -1,0 +1,2 @@
+# KDS Tips
+Use KDS effectively.

--- a/docs/faq/meta.json
+++ b/docs/faq/meta.json
@@ -1,0 +1,6 @@
+[
+  {"id": "getting-started", "title": "Getting Started"},
+  {"id": "qr-troubleshooting", "title": "QR Troubleshooting"},
+  {"id": "billing-faq", "title": "Billing FAQ"},
+  {"id": "kds-tips", "title": "KDS Tips"}
+]

--- a/docs/faq/qr-troubleshooting.md
+++ b/docs/faq/qr-troubleshooting.md
@@ -1,0 +1,2 @@
+# QR Troubleshooting
+How to fix QR issues.

--- a/templates/support/email_agent_reply.html
+++ b/templates/support/email_agent_reply.html
@@ -1,0 +1,1 @@
+<html><body><p>Agent replied on {{subject}}</p></body></html>

--- a/templates/support/email_new_ticket.html
+++ b/templates/support/email_new_ticket.html
@@ -1,0 +1,1 @@
+<html><body><p>New ticket: {{subject}}</p></body></html>


### PR DESCRIPTION
## Summary
- implement diagnostics redaction and new ticket APIs
- add owner Support Center and staff console UI
- ship FAQ docs and support email templates

## Testing
- `pytest api/tests/test_support_tickets.py api/tests/test_support_feedback.py`
- `corepack pnpm --filter @neo/admin test`
- `pre-commit run --files api/app/main.py api/app/routes_staff_support.py api/app/routes_support.py api/tests/test_support_tickets.py apps/admin/src/pages/Support.tsx apps/admin/src/routes.tsx apps/admin/src/diagnostics.ts apps/admin/src/pages/StaffSupport.tsx apps/admin/tests/support.ui.spec.tsx docs/faq/getting-started.md docs/faq/qr-troubleshooting.md docs/faq/billing-faq.md docs/faq/kds-tips.md docs/faq/meta.json templates/support/email_new_ticket.html templates/support/email_agent_reply.html`


------
https://chatgpt.com/codex/tasks/task_e_68b1be3bf37c832a983510aecd3f6124