### PR TITLE
feat(admin/export): self-serve data export + download center

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -118,6 +118,7 @@ from .routes_accounting_exports import router as accounting_exports_router
 from .routes_admin_billing import router as admin_billing_router
 from .routes_admin_billing import webhook_router as billing_webhook_router
 from .routes_admin_devices import router as admin_devices_router
+from .routes_admin_export import router as admin_export_router
 from .routes_admin_menu import router as admin_menu_router
 from .routes_admin_onboarding import router as admin_onboarding_router
 from .routes_admin_ops import router as admin_ops_router
@@ -1034,6 +1035,7 @@ app.include_router(postman_router)
 app.include_router(admin_qrpack_router)
 app.include_router(admin_qrposter_router)
 app.include_router(admin_devices_router)
+app.include_router(admin_export_router)
 
 # Reports domain
 app.include_router(daybook_pdf_router)

--- a/api/app/routes_admin_export.py
+++ b/api/app/routes_admin_export.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+"""Admin route for exporting orders, items and customers."""
+
+from io import BytesIO
+from zipfile import ZipFile
+
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+from .models_tenant import Customer, MenuItem, Order, OrderItem
+from .routes_export_all import _export_table, _iter_bytes
+from .routes_exports import DEFAULT_LIMIT, HARD_LIMIT, _session
+from .security import ratelimit
+from .utils import ratelimits
+from .utils.rate_limit import rate_limited
+
+router = APIRouter()
+
+
+@router.get("/api/admin/export/data.zip")
+async def admin_export(
+    request: Request, limit: int = DEFAULT_LIMIT, cursor: int | None = None
+) -> StreamingResponse:
+    """Return a ZIP bundle with order, item and customer data."""
+
+    limit = min(limit, DEFAULT_LIMIT, HARD_LIMIT)
+    cur = cursor or 0
+
+    redis = request.app.state.redis
+    ip = request.client.host if request.client else "unknown"
+    policy = ratelimits.exports()
+    allowed = await ratelimit.allow(
+        redis, ip, "exports", rate_per_min=policy.rate_per_min, burst=policy.burst
+    )
+    if not allowed:
+        retry_after = await redis.ttl(f"ratelimit:{ip}:exports")
+        return rate_limited(retry_after)
+
+    tenant_id = request.headers.get("X-Tenant-ID", "demo")
+    bundle = BytesIO()
+    async with _session(tenant_id) as session:
+        with ZipFile(bundle, "w") as zf:
+            max_cursor = cur
+            max_cursor = max(
+                max_cursor,
+                await _export_table(
+                    session,
+                    Order,
+                    ["id", "table_id", "status", "placed_at"],
+                    "orders.csv",
+                    zf,
+                    limit,
+                    cur,
+                ),
+            )
+            max_cursor = max(
+                max_cursor,
+                await _export_table(
+                    session,
+                    OrderItem,
+                    [
+                        "id",
+                        "order_id",
+                        "item_id",
+                        "name_snapshot",
+                        "price_snapshot",
+                        "qty",
+                        "status",
+                    ],
+                    "order_items.csv",
+                    zf,
+                    limit,
+                    cur,
+                ),
+            )
+            max_cursor = max(
+                max_cursor,
+                await _export_table(
+                    session,
+                    MenuItem,
+                    [
+                        "id",
+                        "category_id",
+                        "name",
+                        "price",
+                        "is_veg",
+                        "gst_rate",
+                        "hsn_sac",
+                        "show_fssai",
+                        "out_of_stock",
+                    ],
+                    "items.csv",
+                    zf,
+                    limit,
+                    cur,
+                ),
+            )
+            max_cursor = max(
+                max_cursor,
+                await _export_table(
+                    session,
+                    Customer,
+                    ["id", "name", "phone"],
+                    "customers.csv",
+                    zf,
+                    limit,
+                    cur,
+                ),
+            )
+    headers = {"Content-Disposition": "attachment; filename=export.zip"}
+    if cursor and max_cursor != cursor:
+        headers["X-Cursor"] = str(max_cursor)
+    return StreamingResponse(
+        _iter_bytes(bundle), media_type="application/zip", headers=headers
+    )

--- a/api/tests/test_admin_export.py
+++ b/api/tests/test_admin_export.py
@@ -1,0 +1,78 @@
+import io
+import os
+import pathlib
+import sys
+import zipfile
+from contextlib import asynccontextmanager
+
+import fakeredis.aioredis
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from api.app import models_tenant, routes_admin_export  # noqa: E402
+from api.app.auth import create_access_token  # noqa: E402
+from api.app.db.tenant import get_engine  # noqa: E402
+
+os.environ.setdefault(
+    "POSTGRES_TENANT_DSN_TEMPLATE", "sqlite+aiosqlite:///./tenant_{tenant_id}.db"
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+async def tenant_session() -> AsyncSession:
+    tenant_id = "demo"
+    engine = get_engine(tenant_id)
+    async with engine.begin() as conn:
+        await conn.run_sync(models_tenant.Base.metadata.create_all)
+    sessionmaker = async_sessionmaker(
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        if engine.url.get_backend_name().startswith("sqlite"):
+            await engine.dispose()
+            db_path = engine.url.database
+            if db_path and db_path != ":memory:" and os.path.exists(db_path):
+                os.remove(db_path)
+        else:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE'))
+            await engine.dispose()
+
+
+app = FastAPI()
+app.include_router(routes_admin_export.router)
+app.state.redis = fakeredis.aioredis.FakeRedis()
+
+
+@pytest.mark.anyio
+async def test_admin_export_bundle(tenant_session, monkeypatch):
+    @asynccontextmanager
+    async def fake_session(tenant_id: str):
+        yield tenant_session
+
+    monkeypatch.setattr(routes_admin_export, "_session", fake_session)
+
+    token = create_access_token({"sub": "admin@example.com", "role": "super_admin"})
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/admin/export/data.zip",
+            headers={"Authorization": f"Bearer {token}", "X-Tenant-ID": "demo"},
+        )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/zip"
+    names = set(zipfile.ZipFile(io.BytesIO(resp.content)).namelist())
+    expected = {"orders.csv", "order_items.csv", "items.csv", "customers.csv"}
+    assert expected.issubset(names)


### PR DESCRIPTION
## Summary
- add admin export endpoint to bundle orders, items, order items, and customers into ZIP
- wire admin export router into main application
- cover export bundle path with test

## Testing
- `pre-commit run --files api/app/main.py api/app/routes_admin_export.py api/tests/test_admin_export.py`
- `pytest api/tests/test_admin_export.py::test_admin_export_bundle -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d0f01ec0832a8ea22d9a83468f03