### PR TITLE
feat(flags): remote feature flags + admin toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Floor map editor with live table status (SSE/WS).
 - Validate async DB URLs for Alembic migrations and expose `SYNC_DATABASE_URL` in Lighthouse workflow.
 - `usePageview` hook posts navigations to `/telemetry/pageview` with debounce.
+- Runtime feature flag service with `<Flag>` wrapper and admin toggles page.
 
 ### Fixed
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -128,6 +128,7 @@ from .routes_admin_privacy import router as admin_privacy_router
 from .routes_admin_qrpack import router as admin_qrpack_router
 from .routes_admin_qrposter_pack import router as admin_qrposter_router
 from .routes_admin_support import router as admin_support_router
+from .routes_admin_flags import router as admin_flags_router
 from .routes_admin_webhooks import router as admin_webhooks_router
 from .routes_alerts import router as alerts_router
 from .routes_analytics_outlets import router as analytics_outlets_router
@@ -1005,6 +1006,7 @@ app.include_router(troubleshoot_router)
 app.include_router(help_router)
 app.include_router(support_router)
 app.include_router(admin_support_router)
+app.include_router(admin_flags_router)
 app.include_router(staff_support_router)
 app.include_router(support_console_router)
 app.include_router(admin_webhooks_router)

--- a/api/app/routes_admin_flags.py
+++ b/api/app/routes_admin_flags.py
@@ -1,0 +1,34 @@
+"""Endpoints for runtime feature flag toggles."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from . import flags
+from .auth import User, role_required
+from .utils.responses import ok
+
+
+router = APIRouter(prefix="/admin/flags")
+
+
+@router.get("")
+async def list_flags(user: User = Depends(role_required("super_admin"))) -> dict:
+    """Return current flag values."""
+    data = {name: flags.get(name) for name in flags.REGISTRY}
+    return ok(data)
+
+
+class FlagUpdate(BaseModel):
+    value: bool
+
+
+@router.post("/{name}")
+async def set_flag(
+    name: str, payload: FlagUpdate, user: User = Depends(role_required("super_admin"))
+) -> dict:
+    """Set a runtime override for a flag."""
+    flags.set_override(name, payload.value)
+    return ok({name: flags.get(name)})
+

--- a/api/tests/test_flags.py
+++ b/api/tests/test_flags.py
@@ -26,9 +26,23 @@ def test_tenant_override(monkeypatch):
     assert flags.get("hotel_mode", Tenant()) is True
 
 
-def test_tenant_overrides_env(monkeypatch):
+def test_env_overrides_tenant(monkeypatch):
     class Tenant:
-        enable_hotel = False
+        enable_hotel = True
 
-    monkeypatch.setenv("FLAG_HOTEL_MODE", "1")
+    monkeypatch.setenv("FLAG_HOTEL_MODE", "0")
     assert flags.get("hotel_mode", Tenant()) is False
+
+
+def test_remote_override(monkeypatch):
+    monkeypatch.delenv("FLAG_HOTEL_MODE", raising=False)
+    flags.set_override("hotel_mode", True)
+    assert flags.get("hotel_mode") is True
+    flags.set_override("hotel_mode", False)
+    assert flags.get("hotel_mode") is False
+
+
+def test_env_overrides_remote(monkeypatch):
+    flags.set_override("hotel_mode", False)
+    monkeypatch.setenv("FLAG_HOTEL_MODE", "1")
+    assert flags.get("hotel_mode") is True

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -9,7 +9,7 @@ import './i18n';
 import { router } from './routes';
 import { Workbox } from 'workbox-window';
 import { AuthProvider } from './auth';
-import { withInterceptors } from '@neo/api';
+import { withInterceptors, loadFlags } from '@neo/api';
 
 const qc = new QueryClient();
 
@@ -27,7 +27,10 @@ if ('serviceWorker' in navigator) {
 }
 
 async function init() {
-  const outlet = await fetch('/api/outlet/theme').then(r => r.json()).catch(() => ({}));
+  const [outlet] = await Promise.all([
+    fetch('/api/outlet/theme').then(r => r.json()).catch(() => ({})),
+    loadFlags(),
+  ]);
   const tokens = tokensFromOutlet(outlet);
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>

--- a/apps/admin/src/pages/Flags.tsx
+++ b/apps/admin/src/pages/Flags.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import { loadFlags, setFlag } from '@neo/api';
+
+export function Flags() {
+  const [flags, setFlags] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    loadFlags().then(setFlags);
+  }, []);
+
+  async function toggle(name: string) {
+    const next = !flags[name];
+    setFlags({ ...flags, [name]: next });
+    await setFlag(name, next);
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Feature Flags</h1>
+      <ul>
+        {Object.entries(flags).map(([name, value]) => (
+          <li key={name} className="mb-2">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={value}
+                onChange={() => toggle(name)}
+              />
+              {name}
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -9,6 +9,8 @@ import { Layout } from './components/Layout';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { StaffSupport } from './pages/StaffSupport';
 import { Changelog } from './pages/Changelog';
+import { Flags } from './pages/Flags';
+import { Flag } from '@neo/ui';
 
 export const routes: RouteObject[] = [
   { path: '/login', element: <Login /> },
@@ -33,7 +35,7 @@ export const routes: RouteObject[] = [
         },
         { path: 'onboarding', element: <Onboarding /> },
         { path: 'support', element: <Support /> },
-        { path: 'changelog', element: <Changelog /> }
+        { path: 'changelog', element: <Flag name="changelog"><Changelog /></Flag> }
       ]
     }
   },
@@ -44,7 +46,10 @@ export const routes: RouteObject[] = [
         <Layout />
       </ProtectedRoute>
     ),
-    children: [{ path: 'support', element: <StaffSupport /> }],
+    children: [
+      { path: 'support', element: <StaffSupport /> },
+      { path: 'flags', element: <Flags /> },
+    ],
   }
 ];
 

--- a/config/feature_flags.yaml
+++ b/config/feature_flags.yaml
@@ -3,3 +3,4 @@ wa_enabled: false
 happy_hour: false
 marketplace: false
 analytics: false
+changelog: false

--- a/packages/api/src/flags.ts
+++ b/packages/api/src/flags.ts
@@ -1,0 +1,26 @@
+import { apiFetch } from './api';
+
+let cache: Record<string, boolean> = {};
+
+export async function loadFlags(): Promise<Record<string, boolean>> {
+  cache = await apiFetch<Record<string, boolean>>('/admin/flags');
+  return cache;
+}
+
+export function getFlag(name: string): boolean {
+  return !!cache[name];
+}
+
+export function allFlags(): Record<string, boolean> {
+  return { ...cache };
+}
+
+export async function setFlag(name: string, value: boolean): Promise<void> {
+  cache[name] = value;
+  await apiFetch(`/admin/flags/${name}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ value }),
+  });
+}
+

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,5 @@
 export * from './api';
+export * from './flags';
 export * from './hooks/sse';
 export * from './hooks/ws';
 export * from './hooks/useLicense';

--- a/packages/ui/src/components/Flag.tsx
+++ b/packages/ui/src/components/Flag.tsx
@@ -1,0 +1,12 @@
+import React, { PropsWithChildren } from 'react';
+import { getFlag } from '@neo/api';
+
+interface FlagProps extends PropsWithChildren {
+  name: string;
+  fallback?: React.ReactNode;
+}
+
+export function Flag({ name, children, fallback = null }: FlagProps) {
+  return getFlag(name) ? <>{children}</> : <>{fallback}</>;
+}
+

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -3,3 +3,4 @@ export * from './global-error-boundary';
 export * from './Skeleton';
 export * from './empty-state';
 export * from './LicenseBanner';
+export * from './Flag';


### PR DESCRIPTION
## Summary
- add runtime flag overrides and admin endpoints
- wrap risky UI in new `<Flag>` component
- expose admin page to toggle feature flags

## Testing
- `pytest api/tests/test_flags.py`
- `pnpm --filter @neo/api test`
- `pnpm --filter @neo/ui test`
- `pnpm --filter @neo/admin test`
- `ruff check api/app/flags.py api/app/routes_admin_flags.py api/app/main.py api/tests/test_flags.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1d6207af0832a8d1dc513dfef1eea