### PR TITLE
ci: start app servers for lighthouse

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -6,37 +6,66 @@
         "http://localhost:5174/",
         "http://localhost:5175/"
       ],
-      "startServerCommand": "pnpm --filter pwa build && pnpm --filter pwa preview --port 5173",
+      "startServerCommand": "pnpm --filter @neo/guest build && pnpm --filter @neo/kds build && pnpm --filter @neo/admin build && pnpm --filter @neo/guest preview --port 5173 & pnpm --filter @neo/kds preview --port 5174 & pnpm --filter @neo/admin preview --port 5175 & wait",
+      "startServerReadyPattern": "http://localhost:5175/",
       "numberOfRuns": 1,
-      "output": ["html"],
+      "output": [
+        "html"
+      ],
       "reportFilenamePattern": "%%PATHNAME%%-lighthouse.%%EXTENSION%%",
       "chromeFlags": "--no-sandbox",
       "settings": {
         "budgetsPath": "budgets.json"
       }
     },
-
     "assert": {
       "assertMatrix": [
         {
           "matchingUrlPattern": "guest/menu",
           "assertions": {
-            "categories:performance": ["error", { "minScore": 0.90 }],
-            "total-blocking-time": ["error", { "maxNumericValue": 200, "aggregationMethod": "median" }],
-            "largest-contentful-paint": ["error", { "maxNumericValue": 2500, "aggregationMethod": "median" }],
+            "categories:performance": [
+              "error",
+              {
+                "minScore": 0.9
+              }
+            ],
+            "total-blocking-time": [
+              "error",
+              {
+                "maxNumericValue": 200,
+                "aggregationMethod": "median"
+              }
+            ],
+            "largest-contentful-paint": [
+              "error",
+              {
+                "maxNumericValue": 2500,
+                "aggregationMethod": "median"
+              }
+            ],
             "installable-manifest": "error"
           }
         },
         {
           "matchingUrlPattern": "kds/expo",
           "assertions": {
-            "categories:performance": ["error", { "minScore": 0.85 }]
+            "categories:performance": [
+              "error",
+              {
+                "minScore": 0.85
+              }
+            ]
           }
         },
         {
           "matchingUrlPattern": "admin/dashboard",
           "assertions": {
-            "categories:performance": ["error", { "minScore": 0.85 }]
+            "categories:performance": [
+              "error",
+              {
+                "minScore": 0.85
+              }
+            ]
           }
         }
       ]


### PR DESCRIPTION
## Summary
- run guest, kds, and admin preview servers for Lighthouse CI
- wait for port 5175 to signal readiness

## Testing
- `python -m pre_commit run --files lighthouserc.json`
- `npx --yes lhci autorun --config=lighthouserc.json` *(fails: Hello, this is AnupamAS01!)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f3ecfdb4832a815fbef780000269