### PR TITLE
chore(deploy): finalize UI image + blue/green rollout script

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -19,3 +19,5 @@ COPY deploy/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY --from=build /dist/guest /usr/share/nginx/html/guest
 COPY --from=build /dist/kds /usr/share/nginx/html/kds
 COPY --from=build /dist/admin /usr/share/nginx/html/admin
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -106,6 +106,14 @@ python scripts/deploy_blue_green.py --new neo-green --old neo-blue --tenant TENA
 
 For manual steps and more background, see the [blue/green guide](bluegreen/README.md).
 
+For container rollouts managed by Kubernetes, use the lightweight helper:
+
+```bash
+python scripts/rollout_blue_green.py --env prod --to TAG
+```
+
+To revert to a previous tag, run `rollback_blue_green.py` with the same options.
+
 To slowly shift traffic, run the weighted ramp helper which adjusts Nginx
 weights to 5%, 25% and 50%, gating on `/ready` between each bump:
 

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -15,13 +15,13 @@ http {
     root /usr/share/nginx/html;
 
     location /guest/ {
-      try_files $uri /guest/index.html;
+      try_files $uri $uri/ /guest/index.html;
     }
     location /kds/ {
-      try_files $uri /kds/index.html;
+      try_files $uri $uri/ /kds/index.html;
     }
     location /admin/ {
-      try_files $uri /admin/index.html;
+      try_files $uri $uri/ /admin/index.html;
     }
 
     # Cache static assets aggressively, not HTML

--- a/scripts/rollout_blue_green.py
+++ b/scripts/rollout_blue_green.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Roll forward helper for blue/green deployments.
+
+Updates a deployment to a new image tag and waits for the rollout to finish.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from typing import Sequence
+
+
+def _run(cmd: Sequence[str], dry_run: bool) -> None:
+    """Run *cmd* unless ``dry_run`` is true."""
+    print("+", " ".join(cmd))
+    if dry_run:
+        return
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Blue/green rollout helper")
+    parser.add_argument(
+        "--env", required=True, choices=["prod", "staging"], help="Target environment"
+    )
+    parser.add_argument("--to", required=True, help="Deployment tag to roll out")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print commands without executing"
+    )
+    args = parser.parse_args()
+
+    deployment = f"web-{args.env}"
+    image = f"myapp:{args.to}"
+
+    cmds = [
+        ["kubectl", "set", "image", f"deploy/{deployment}", f"app={image}"],
+        ["kubectl", "rollout", "status", f"deploy/{deployment}", "--timeout=300s"],
+    ]
+    for cmd in cmds:
+        _run(cmd, args.dry_run)
+
+    print(f"Rolled out {args.env} to {args.to}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()


### PR DESCRIPTION
## Summary
- expose port 80 and explicit nginx command in UI Docker image
- add SPA fallback for guest/kds/admin routes
- provide Kubernetes blue/green rollout helper and docs

## Testing
- `pre-commit run --files Dockerfile.ui deploy/nginx/nginx.conf deploy/README.md scripts/rollout_blue_green.py`
- `pytest` *(fails: tests/test_alembic_env.py, tests/test_analytics_outlets.py, tests/test_export_streaming.py, tests/test_kds_expo.py, tests/test_rum_vitals.py, tests/test_slo_metrics.py, tests/test_time_skew.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dd136b50832a9339f042c99f551f