### PR TITLE
feat(kds): KOT print toggle + compact/full layouts + dev stub

### DIFF
--- a/apps/kds/src/components/PrintKOTButton.tsx
+++ b/apps/kds/src/components/PrintKOTButton.tsx
@@ -1,0 +1,63 @@
+import { apiFetch } from '@neo/api';
+import { useKdsPrefs } from '../state/kdsPrefs';
+
+interface Item {
+  qty: number;
+  name: string;
+}
+
+interface Ticket {
+  id: string;
+  table: string;
+  items: Item[];
+}
+
+export function PrintKOTButton({ ticket }: { ticket: Ticket }) {
+  const { printer, layout, set } = useKdsPrefs();
+
+  if (!printer) return null;
+
+  const print = (l: 'compact' | 'full') => {
+    apiFetch('/print/notify', {
+      method: 'POST',
+      body: JSON.stringify({ order_id: ticket.id, layout: l }),
+      headers: { 'Content-Type': 'application/json' },
+    }).catch(() => {
+      /* ignore */
+    });
+    if (import.meta.env.MODE !== 'production') {
+      const w = window.open('', '_blank');
+      if (w) {
+        const items = ticket.items
+          .map((i) => `<li>${i.qty}x ${i.name}</li>`)
+          .join('');
+        w.document.write(
+          `<html><body><h1>Table ${ticket.table}</h1><ul>${items}</ul></body></html>`
+        );
+        w.document.close();
+        w.focus();
+        w.print();
+      }
+    }
+  };
+
+  return (
+    <div className="mt-2 flex items-center space-x-1">
+      <button
+        onClick={() => print(layout)}
+        className="border px-1 py-0.5 rounded text-sm"
+      >
+        Print KOT
+      </button>
+      <select
+        value={layout}
+        onChange={(e) => set({ layout: e.target.value as 'compact' | 'full' })}
+        className="border p-1 rounded text-sm"
+      >
+        <option value="compact">Compact</option>
+        <option value="full">Full</option>
+      </select>
+    </div>
+  );
+}
+

--- a/apps/kds/src/pages/Expo.test.tsx
+++ b/apps/kds/src/pages/Expo.test.tsx
@@ -252,7 +252,12 @@ describe('Expo', () => {
     useKdsPrefs.getState().set({ printer: true, layout: 'compact' });
     render(<Expo />);
     await screen.findByTestId('ticket-1');
-    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const fakeWindow = {
+      document: { write: vi.fn(), close: vi.fn() },
+      focus: vi.fn(),
+      print: vi.fn(),
+    } as any;
+    const open = vi.spyOn(window, 'open').mockReturnValue(fakeWindow);
     await userEvent.click(screen.getByRole('button', { name: 'Print KOT' }));
     expect(apiFetch).toHaveBeenCalledWith(
       '/print/notify',
@@ -261,8 +266,8 @@ describe('Expo', () => {
         body: JSON.stringify({ order_id: '1', layout: 'compact' }),
       })
     );
-    expect(log).toHaveBeenCalledWith('stub print', { id: '1', layout: 'compact' });
-    log.mockRestore();
+    expect(open).toHaveBeenCalled();
+    open.mockRestore();
   });
 
   test('Test Print hits endpoint in dev', async () => {

--- a/apps/kds/src/pages/Expo.tsx
+++ b/apps/kds/src/pages/Expo.tsx
@@ -3,6 +3,7 @@ import { apiFetch, useWS, useLicense } from '@neo/api';
 import { WS_BASE } from '../env';
 import { SettingsDrawer } from '../components/SettingsDrawer';
 import { useKdsPrefs } from '../state/kdsPrefs';
+import { PrintKOTButton } from '../components/PrintKOTButton';
 import sounds from '../sounds.json';
 
 interface Item {
@@ -31,8 +32,7 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
   const [zone, setZone] = useState<string | undefined>();
   const [order, setOrder] = useState<string[]>([]);
 
-  const { soundNew, soundReady, desktopNotify, darkMode, fontScale, printer, layout } =
-    useKdsPrefs();
+  const { soundNew, soundReady, desktopNotify, darkMode, fontScale } = useKdsPrefs();
   const [showSettings, setShowSettings] = useState(false);
   const [fullscreen, setFullscreen] = useState(() => localStorage.getItem('kdsFullscreen') === '1');
 
@@ -189,18 +189,6 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
     }
   };
 
-  const print = (id: string) => {
-    apiFetch('/print/notify', {
-      method: 'POST',
-      body: JSON.stringify({ order_id: id, layout }),
-      headers: { 'Content-Type': 'application/json' },
-    }).catch(() => {
-      /* ignore */
-    });
-    if (import.meta.env.MODE !== 'production') {
-      console.log('stub print', { id, layout });
-    }
-  };
 
   const onKey = useCallback(
     (e: KeyboardEvent) => {
@@ -369,14 +357,7 @@ export function Expo({ offlineMs = 10000 }: { offlineMs?: number } = {}) {
                         </li>
                       ))}
                     </ul>
-                    {printer && (
-                      <button
-                        onClick={() => print(t.id)}
-                        className="mt-2 border px-1 py-0.5 rounded text-sm"
-                      >
-                        Print KOT
-                      </button>
-                    )}
+                    <PrintKOTButton ticket={t} />
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- add PrintKOTButton with compact/full layouts and HTML preview stub
- integrate PrintKOTButton into Expo page
- update Expo tests for new preview stub

## Testing
- `corepack pnpm --filter @neo/kds test`
- `corepack pnpm --filter @neo/kds lint`
- `corepack pnpm --filter @neo/kds typecheck` *(fails: Module './components' has already exported a member named 'Flag')*

------
https://chatgpt.com/codex/tasks/task_e_68b1f6497d2c832abcc71a608c15b36f