### PR TITLE
feat(admin/export): self-serve exports + download center

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -289,6 +289,7 @@ except Exception:  # pragma: no cover - fallback when Redis is unreachable
     logging.warning("Redis unavailable; using fakeredis")
     app.state.redis = fakeredis.aioredis.FakeRedis()
 app.state.export_progress = {}
+app.state.export_jobs = {}
 app.add_middleware(GZipMiddleware, minimum_size=1024)
 app.add_middleware(PrometheusMiddleware)
 app.add_middleware(HttpErrorCounterMiddleware)

--- a/api/app/routes_admin_export.py
+++ b/api/app/routes_admin_export.py
@@ -2,20 +2,28 @@ from __future__ import annotations
 
 """Admin route for exporting orders, items and customers."""
 
+import asyncio
+import csv
 from io import BytesIO
+from pathlib import Path
+from uuid import uuid4
 from zipfile import ZipFile
 
-from fastapi import APIRouter, Request
-from fastapi.responses import StreamingResponse
+from datetime import datetime
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import FileResponse, StreamingResponse
+from sqlalchemy import select
 
 from .models_tenant import Customer, MenuItem, Order, OrderItem
 from .routes_export_all import _export_table, _iter_bytes
-from .routes_exports import DEFAULT_LIMIT, HARD_LIMIT, _session
+from .routes_exports import DEFAULT_LIMIT, HARD_LIMIT, SCAN_LIMIT, _session
 from .security import ratelimit
 from .utils import ratelimits
 from .utils.rate_limit import rate_limited
 
 router = APIRouter()
+
+EXPORT_DIR = Path(__file__).resolve().parent.parent.parent / "storage" / "exports"
 
 
 @router.get("/api/admin/export/data.zip")
@@ -114,3 +122,96 @@ async def admin_export(
     return StreamingResponse(
         _iter_bytes(bundle), media_type="application/zip", headers=headers
     )
+
+
+async def _run_export(job: str, tenant: str, kind: str, start: str | None, end: str | None, app) -> None:
+    """Generate CSV export for ``kind`` and update job status."""
+    path = EXPORT_DIR / tenant
+    path.mkdir(parents=True, exist_ok=True)
+    file_path = path / f"{job}_{kind}.csv"
+    async with _session(tenant) as session:
+        if kind == "orders":
+            cols = [
+                ("id", Order.id),
+                ("table_id", Order.table_id),
+                ("status", Order.status),
+                ("placed_at", Order.placed_at),
+            ]
+            model = Order
+            start_dt = datetime.fromisoformat(start) if start else None
+            end_dt = datetime.fromisoformat(end) if end else None
+        elif kind == "items":
+            cols = [
+                ("id", MenuItem.id),
+                ("name", MenuItem.name),
+                ("price", MenuItem.price),
+            ]
+            model = MenuItem
+        elif kind == "customers":
+            cols = [
+                ("id", Customer.id),
+                ("name", Customer.name),
+                ("phone", Customer.phone),
+            ]
+            model = Customer
+        else:
+            app.state.export_jobs[job] = {"status": "error", "message": "bad type"}
+            return
+        headers = [c[0] for c in cols]
+        select_cols = [c[1] for c in cols]
+        last_id = 0
+        with file_path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(headers)
+            while True:
+                stmt = (
+                    select(*select_cols)
+                    .where(model.id > last_id)
+                    .order_by(model.id)
+                    .limit(SCAN_LIMIT)
+                )
+                if kind == "orders":
+                    if start_dt:
+                        stmt = stmt.where(Order.placed_at >= start_dt)
+                    if end_dt:
+                        stmt = stmt.where(Order.placed_at <= end_dt)
+                rows = (await session.execute(stmt)).all()
+                if not rows:
+                    break
+                for row in rows:
+                    writer.writerow(row)
+                    last_id = row[0]
+                if len(rows) < SCAN_LIMIT:
+                    break
+    app.state.export_jobs[job] = {
+        "status": "complete",
+        "url": f"/api/admin/export/{job}/download",
+        "path": str(file_path),
+        "type": kind,
+    }
+
+
+@router.post("/api/admin/export")
+async def request_export(request: Request, payload: dict) -> dict:
+    kind = payload.get("type", "")
+    job = uuid4().hex
+    tenant = request.headers.get("X-Tenant-ID", "demo")
+    request.app.state.export_jobs[job] = {"status": "pending", "type": kind}
+    asyncio.create_task(_run_export(job, tenant, kind, payload.get("from"), payload.get("to"), request.app))
+    return {"job": job}
+
+
+@router.get("/api/admin/export/{job}")
+async def export_status(job: str, request: Request):
+    data = request.app.state.export_jobs.get(job)
+    if not data:
+        raise HTTPException(status_code=404, detail="not found")
+    return data
+
+
+@router.get("/api/admin/export/{job}/download")
+async def export_download(job: str, request: Request):
+    data = request.app.state.export_jobs.get(job)
+    if not data or data.get("status") != "complete":
+        raise HTTPException(status_code=404, detail="not found")
+    return FileResponse(data["path"], filename=f"{data.get('type', 'export')}.csv")

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -35,6 +35,7 @@ export function Layout() {
           <Link to="/dashboard">Dashboard</Link>
           <Link to="/floor">Floor</Link>
           {roles.includes('owner') && <Link to="/billing">Billing</Link>}
+          {roles.includes('owner') && <Link to="/export">Export</Link>}
           <Link to="/onboarding">Onboarding</Link>
         </nav>
       </aside>

--- a/apps/admin/src/pages/Export.tsx
+++ b/apps/admin/src/pages/Export.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { requestExport, exportStatus, type ExportStatus } from '@neo/api';
+
+interface Job {
+  id: string;
+  type: string;
+  status: string;
+  url?: string;
+}
+
+export function Export() {
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [jobs, setJobs] = useState<Job[]>([]);
+
+  async function start(type: string) {
+    try {
+      const res = await requestExport({ type, from, to });
+      setJobs((j) => [...j, { id: res.job, type, status: 'pending' }]);
+    } catch (e) {
+      // noop
+    }
+  }
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      jobs.forEach(async (job) => {
+        if (job.status === 'complete') return;
+        try {
+          const res: ExportStatus = await exportStatus(job.id);
+          setJobs((prev) =>
+            prev.map((j) => (j.id === job.id ? { ...j, ...res } : j))
+          );
+        } catch {
+          // ignore
+        }
+      });
+    }, 3000);
+    return () => clearInterval(timer);
+  }, [jobs]);
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="font-bold mb-2">Orders</h2>
+        <input
+          type="date"
+          value={from}
+          onChange={(e) => setFrom(e.target.value)}
+          className="border px-2 py-1"
+        />
+        <input
+          type="date"
+          value={to}
+          onChange={(e) => setTo(e.target.value)}
+          className="border px-2 py-1 ml-2"
+        />
+        <button
+          onClick={() => start('orders')}
+          className="ml-2 border px-2 py-1"
+        >
+          Request export
+        </button>
+      </section>
+      <section>
+        <h2 className="font-bold mb-2">Items</h2>
+        <button
+          onClick={() => start('items')}
+          className="border px-2 py-1"
+        >
+          Request export
+        </button>
+      </section>
+      <section>
+        <h2 className="font-bold mb-2">Customers</h2>
+        <button
+          onClick={() => start('customers')}
+          className="border px-2 py-1"
+        >
+          Request export
+        </button>
+      </section>
+      <section>
+        <h2 className="font-bold mb-2">Download center</h2>
+        <ul className="list-disc pl-5 space-y-1">
+          {jobs.map((job) => (
+            <li key={job.id}>
+              {job.type} - {job.status}
+              {job.url && (
+                <a href={job.url} className="underline ml-2">
+                  Download
+                </a>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -11,6 +11,7 @@ import { StaffSupport } from './pages/StaffSupport';
 import { Changelog } from './pages/Changelog';
 import { Flags } from './pages/Flags';
 import { Flag } from '@neo/ui';
+import { Export } from './pages/Export';
 
 export const routes: RouteObject[] = [
   { path: '/login', element: <Login /> },
@@ -30,6 +31,14 @@ export const routes: RouteObject[] = [
           element: (
             <ProtectedRoute roles={['owner']}>
               <Billing />
+            </ProtectedRoute>
+          )
+        },
+        {
+          path: 'export',
+          element: (
+            <ProtectedRoute roles={['owner']}>
+              <Export />
             </ProtectedRoute>
           )
         },

--- a/packages/api/src/endpoints.ts
+++ b/packages/api/src/endpoints.ts
@@ -240,3 +240,29 @@ export function importMenuI18n(file: File, tenant?: string) {
     tenant
   });
 }
+
+export interface ExportJob {
+  job: string;
+}
+
+export function requestExport(body: {
+  type: string;
+  from?: string;
+  to?: string;
+}) {
+  return apiFetch<ExportJob>('/admin/export', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+export interface ExportStatus {
+  status: string;
+  url?: string;
+  type?: string;
+}
+
+export function exportStatus(job: string) {
+  return apiFetch<ExportStatus>(`/admin/export/${job}`);
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -31,6 +31,15 @@ export {
   deleteItem,
   uploadImage,
   exportMenuI18n,
-  importMenuI18n
+  importMenuI18n,
+  requestExport,
+  exportStatus
 } from './endpoints';
-export type { PlanPreview, Invoice, Credits, Subscription } from './endpoints';
+export type {
+  PlanPreview,
+  Invoice,
+  Credits,
+  Subscription,
+  ExportJob,
+  ExportStatus
+} from './endpoints';


### PR DESCRIPTION
## Summary
- add async export job endpoints that save CSVs and expose download status
- introduce Export page with request buttons and download center
- wire navigation and API helpers for export requests

## Testing
- `pytest` *(fails: Module import errors in tests/test_alembic_env.py, tests/test_analytics_outlets.py, tests/test_export_streaming.py, tests/test_kds_expo.py, tests/test_rum_vitals.py, tests/test_slo_metrics.py, tests/test_time_skew.py)*
- `pnpm -C apps/admin test`

------
https://chatgpt.com/codex/tasks/task_e_68b1f8d7b4f0832a8ae5745d7c641789