### PR TITLE
fix(ux): perf & a11y improvements to meet CI budgets

### DIFF
--- a/apps/guest/index.html
+++ b/apps/guest/index.html
@@ -4,6 +4,25 @@
     <meta charset="UTF-8" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+      />
+    </noscript>
     <title>Guest</title>
   </head>
   <body>

--- a/apps/guest/src/pages/MenuPage.tsx
+++ b/apps/guest/src/pages/MenuPage.tsx
@@ -53,22 +53,27 @@ export function MenuPage() {
         />
       ) : (
         data?.categories?.map((cat) => (
-          <div key={cat.id}>
-            <h2>{cat.name_i18n[lang] || cat.name_i18n.en}</h2>
-            {cat.items.map((item) => (
-              <div key={item.id}>
-                <span>{item.name_i18n[lang] || item.name_i18n.en}</span>
-                <button
-                  aria-label={`add ${item.name_i18n[lang] || item.name_i18n.en} to cart`}
-                  onClick={() =>
-                    add({ id: item.id, name: item.name_i18n.en, qty: 1 })
-                  }
+          <section key={cat.id} aria-labelledby={`cat-${cat.id}`}>
+            <h2 id={`cat-${cat.id}`}>{cat.name_i18n[lang] || cat.name_i18n.en}</h2>
+            <ul>
+              {cat.items.map((item) => (
+                <li
+                  key={item.id}
+                  className="flex items-center justify-between"
                 >
-                  +
-                </button>
-              </div>
-            ))}
-          </div>
+                  <span>{item.name_i18n[lang] || item.name_i18n.en}</span>
+                  <button
+                    aria-label={`add ${item.name_i18n[lang] || item.name_i18n.en} to cart`}
+                    onClick={() =>
+                      add({ id: item.id, name: item.name_i18n.en, qty: 1 })
+                    }
+                  >
+                    +
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
         ))
       )}
     </div>

--- a/apps/guest/src/routes.tsx
+++ b/apps/guest/src/routes.tsx
@@ -1,14 +1,15 @@
 import { Routes, Route, useLocation } from 'react-router-dom';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, lazy, Suspense } from 'react';
 import { capturePageView } from '@neo/utils';
-import { QrPage } from './pages/QrPage';
-import { MenuPage } from './pages/MenuPage';
-import { CartPage } from './pages/CartPage';
-import { TrackPage } from './pages/TrackPage';
-import { PayPage } from './pages/Pay';
-import { Health } from './pages/Health';
-import { Offline } from './pages/Offline';
 import { Layout } from './components/Layout';
+
+const QrPage = lazy(() => import('./pages/QrPage').then(m => ({ default: m.QrPage })));
+const MenuPage = lazy(() => import('./pages/MenuPage').then(m => ({ default: m.MenuPage })));
+const CartPage = lazy(() => import('./pages/CartPage').then(m => ({ default: m.CartPage })));
+const TrackPage = lazy(() => import('./pages/TrackPage').then(m => ({ default: m.TrackPage })));
+const PayPage = lazy(() => import('./pages/Pay').then(m => ({ default: m.PayPage })));
+const Health = lazy(() => import('./pages/Health').then(m => ({ default: m.Health })));
+const Offline = lazy(() => import('./pages/Offline').then(m => ({ default: m.Offline })));
 
 export function AppRoutes() {
   const loc = useLocation();
@@ -21,17 +22,19 @@ export function AppRoutes() {
     capturePageView(loc.pathname);
   }, [loc.pathname]);
   return (
-    <Routes>
-      <Route path="/health" element={<Health />} />
-      <Route element={<Layout />}>
-        <Route path="/" element={<QrPage />} />
-        <Route path="/qr" element={<QrPage />} />
-        <Route path="/menu" element={<MenuPage />} />
-        <Route path="/cart" element={<CartPage />} />
-        <Route path="/track/:orderId" element={<TrackPage />} />
-        <Route path="/pay/:orderId" element={<PayPage />} />
-        <Route path="/offline" element={<Offline />} />
-      </Route>
-    </Routes>
+    <Suspense fallback={<div>Loading...</div>}>
+      <Routes>
+        <Route path="/health" element={<Health />} />
+        <Route element={<Layout />}>
+          <Route path="/" element={<QrPage />} />
+          <Route path="/qr" element={<QrPage />} />
+          <Route path="/menu" element={<MenuPage />} />
+          <Route path="/cart" element={<CartPage />} />
+          <Route path="/track/:orderId" element={<TrackPage />} />
+          <Route path="/pay/:orderId" element={<PayPage />} />
+          <Route path="/offline" element={<Offline />} />
+        </Route>
+      </Routes>
+    </Suspense>
   );
 }

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1,10 +1,10 @@
 :root {
   --color-primary: #2563eb;
-  --color-accent: #64748b;
-  --color-secondary: #64748b;
+  --color-accent: #475569;
+  --color-secondary: #334155;
   --color-success: #15803d;
-  --color-warn: #b45309;
-  --color-danger: #b91c1c;
-  --color-error: #b91c1c;
+  --color-warn: #92400e;
+  --color-danger: #991b1b;
+  --color-error: #991b1b;
   --logo-url: url('');
 }


### PR DESCRIPTION
## Summary
- code-split guest routes for smaller bundles
- preload inter font and enable swap
- improve menu semantics and raise contrast tokens

## Testing
- `pnpm test`
- `pnpm dlx @lhci/cli@0.15.1 autorun --config=lighthouserc.json` *(fails: Unable to connect to Chrome)*
- `pnpm exec playwright test tests/a11y/a11y.spec.ts --config=playwright.config.ts` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dc58795c832aa42aa6dadf753150