### PR TITLE
feat(admin): audit viewer + CSV export

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -114,6 +114,7 @@ from .routes_ab_report import router as ab_report_router
 from .routes_ab_tests import router as ab_tests_router
 from .routes_accounting import router as accounting_router
 from .routes_accounting_exports import router as accounting_exports_router
+from .routes_admin_audit import router as admin_audit_router
 from .routes_admin_billing import router as admin_billing_router
 from .routes_admin_billing import webhook_router as billing_webhook_router
 from .routes_admin_devices import router as admin_devices_router
@@ -962,6 +963,7 @@ app.include_router(kds_expo_router)
 app.include_router(counter_admin_router)
 app.include_router(staff_router)
 app.include_router(admin_menu_router)
+app.include_router(admin_audit_router)
 app.include_router(menu_i18n_router)
 app.include_router(admin_onboarding_router)
 app.include_router(slo_router)

--- a/api/app/routes_admin_audit.py
+++ b/api/app/routes_admin_audit.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 """Admin route for listing audit log entries."""
 
-from fastapi import APIRouter, Depends
+import csv
+import io
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, Response
+from fastapi.responses import JSONResponse
 
 from .audit import Audit, SessionLocal
 from .auth import User, role_required
@@ -10,16 +16,31 @@ from .utils.pagination import Pagination
 from .utils.pagination import pagination as paginate
 from .utils.responses import ok
 
-router = APIRouter()
+router = APIRouter(prefix="/admin/audit")
 
 
-@router.get("/api/admin/audit/logs")
+@router.get("")
 def list_audit_logs(
     page: Pagination = Depends(paginate),
-    user: User = Depends(role_required("super_admin")),
-) -> dict:
+    actor: Optional[str] = Query(None),
+    event: Optional[str] = Query(None),
+    start: Optional[str] = Query(None),
+    end: Optional[str] = Query(None),
+    format: Optional[str] = Query(None),
+    user: User = Depends(role_required("owner", "super_admin")),
+) -> Response:
+    """Return audit log entries with optional filters and CSV export."""
+
     with SessionLocal() as session:
         query = session.query(Audit).order_by(Audit.id.desc())
+        if actor:
+            query = query.filter(Audit.actor == actor)
+        if event:
+            query = query.filter(Audit.action.like(f"{event}%"))
+        if start:
+            query = query.filter(Audit.created_at >= datetime.fromisoformat(start))
+        if end:
+            query = query.filter(Audit.created_at <= datetime.fromisoformat(end))
         if page.cursor:
             query = query.filter(Audit.id < page.cursor)
         query = query.limit(page.limit)
@@ -29,8 +50,17 @@ def list_audit_logs(
                 "actor": row.actor,
                 "action": row.action,
                 "entity": row.entity,
-                "created_at": row.created_at,
+                "created_at": row.created_at.isoformat(),
             }
             for row in query.all()
         ]
-    return ok(rows)
+
+    if format == "csv":
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["id", "actor", "action", "entity", "created_at"])
+        for r in rows:
+            writer.writerow([r["id"], r["actor"], r["action"], r["entity"], r["created_at"]])
+        return Response(output.getvalue(), media_type="text/csv")
+
+    return JSONResponse(ok(rows))

--- a/api/tests/test_pagination.py
+++ b/api/tests/test_pagination.py
@@ -141,13 +141,11 @@ def test_audit_log_pagination_and_limit(tmp_path):
         for i in range(120):
             session.add(audit.Audit(actor="a", action="x", entity=str(i)))
         session.commit()
-    resp = client.get(
-        "/api/admin/audit/logs", params={"limit": 1000}, headers=_admin_headers()
-    )
+    resp = client.get("/admin/audit", params={"limit": 1000}, headers=_admin_headers())
     data = resp.json()["data"]
     assert len(data) == 100
     cursor = data[-1]["id"]
     resp = client.get(
-        "/api/admin/audit/logs", params={"cursor": cursor}, headers=_admin_headers()
+        "/admin/audit", params={"cursor": cursor}, headers=_admin_headers()
     )
     assert len(resp.json()["data"]) == 20

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -38,6 +38,7 @@ export function Layout() {
             <>
               <Link to="/billing">Billing</Link>
               <Link to="/referrals">Referrals</Link>
+              <Link to="/audit">Audit</Link>
             </>
           )}
           <Link to="/onboarding">Onboarding</Link>

--- a/apps/admin/src/pages/Audit.tsx
+++ b/apps/admin/src/pages/Audit.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+
+interface Log {
+  id: number;
+  actor: string;
+  action: string;
+  entity: string;
+  created_at: string;
+}
+
+export function Audit() {
+  const [actor, setActor] = useState('');
+  const [event, setEvent] = useState('');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [logs, setLogs] = useState<Log[]>([]);
+
+  const load = async () => {
+    const params = new URLSearchParams();
+    if (actor) params.set('actor', actor);
+    if (event) params.set('event', event);
+    if (start) params.set('start', start);
+    if (end) params.set('end', end);
+    const res = await fetch(`/admin/audit?${params.toString()}`);
+    const data = await res.json();
+    setLogs(data.data || []);
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const csvHref = () => {
+    const params = new URLSearchParams();
+    if (actor) params.set('actor', actor);
+    if (event) params.set('event', event);
+    if (start) params.set('start', start);
+    if (end) params.set('end', end);
+    params.set('format', 'csv');
+    return `/admin/audit?${params.toString()}`;
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <select value={actor} onChange={(e) => setActor(e.target.value)}>
+          <option value="">actor</option>
+          <option value="staff">staff</option>
+          <option value="system">system</option>
+        </select>
+        <select value={event} onChange={(e) => setEvent(e.target.value)}>
+          <option value="">event</option>
+          <option value="order">order</option>
+          <option value="kds">kds</option>
+          <option value="billing">billing</option>
+          <option value="support">support</option>
+        </select>
+        <input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
+        <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
+        <button onClick={load}>Filter</button>
+        <a href={csvHref()} className="btn">Export CSV</a>
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Actor</th>
+            <th>Action</th>
+            <th>Entity</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((l) => (
+            <tr key={l.id}>
+              <td>{l.id}</td>
+              <td>{l.actor}</td>
+              <td>{l.action}</td>
+              <td>{l.entity}</td>
+              <td>{new Date(l.created_at).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default Audit;

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -15,6 +15,7 @@ import { FeatureFlag } from '@neo/ui';
 import { Flag } from '@neo/ui';
 import { QRPack } from './pages/QRPack';
 import { Status } from './pages/Status';
+import { Audit } from './pages/Audit';
 
 export const routes: RouteObject[] = [
   { path: '/status', element: <Status /> },
@@ -49,6 +50,7 @@ export const routes: RouteObject[] = [
         )
       },
       { path: 'onboarding', element: <Onboarding /> },
+      { path: 'audit', element: <Audit /> },
       { path: 'support', element: <Support /> },
       { path: 'changelog', element: <Flag name="changelog"><Changelog /></Flag> }
     ]


### PR DESCRIPTION
## Summary
- add admin audit endpoint with filtering and CSV export
- add audit viewer page with filters and CSV download
- link audit page in owner navigation

## Testing
- `pytest tests/test_pagination.py`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1fadc1ae0832ab3781e51f9733f26