### PR TITLE
fix: store table enums as strings

### DIFF
--- a/api/app/models_tenant.py
+++ b/api/app/models_tenant.py
@@ -112,7 +112,11 @@ class Table(Base):
     name = Column(String, nullable=False)
     code = Column(String, nullable=True)
     qr_token = Column(String, unique=True, nullable=True)
-    status = Column(Enum(TableStatus), nullable=False, default=TableStatus.AVAILABLE)
+    status = Column(
+        Enum(TableStatus, native_enum=False),
+        nullable=False,
+        default=TableStatus.AVAILABLE,
+    )
     state = Column(String, nullable=False, default="AVAILABLE")
     pos_x = Column(Integer, nullable=True)
     pos_y = Column(Integer, nullable=True)
@@ -190,7 +194,7 @@ class Order(Base):
 
     id = Column(Integer, primary_key=True)
     table_id = Column(Integer, ForeignKey("tables.id"), nullable=False)
-    status = Column(Enum(OrderStatus), nullable=False)
+    status = Column(Enum(OrderStatus, native_enum=False), nullable=False)
     placed_at = Column(DateTime(timezone=True), nullable=True)
     accepted_at = Column(DateTime(timezone=True), nullable=True)
     ready_at = Column(DateTime(timezone=True), nullable=True)
@@ -312,7 +316,7 @@ class CounterOrder(Base):
 
     id = Column(Integer, primary_key=True)
     counter_id = Column(Integer, ForeignKey("counters.id"), nullable=False)
-    status = Column(Enum(CounterOrderStatus), nullable=False)
+    status = Column(Enum(CounterOrderStatus, native_enum=False), nullable=False)
     placed_at = Column(DateTime(timezone=True), nullable=True)
     delivered_at = Column(DateTime(timezone=True), nullable=True)
 


### PR DESCRIPTION
## Summary
- avoid Postgres enum types by storing table, order, and counter order statuses as plain strings

## Testing
- `python -m alembic -c api/alembic.ini -x db_url=$SYNC_DATABASE_URL upgrade head`
- `PYTHONPATH=. python scripts/tenant_create_db.py --tenant demo` *(fails: sqlite3.OperationalError: no such table: pg_database)*
- `pytest tests` *(fails: 14 failed, 117 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e6ae17b8832aaddbba578e6a4361