### PR TITLE
feat(admin): audit viewer + CSV export

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -117,6 +117,7 @@ from .routes_accounting_exports import router as accounting_exports_router
 from .routes_admin_billing import router as admin_billing_router
 from .routes_admin_billing import webhook_router as billing_webhook_router
 from .routes_admin_devices import router as admin_devices_router
+from .routes_admin_audit import router as admin_audit_router
 from .routes_admin_export import router as admin_export_router
 from .routes_admin_flags import router as admin_flags_router
 from .routes_admin_menu import router as admin_menu_router
@@ -1037,6 +1038,7 @@ app.include_router(postman_router)
 app.include_router(admin_qrpack_router)
 app.include_router(admin_qrposter_router)
 app.include_router(admin_devices_router)
+app.include_router(admin_audit_router)
 app.include_router(admin_export_router)
 
 # Reports domain

--- a/api/app/routes_admin_audit.py
+++ b/api/app/routes_admin_audit.py
@@ -2,35 +2,59 @@ from __future__ import annotations
 
 """Admin route for listing audit log entries."""
 
-from fastapi import APIRouter, Depends
+import csv
+import io
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query, Response
 
 from .audit import Audit, SessionLocal
 from .auth import User, role_required
-from .utils.pagination import Pagination
-from .utils.pagination import pagination as paginate
 from .utils.responses import ok
 
 router = APIRouter()
 
 
-@router.get("/api/admin/audit/logs")
+@router.get('/admin/audit')
 def list_audit_logs(
-    page: Pagination = Depends(paginate),
-    user: User = Depends(role_required("super_admin")),
-) -> dict:
+    actor: str | None = Query(None),
+    event: str | None = Query(None),
+    date: str | None = Query(None),
+    format: str | None = Query(None),
+    user: User = Depends(role_required('super_admin')),
+):
     with SessionLocal() as session:
         query = session.query(Audit).order_by(Audit.id.desc())
-        if page.cursor:
-            query = query.filter(Audit.id < page.cursor)
-        query = query.limit(page.limit)
+        if actor:
+            query = query.filter(Audit.actor == actor)
+        if event:
+            query = query.filter(Audit.action == event)
+        if date:
+            start = datetime.fromisoformat(date)
+            end = start + timedelta(days=1)
+            query = query.filter(Audit.created_at >= start, Audit.created_at < end)
         rows = [
             {
-                "id": row.id,
-                "actor": row.actor,
-                "action": row.action,
-                "entity": row.entity,
-                "created_at": row.created_at,
+                'id': row.id,
+                'actor': row.actor,
+                'action': row.action,
+                'entity': row.entity,
+                'created_at': row.created_at,
             }
-            for row in query.all()
+            for row in query.limit(100).all()
         ]
+    if format == 'csv':
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(['id', 'actor', 'action', 'entity', 'created_at'])
+        for r in rows:
+            writer.writerow([r['id'], r['actor'], r['action'], r['entity'], r['created_at']])
+        return Response(
+            buffer.getvalue(),
+            media_type='text/csv',
+            headers={'Content-Disposition': 'attachment; filename=audit.csv'},
+        )
     return ok(rows)
+
+
+__all__ = ['router']

--- a/api/tests/test_admin_audit_viewer.py
+++ b/api/tests/test_admin_audit_viewer.py
@@ -1,0 +1,42 @@
+import os
+import pathlib
+import sys
+
+from fastapi.testclient import TestClient
+import fakeredis.aioredis
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault('POSTGRES_MASTER_URL', 'postgresql://localhost/test')
+os.environ.setdefault('REDIS_URL', 'redis://localhost/0')
+os.environ.setdefault('SECRET_KEY', 'x' * 32)
+os.environ.setdefault('ALLOWED_ORIGINS', '*')
+
+from api.app.main import app
+from api.app import audit
+from api.app.auth import create_access_token
+
+client = TestClient(app)
+
+
+def setup_module() -> None:
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    audit.Base.metadata.drop_all(bind=audit.engine)
+    audit.Base.metadata.create_all(bind=audit.engine)
+    audit.log_event('staff', 'order', 'o1')
+    audit.log_event('system', 'kds', 'k1')
+
+
+def test_filters_and_csv() -> None:
+    token = create_access_token({'sub': 'admin@example.com', 'role': 'super_admin'})
+    headers = {'Authorization': f'Bearer {token}'}
+    resp = client.get('/admin/audit?actor=staff&event=order', headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()['data']
+    assert len(data) == 1
+    assert data[0]['actor'] == 'staff'
+
+    csv_resp = client.get('/admin/audit?event=kds&format=csv', headers=headers)
+    assert csv_resp.status_code == 200
+    assert 'kds' in csv_resp.text
+    assert csv_resp.headers['content-type'].startswith('text/csv')

--- a/apps/admin/src/pages/Audit.tsx
+++ b/apps/admin/src/pages/Audit.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { listAuditLogs, type AuditLog } from '@neo/api';
+
+export function Audit() {
+  const [logs, setLogs] = useState<AuditLog[]>([]);
+  const [params, setParams] = useSearchParams();
+
+  const actor = params.get('actor') || '';
+  const event = params.get('event') || '';
+  const date = params.get('date') || '';
+
+  useEffect(() => {
+    listAuditLogs({ actor, event, date })
+      .then(setLogs)
+      .catch(() => setLogs([]));
+  }, [actor, event, date]);
+
+  function update(key: string, value: string) {
+    const next = new URLSearchParams(params);
+    if (value) next.set(key, value);
+    else next.delete(key);
+    setParams(next);
+  }
+
+  function exportCsv() {
+    const qs = new URLSearchParams(params);
+    qs.set('format', 'csv');
+    window.open(`/admin/audit?${qs.toString()}`);
+  }
+
+  return (
+    <div>
+      <div className="space-x-2 mb-4">
+        <select value={actor} onChange={(e) => update('actor', e.target.value)}>
+          <option value="">actor</option>
+          <option value="staff">staff</option>
+          <option value="system">system</option>
+        </select>
+        <select value={event} onChange={(e) => update('event', e.target.value)}>
+          <option value="">event</option>
+          <option value="order">order</option>
+          <option value="kds">kds</option>
+          <option value="billing">billing</option>
+          <option value="support">support</option>
+        </select>
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => update('date', e.target.value)}
+        />
+        <button onClick={exportCsv}>Export CSV</button>
+      </div>
+      <table className="min-w-full">
+        <thead>
+          <tr>
+            <th>Actor</th>
+            <th>Event</th>
+            <th>Entity</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((l) => (
+            <tr key={l.id}>
+              <td>{l.actor}</td>
+              <td>{l.action}</td>
+              <td>{l.entity}</td>
+              <td>{new Date(l.created_at).toLocaleString()}</td>
+            </tr>
+          ))}
+          {logs.length === 0 && (
+            <tr>
+              <td colSpan={4}>No logs</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -6,6 +6,7 @@ import { Billing } from './pages/Billing';
 import { Referrals } from './pages/Referrals';
 import { Onboarding } from './pages/Onboarding';
 import { Support } from './pages/Support';
+import { Audit } from './pages/Audit';
 import { Layout } from './components/Layout';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { StaffSupport } from './pages/StaffSupport';
@@ -50,6 +51,7 @@ export const routes: RouteObject[] = [
       },
       { path: 'onboarding', element: <Onboarding /> },
       { path: 'support', element: <Support /> },
+      { path: 'audit', element: <Audit /> },
       { path: 'changelog', element: <Flag name="changelog"><Changelog /></Flag> }
     ]
 

--- a/packages/api/src/endpoints.ts
+++ b/packages/api/src/endpoints.ts
@@ -265,3 +265,24 @@ export function importMenuI18n(file: File, tenant?: string) {
     tenant
   });
 }
+
+export interface AuditLog {
+  id: number;
+  actor: string;
+  action: string;
+  entity: string;
+  created_at: string;
+}
+
+export function listAuditLogs(params: {
+  actor?: string;
+  event?: string;
+  date?: string;
+}) {
+  const qs = new URLSearchParams();
+  if (params.actor) qs.set('actor', params.actor);
+  if (params.event) qs.set('event', params.event);
+  if (params.date) qs.set('date', params.date);
+  const q = qs.toString();
+  return apiFetch<AuditLog[]>(`/admin/audit${q ? `?${q}` : ''}`);
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -33,7 +33,8 @@ export {
   deleteItem,
   uploadImage,
   exportMenuI18n,
-  importMenuI18n
+  importMenuI18n,
+  listAuditLogs
 } from './endpoints';
-export type { PlanPreview, Invoice, Credits, Subscription } from './endpoints';
+export type { PlanPreview, Invoice, Credits, Subscription, AuditLog } from './endpoints';
 export type { Referral, ReferralCredit } from './endpoints';


### PR DESCRIPTION
## Summary
- add admin audit viewer with filters and CSV export
- expose audit logs API with filtering and CSV support
- wire up audit page route and client helpers

## Testing
- `pnpm -F @neo/api test`
- `pnpm -F @neo/admin test`
- `pytest api/tests/test_admin_audit_viewer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1fae82cfc832a9c9881b985dddb99