### PR TITLE
fix(ux): perf & a11y improvements to meet CI budgets

### DIFF
--- a/apps/guest/index.html
+++ b/apps/guest/index.html
@@ -4,13 +4,27 @@
     <meta charset="UTF-8" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="preload"
-      as="style"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
-    />
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link
+        rel="preload"
+        as="font"
+        type="font/ttf"
+        href="https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf"
+        crossorigin
+      />
+      <link
+        rel="preload"
+        as="font"
+        type="font/ttf"
+        href="https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuFuYMZg.ttf"
+        crossorigin
+      />
+      <link
+        rel="preload"
+        as="style"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+      />
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"

--- a/apps/guest/src/components/Layout.tsx
+++ b/apps/guest/src/components/Layout.tsx
@@ -15,9 +15,9 @@ export function Layout() {
       {status && (
         <LicenseBanner status={status} daysLeft={data?.daysLeft} renewUrl={data?.renewUrl} />
       )}
-      <main id="main">
-        <Outlet />
-      </main>
+        <main id="main" role="main" tabIndex={-1}>
+          <Outlet />
+        </main>
     </>
   );
 }

--- a/apps/guest/src/pages/Pay.tsx
+++ b/apps/guest/src/pages/Pay.tsx
@@ -88,13 +88,14 @@ export function PayPage() {
         </ul>
         <p>Tax: {invoice.tax}</p>
         <p>Total: {invoice.total}</p>
-        <div data-testid="cashier-qr">
-          <p>Show this screen to cashier</p>
-          <img
-            src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${orderId}`}
-            alt="qr"
-          />
-        </div>
+          <div data-testid="cashier-qr">
+            <p>Show this screen to cashier</p>
+            <img
+              src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${orderId}`}
+              alt="order QR code"
+              loading="lazy"
+            />
+          </div>
       </div>
     );
   }
@@ -119,25 +120,26 @@ export function PayPage() {
           <a href={upiLink}>Paytm</a>
           <button onClick={() => setShowUtr(true)}>I've paid</button>
         </>
-      ) : (
-        <div data-testid="cashier-qr">
-          <p>Show this screen to cashier</p>
-          <img
-            src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${orderId}`}
-            alt="qr"
-          />
-          <p style={{ color: status === 'success' ? 'green' : undefined }}>
-            {status === 'success'
-              ? 'Payment successful'
+        ) : (
+          <div data-testid="cashier-qr">
+            <p>Show this screen to cashier</p>
+            <img
+              src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${orderId}`}
+              alt="order QR code"
+              loading="lazy"
+            />
+            <p style={{ color: status === 'success' ? 'green' : undefined }}>
+              {status === 'success'
+                ? 'Payment successful'
               : 'Waiting for verification'}
           </p>
         </div>
       )}
-      {showUtr && (
-        <div role="dialog">
-          <label>
-            UTR
-            <input
+        {showUtr && (
+          <div role="dialog" aria-modal="true">
+            <label>
+              UTR
+              <input
               value={utr}
               onChange={(e) => setUtr(e.target.value)}
             />

--- a/apps/guest/src/routes.tsx
+++ b/apps/guest/src/routes.tsx
@@ -1,7 +1,10 @@
 import { Routes, Route, useLocation } from 'react-router-dom';
 import { useEffect, useRef, lazy, Suspense } from 'react';
 import { capturePageView } from '@neo/utils';
-import { Layout } from './components/Layout';
+
+const Layout = lazy(() =>
+  import('./components/Layout').then((m) => ({ default: m.Layout }))
+);
 
 const QrPage = lazy(() => import('./pages/QrPage').then(m => ({ default: m.QrPage })));
 const MenuPage = lazy(() => import('./pages/MenuPage').then(m => ({ default: m.MenuPage })));

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -1,8 +1,8 @@
 export const colors = {
-  primary: '#2563eb',
-  secondary: '#64748b',
+  primary: '#1d4ed8',
+  secondary: '#334155',
   success: '#15803d',
-  warn: '#b45309',
-  danger: '#b91c1c',
-  error: '#b91c1c'
+  warn: '#92400e',
+  danger: '#991b1b',
+  error: '#991b1b'
 };


### PR DESCRIPTION
## Summary
- code-split layout route to reduce bundle size
- preload Inter fonts for faster rendering
- improve accessibility with main landmark, lazy QR images, and higher contrast tokens

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck` *(fails: Cannot find module '@neo/api')*
- `npx @lhci/cli@0.11.0 autorun` *(fails: Chrome installation not found)*
- `npx pa11y-ci` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e1baf1e8832a8440def2c5f2dcd5