### PR TITLE
feat(growth): referrals owner UI + credit history

### DIFF
--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -34,7 +34,12 @@ export function Layout() {
         <nav className="flex flex-col space-y-2" aria-label="Primary">
           <Link to="/dashboard">Dashboard</Link>
           <Link to="/floor">Floor</Link>
-          {roles.includes('owner') && <Link to="/billing">Billing</Link>}
+          {roles.includes('owner') && (
+            <>
+              <Link to="/billing">Billing</Link>
+              <Link to="/referrals">Referrals</Link>
+            </>
+          )}
           <Link to="/onboarding">Onboarding</Link>
         </nav>
       </aside>

--- a/apps/admin/src/pages/Referrals.test.tsx
+++ b/apps/admin/src/pages/Referrals.test.tsx
@@ -1,0 +1,67 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { Referrals } from './Referrals';
+import { getReferral, createReferral, getCredits } from '@neo/api';
+
+vi.mock('@neo/api', () => ({
+  getReferral: vi.fn(),
+  createReferral: vi.fn(),
+  getCredits: vi.fn()
+}));
+
+describe('Referrals page', () => {
+  beforeEach(() => {
+    (getCredits as any).mockResolvedValue({ balance: 0, referrals: 0, adjustments: 0 });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('shows stats and credit history when referral exists', async () => {
+    (getReferral as any).mockResolvedValue({
+      code: 'abc',
+      landing_url: 'https://ref/abc',
+      clicks: 1,
+      signups: 2,
+      converted: 3,
+      max_credit_inr: 5000,
+      credits: [
+        { id: 'c1', amount_inr: 100, created_at: '2024-01-01', applied_invoice_id: 'inv1' }
+      ]
+    });
+    render(
+      <MemoryRouter>
+        <Referrals />
+      </MemoryRouter>
+    );
+    await screen.findByDisplayValue('https://ref/abc');
+    expect(screen.getByText('Clicks 1')).toBeInTheDocument();
+    expect(screen.getByTestId('credits-table').querySelectorAll('tr').length).toBe(2);
+  });
+
+  test('generates referral when none exists', async () => {
+    (getReferral as any).mockResolvedValue(null);
+    (createReferral as any).mockResolvedValue({
+      code: 'xyz',
+      landing_url: 'https://ref/xyz',
+      clicks: 0,
+      signups: 0,
+      converted: 0,
+      max_credit_inr: 5000,
+      credits: []
+    });
+    render(
+      <MemoryRouter>
+        <Referrals />
+      </MemoryRouter>
+    );
+    const btn = await screen.findByText('Generate Link');
+    await userEvent.click(btn);
+    await screen.findByDisplayValue('https://ref/xyz');
+    expect(createReferral).toHaveBeenCalled();
+  });
+});

--- a/apps/admin/src/pages/Referrals.tsx
+++ b/apps/admin/src/pages/Referrals.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@neo/ui';
+import { getReferral, createReferral, getCredits, type Referral, type Credits } from '@neo/api';
+
+export function Referrals() {
+  const [ref, setRef] = useState<Referral | null>(null);
+  const [credits, setCredits] = useState<Credits | null>(null);
+
+  useEffect(() => {
+    getReferral().then(setRef).catch(() => {});
+    getCredits().then(setCredits).catch(() => {});
+  }, []);
+
+  async function generate() {
+    try {
+      const r = await createReferral();
+      setRef(r);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function copy() {
+    if (ref) navigator.clipboard.writeText(ref.landing_url);
+  }
+
+  if (!ref)
+    return (
+      <Button onClick={generate}>Generate Link</Button>
+    );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-2">
+        <input
+          data-testid="link-input"
+          readOnly
+          value={ref.landing_url}
+          className="border p-1 flex-1"
+        />
+        <Button data-testid="copy-btn" onClick={copy}>
+          Copy
+        </Button>
+      </div>
+      <div className="flex flex-wrap gap-4 items-center">
+        <span>Clicks {ref.clicks}</span>
+        <span>Signups {ref.signups}</span>
+        <span>Conversions {ref.converted}</span>
+        <span className="px-2 py-0.5 bg-gray-100 rounded" data-testid="cap-chip">
+          Max ₹{ref.max_credit_inr}
+        </span>
+        {credits && <span>Referral credits ₹{credits.referrals}</span>}
+      </div>
+      <table data-testid="credits-table" className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="text-left p-2">Date</th>
+            <th className="text-left p-2">Amount</th>
+            <th className="text-left p-2">Invoice</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ref.credits.map((c) => (
+            <tr key={c.id}>
+              <td className="p-2">{c.created_at}</td>
+              <td className="p-2">₹{c.amount_inr}</td>
+              <td className="p-2">
+                {c.applied_invoice_id ? (
+                  <a href={`/admin/billing/invoice/${c.applied_invoice_id}`}>
+                    {c.applied_invoice_id}
+                  </a>
+                ) : (
+                  '-'
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -3,6 +3,7 @@ import { Login } from './pages/Login';
 import { Dashboard } from './pages/Dashboard';
 import { Floor } from './pages/Floor';
 import { Billing } from './pages/Billing';
+import { Referrals } from './pages/Referrals';
 import { Onboarding } from './pages/Onboarding';
 import { Support } from './pages/Support';
 import { Layout } from './components/Layout';
@@ -16,28 +17,35 @@ export const routes: RouteObject[] = [
   { path: '/login', element: <Login /> },
   {
     path: '/',
-      element: (
-        <ProtectedRoute roles={['owner', 'manager']}>
-          <Layout />
-        </ProtectedRoute>
-      ),
+    element: (
+      <ProtectedRoute roles={['owner', 'manager']}>
+        <Layout />
+      </ProtectedRoute>
+    ),
     children: [
       { index: true, element: <Navigate to="/dashboard" replace /> },
       { path: 'dashboard', element: <Dashboard /> },
       { path: 'floor', element: <Floor /> },
-        {
-          path: 'billing',
-          element: (
-            <ProtectedRoute roles={['owner']}>
-              <Billing />
-            </ProtectedRoute>
-          )
-        },
-        { path: 'onboarding', element: <Onboarding /> },
-        { path: 'support', element: <Support /> },
-        { path: 'changelog', element: <Flag name="changelog"><Changelog /></Flag> }
-      ]
-    }
+      {
+        path: 'billing',
+        element: (
+          <ProtectedRoute roles={['owner']}>
+            <Billing />
+          </ProtectedRoute>
+        )
+      },
+      {
+        path: 'referrals',
+        element: (
+          <ProtectedRoute roles={['owner']}>
+            <Referrals />
+          </ProtectedRoute>
+        )
+      },
+      { path: 'onboarding', element: <Onboarding /> },
+      { path: 'support', element: <Support /> },
+      { path: 'changelog', element: <Flag name="changelog"><Changelog /></Flag> }
+    ]
   },
   {
     path: '/staff',

--- a/packages/api/src/endpoints.ts
+++ b/packages/api/src/endpoints.ts
@@ -121,6 +121,31 @@ export function getCredits() {
   return apiFetch<Credits>('/admin/billing/credits');
 }
 
+export interface ReferralCredit {
+  id: string;
+  amount_inr: number;
+  applied_invoice_id?: string;
+  created_at: string;
+}
+
+export interface Referral {
+  code: string;
+  landing_url: string;
+  clicks: number;
+  signups: number;
+  converted: number;
+  max_credit_inr: number;
+  credits: ReferralCredit[];
+}
+
+export function getReferral() {
+  return apiFetch<Referral | null>('/admin/referrals');
+}
+
+export function createReferral() {
+  return apiFetch<Referral>('/admin/referrals/new', { method: 'POST' });
+}
+
 export interface Subscription {
   plan_id: string;
   table_cap: number;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -21,6 +21,8 @@ export {
   listInvoices,
   downloadInvoice,
   getCredits,
+  getReferral,
+  createReferral,
   getSubscription,
   getCategories,
   createCategory,
@@ -34,3 +36,4 @@ export {
   importMenuI18n
 } from './endpoints';
 export type { PlanPreview, Invoice, Credits, Subscription } from './endpoints';
+export type { Referral, ReferralCredit } from './endpoints';


### PR DESCRIPTION
## Summary
- add owner referrals page with link generation, stats, and credit history
- expose referral endpoints in api package
- link to referrals from admin navigation and routes

## Testing
- `pnpm -F @neo/api test`
- `pnpm -F @neo/api typecheck`
- `pnpm -F @neo/admin test`
- `pytest api/tests/test_referrals.py`
- ⚠️ `pnpm -F @neo/admin typecheck` (missing modules)


------
https://chatgpt.com/codex/tasks/task_e_68b1f64feb24832a91c30123932055b2