### PR TITLE
chore: extend pa11y startup wait

### DIFF
--- a/pa11y-start.js
+++ b/pa11y-start.js
@@ -1,5 +1,10 @@
 const { spawn } = require('child_process');
 const net = require('net');
+
+// Allow extra time for the application to start in slower environments
+const APP_PORT = 8000;
+const WAIT_TIMEOUT_MS = 60000; // 60 seconds
+
 let server;
 async function waitForPort(port, timeoutMs) {
   const start = Date.now();
@@ -28,6 +33,6 @@ module.exports = async () => {
     process.on('exit', () => {
       if (server) server.kill();
     });
-    await waitForPort(8000, 15000);
+    await waitForPort(APP_PORT, WAIT_TIMEOUT_MS);
   }
 };


### PR DESCRIPTION
## Summary
- allow pa11y startup script to wait longer for the dev server

## Testing
- `npx -y pa11y-ci -c pa11y-ci.json` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f4488908832aaec3e8c06ec4ef43