### PR TITLE
chore: install node deps in Lighthouse workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -45,6 +45,8 @@ jobs:
         run: corepack enable && corepack prepare pnpm@latest --activate
       - name: Verify pnpm installation
         run: pnpm --version
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
## Summary
- ensure Lighthouse workflow installs Node dependencies before running

## Testing
- `pnpm install --frozen-lockfile`
- `lhci autorun --config=lighthouserc.json` *(fails: Chrome installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e574d820832a873310bf05dceb3b