### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,11 @@ repos:
       - id: ruff
         args: ["--fix"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
   - repo: https://github.com/PyCQA/bandit


### PR DESCRIPTION
## Summary
- bump isort and pre-commit-hooks to latest versions to remove deprecation warnings

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `pytest -q` *(fails: import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e3be7d18832ab05d03cb19e4b417