### PR TITLE
feat(floor): live map color states, filters, full-screen

### DIFF
--- a/api/app/routes_tables_map.py
+++ b/api/app/routes_tables_map.py
@@ -95,6 +95,10 @@ async def get_table_map(tenant: str, include_deleted: bool = False) -> dict:
                 "x": t.pos_x,
                 "y": t.pos_y,
                 "state": t.state,
+                "zone": t.zone,
+                "width": t.width,
+                "height": t.height,
+                "shape": t.shape,
             }
             for t in records
         ]

--- a/api/app/routes_tables_sse.py
+++ b/api/app/routes_tables_sse.py
@@ -99,6 +99,10 @@ async def stream_table_map(
                         "x": t.pos_x,
                         "y": t.pos_y,
                         "state": t.state,
+                        "zone": t.zone,
+                        "width": t.width,
+                        "height": t.height,
+                        "shape": t.shape,
                     }
                     for t in records
                 ]

--- a/api/tests/test_tables_map.py
+++ b/api/tests/test_tables_map.py
@@ -77,6 +77,10 @@ def test_table_positions_map():
         "x": 10,
         "y": 20,
         "state": "AVAILABLE",
+        "zone": None,
+        "width": 80,
+        "height": 80,
+        "shape": "rect",
     }
 
     m2 = next(item for item in data if item["id"] == str(tid2))
@@ -87,6 +91,10 @@ def test_table_positions_map():
         "x": 30,
         "y": 40,
         "state": "LOCKED",
+        "zone": None,
+        "width": 80,
+        "height": 80,
+        "shape": "rect",
     }
 
 

--- a/static/js/floor_live.js
+++ b/static/js/floor_live.js
@@ -1,0 +1,81 @@
+const canvas = document.getElementById('floor-live');
+const ctx = canvas.getContext('2d');
+const zoneSelect = document.getElementById('zone-filter');
+
+const STATE_COLORS = {
+  open: '#4ade80',
+  prep: '#facc15',
+  ready: '#3b82f6',
+  billed: '#f97316',
+  locked: '#9ca3af'
+};
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  draw(currentTables);
+}
+window.addEventListener('resize', resize);
+
+let currentTables = [];
+
+function draw(tables) {
+  if (!ctx) return;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  tables.forEach(t => {
+    if (zoneSelect.value && t.zone !== zoneSelect.value) {
+      return;
+    }
+    const color = STATE_COLORS[t.state?.toLowerCase()] || '#e5e7eb';
+    ctx.fillStyle = color;
+    const x = t.x ?? 0;
+    const y = t.y ?? 0;
+    const width = t.width ?? 80;
+    const height = t.height ?? 80;
+    ctx.fillRect(x, y, width, height);
+    if (t.label) {
+      ctx.fillStyle = '#000';
+      ctx.fillText(t.label, x + 4, y + 12);
+    }
+  });
+}
+
+async function fetchTables() {
+  const tenant = new URLSearchParams(window.location.search).get('tenant');
+  if (!tenant) return [];
+  const resp = await fetch(`/api/outlet/${tenant}/tables/map`);
+  const json = await resp.json();
+  return json.data ?? [];
+}
+
+async function init() {
+  currentTables = await fetchTables();
+  const zones = Array.from(new Set(currentTables.map(t => t.zone).filter(Boolean)));
+  zones.forEach(z => {
+    const opt = document.createElement('option');
+    opt.value = z;
+    opt.textContent = z;
+    zoneSelect.appendChild(opt);
+  });
+  draw(currentTables);
+  const tenant = new URLSearchParams(window.location.search).get('tenant');
+  if (tenant) {
+    const evt = new EventSource(`/floor/stream?tenant=${tenant}`);
+    evt.onmessage = e => {
+      try {
+        const payload = JSON.parse(e.data);
+        if (Array.isArray(payload.tables)) {
+          currentTables = payload.tables;
+          draw(currentTables);
+        }
+      } catch (_) {
+        // ignore malformed messages
+      }
+    };
+  }
+}
+
+zoneSelect.addEventListener('change', () => draw(currentTables));
+
+resize();
+init();

--- a/templates/floor_live.html
+++ b/templates/floor_live.html
@@ -3,8 +3,28 @@
 <head>
     <meta charset="utf-8" />
     <title>Floor Live View</title>
+    <style>
+        html, body {
+            margin: 0;
+            height: 100%;
+            overflow: hidden;
+        }
+        #floor-live {
+            width: 100vw;
+            height: 100vh;
+            display: block;
+        }
+        #zone-filter {
+            position: absolute;
+            top: 10px;
+            left: 10px;
+            z-index: 10;
+        }
+    </style>
 </head>
 <body>
+<select id="zone-filter"><option value="">All Zones</option></select>
 <canvas id="floor-live" tabindex="0" aria-label="Live Floor Map"></canvas>
+<script src="/static/js/floor_live.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include zone and size data in table map API and SSE snapshot
- add live floor view client script with state colors and zone filtering
- style floor live page for full-screen display

## Testing
- `POSTGRES_MASTER_URL=sqlite:// REDIS_URL=redis:// pytest tests/test_tables_map.py -q`
- `POSTGRES_MASTER_URL=sqlite:// REDIS_URL=redis:// pytest tests/test_tables_sse.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1cc94e00c832a9eb8637045fafa6f