### PR TITLE
Ensure tenant migration script resolves project modules

### DIFF
--- a/scripts/tenant_migrate.py
+++ b/scripts/tenant_migrate.py
@@ -15,11 +15,16 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import sys
+from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
 from sqlalchemy.ext.asyncio import create_async_engine
 
+# Ensure project root is on the import path so ``api`` resolves when invoked
+# as ``python scripts/tenant_migrate.py``.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from api.app.db.tenant import build_dsn, TEMPLATE_ENV
 
 


### PR DESCRIPTION
## Summary
- ensure tenant migration script adds project root to import path to resolve `api` package

## Testing
- `python scripts/tenant_migrate.py --tenant demo`
- `pytest scripts/tests/test_emit_test_alert.py scripts/tests/test_synthetic_monitor_stub.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1f3b2c1f8832a8c985b1f01276063