### PR TITLE
feat(security): CSP/CORS/rate-limit middlewares + tests + global wiring

### DIFF
--- a/api/app/middleware/cors.py
+++ b/api/app/middleware/cors.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Callable, Iterable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.status import HTTP_403_FORBIDDEN
+
+
+class CORSMiddleware(BaseHTTPMiddleware):
+    """CORS middleware allowing only whitelisted origins."""
+
+    def __init__(
+        self,
+        app: Callable,
+        allowed_origins: Iterable[str] | None = None,
+        max_age: int = 3600,
+    ) -> None:
+        super().__init__(app)
+        self.allowed = {o for o in (allowed_origins or []) if o}
+        self.max_age = max_age
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:  # type: ignore[override]
+        origin = request.headers.get("origin")
+        if origin and self.allowed and origin not in self.allowed:
+            return Response(status_code=HTTP_403_FORBIDDEN)
+
+        # Handle preflight
+        if (
+            request.method == "OPTIONS"
+            and origin
+            and (not self.allowed or origin in self.allowed)
+            and request.headers.get("access-control-request-method")
+        ):
+            headers = {
+                "Access-Control-Allow-Origin": origin,
+                "Vary": "Origin",
+                "Access-Control-Allow-Methods": request.headers.get(
+                    "access-control-request-method", ""
+                ),
+                "Access-Control-Allow-Headers": request.headers.get(
+                    "access-control-request-headers", ""
+                ),
+                "Access-Control-Max-Age": str(self.max_age),
+                "Access-Control-Allow-Credentials": "true",
+            }
+            return Response(status_code=200, headers=headers)
+
+        response = await call_next(request)
+        if origin and (not self.allowed or origin in self.allowed):
+            response.headers.setdefault("Access-Control-Allow-Origin", origin)
+            response.headers.setdefault("Vary", "Origin")
+            response.headers.setdefault("Access-Control-Allow-Credentials", "true")
+            response.headers.setdefault("Access-Control-Max-Age", str(self.max_age))
+        return response

--- a/api/app/middleware/csp.py
+++ b/api/app/middleware/csp.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+import secrets
+from typing import Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class CSPMiddleware(BaseHTTPMiddleware):
+    """Attach a nonce-based Content-Security-Policy header."""
+
+    def __init__(
+        self,
+        app: Callable,
+        api_base: str | None = None,
+        ws_base: str | None = None,
+    ) -> None:
+        super().__init__(app)
+        self.api_base = api_base or os.getenv("API_BASE", "https://API")
+        self.ws_base = ws_base or os.getenv("WS_BASE", "https://WS")
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:  # type: ignore[override]
+        nonce = secrets.token_urlsafe(16)
+        request.state.csp_nonce = nonce
+        response = await call_next(request)
+        csp = (
+            "default-src 'self'; "
+            f"script-src 'self' 'nonce-{nonce}'; "
+            "style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data: blob:; "
+            f"connect-src 'self' {self.api_base} {self.ws_base}; "
+            "frame-ancestors 'self'"
+        )
+        response.headers.setdefault("Content-Security-Policy", csp)
+        return response

--- a/api/app/middleware/rate_limit.py
+++ b/api/app/middleware/rate_limit.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+import re
+import time
+import uuid
+from typing import Callable
+
+from redis.asyncio import Redis
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.status import HTTP_429_TOO_MANY_REQUESTS
+
+_TIME_UNITS = {"s": 1, "m": 60, "h": 3600}
+
+
+def _parse_limit(value: str, default: tuple[int, int]) -> tuple[int, int]:
+    match = re.fullmatch(r"(\d+)/(\d+)([smh])", value)
+    if not match:
+        return default
+    count, span, unit = match.groups()
+    return int(count), int(span) * _TIME_UNITS[unit]
+
+
+class SlidingWindowRateLimitMiddleware(BaseHTTPMiddleware):
+    """Sliding window rate limiter for authentication endpoints."""
+
+    def __init__(self, app: Callable) -> None:
+        super().__init__(app)
+        login = _parse_limit(os.getenv("RATE_LIMIT_LOGIN", "10/5m"), (10, 300))
+        refresh = _parse_limit(os.getenv("RATE_LIMIT_REFRESH", "60/5m"), (60, 300))
+        self.limits = {
+            "/login/pin": login,
+            "/auth/login-pin": login,
+            "/auth/refresh": refresh,
+        }
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:  # type: ignore[override]
+        if request.url.path not in self.limits:
+            return await call_next(request)
+        limit, window = self.limits[request.url.path]
+        redis: Redis = request.app.state.redis
+        ip = request.client[0] if request.client else "unknown"
+        tenant = request.headers.get("X-Tenant-ID", "-")
+        key = f"ratelimit:{request.url.path}:{tenant}:{ip}"
+        now = int(time.time())
+        pipe = redis.pipeline()
+        pipe.zadd(key, {str(uuid.uuid4()): now})
+        pipe.zremrangebyscore(key, 0, now - window)
+        pipe.zcard(key)
+        pipe.expire(key, window)
+        _, _, count, _ = await pipe.execute()
+        if count and count > limit:
+            retry = await redis.ttl(key)
+            headers = {"Retry-After": str(retry if retry > 0 else window)}
+            return JSONResponse(
+                {"error": "Rate limit exceeded"},
+                status_code=HTTP_429_TOO_MANY_REQUESTS,
+                headers=headers,
+            )
+        return await call_next(request)

--- a/api/tests/test_security_headers.py
+++ b/api/tests/test_security_headers.py
@@ -1,6 +1,7 @@
 import importlib
 import pathlib
 import sys
+import time
 
 import fakeredis.aioredis
 import pytest
@@ -10,7 +11,9 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
 
 def _setup_app(monkeypatch):
-    monkeypatch.setenv("ALLOWED_ORIGINS", "https://allowed.com")
+    monkeypatch.setenv("ORIGINS", "https://allowed.com")
+    monkeypatch.setenv("RATE_LIMIT_LOGIN", "2/1s")
+    monkeypatch.setenv("RATE_LIMIT_REFRESH", "60/5m")
     monkeypatch.setenv("DB_URL", "postgresql://localhost/test")
     monkeypatch.setenv("POSTGRES_MASTER_URL", "postgresql://localhost/test")
     monkeypatch.setenv("REDIS_URL", "redis://redis:6379/0")
@@ -22,27 +25,30 @@ def _setup_app(monkeypatch):
     return app_main.app
 
 
-def test_csp_header(monkeypatch):
+def test_csp_header_blocks_inline(monkeypatch):
     app = _setup_app(monkeypatch)
     client = TestClient(app)
     resp = client.get("/health", headers={"Origin": "https://allowed.com"})
     csp = resp.headers.get("Content-Security-Policy")
     assert csp is not None
     assert "script-src 'self' 'nonce-" in csp
-    assert "connect-src 'self' https://API https://WS" in csp
+    for part in csp.split(";"):
+        if part.strip().startswith("script-src"):
+            assert "'unsafe-inline'" not in part
+            break
 
 
-def test_cors_blocks_unknown_origin(monkeypatch):
+def test_cors_rejects_unknown_origin(monkeypatch):
     app = _setup_app(monkeypatch)
     client = TestClient(app)
     resp = client.get("/ready", headers={"Origin": "https://evil.com"})
     assert resp.status_code == 403
 
 
-def test_login_rate_limit(monkeypatch):
+def test_login_rate_limit_resets(monkeypatch):
     app = _setup_app(monkeypatch)
     client = TestClient(app)
-    for _ in range(3):
+    for _ in range(2):
         resp = client.post(
             "/login/pin",
             json={"username": "cashier1", "pin": "bad"},
@@ -54,3 +60,9 @@ def test_login_rate_limit(monkeypatch):
     )
     assert resp.status_code == 429
     assert resp.headers.get("Retry-After")
+    time.sleep(1)
+    resp = client.post(
+        "/login/pin",
+        json={"username": "cashier1", "pin": "bad"},
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add per-request CSP nonce and header
- enforce CORS origin whitelist with preflight caching
- apply Redis-backed sliding window rate limits on login and refresh

## Testing
- `pre-commit run --files api/app/middleware/__init__.py api/app/middleware/csp.py api/app/middleware/cors.py api/app/middleware/rate_limit.py api/app/main.py api/tests/test_security_headers.py`
- `pytest api/tests/test_security_headers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f538a5cc832a85b43934837b5de7