### PR TITLE
chore(pilot): seed/demo tenant, smoke scripts, runbooks & SLOs + nightly pilot checklist

### DIFF
--- a/.github/workflows/pilot_checklist.yml
+++ b/.github/workflows/pilot_checklist.yml
@@ -1,0 +1,39 @@
+name: pilot-checklist
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pnpm install --frozen-lockfile
+          python -m pip install --upgrade pip
+          pip install -r api/requirements.txt
+          npx playwright install --with-deps
+      - name: Seed pilot tenant
+        env:
+          PYTHONPATH: .
+        run: python scripts/seed_pilot.py --tenant pilot
+      - name: Run smoke tests
+        run: bash scripts/smoke_e2e.sh
+      - name: Notify on failure
+        if: failure()
+        env:
+          WEBHOOK: ${{ secrets.PILOT_ALERT_WEBHOOK }}
+        run: bash scripts/notify.sh staging pilot_checklist

--- a/docs/BACKUP_DR.md
+++ b/docs/BACKUP_DR.md
@@ -1,0 +1,14 @@
+# Backup & Disaster Recovery
+
+## Database
+- Nightly snapshot of master and tenant databases
+- Retain last 7 days on cold storage
+
+## Storage
+- `rsync` static assets to off-site bucket daily
+
+## Restore Drill
+1. Provision fresh database from snapshot
+2. Restore storage archive
+3. Run `scripts/tenant_restore.py --tenant <id>`
+4. Verify application health and data integrity

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,33 +1,23 @@
-# Incident Response Runbook
+# Pilot Operations Runbook
 
-## Common failures
-- Order service timeout or degraded performance
-- Database connection errors
-- Queue backlog causing delayed notifications
+## Start / Stop
+- `docker-compose up -d` starts API, worker and web assets
+- `docker-compose down` stops all services
 
-## Dashboards to check
-- API latency and error-rate dashboard
-- Database health dashboard
-- Worker queue depth dashboard
+## Blue / Green Rollout
+1. Build images for the new release
+2. Deploy using `scripts/rollout_blue_green.py` with the target color
+3. Verify health and switch traffic
 
-## SLIs
-- Request success rate
-- P95 latency
-- Queue processing time
+## Rollback
+- `python scripts/rollback_blue_green.py` restores the previous color
+- Confirm metrics and user flows before marking incident resolved
 
-## Rollback steps
-1. Identify the offending deployment version
-2. Trigger rollback via the deployment pipeline
-3. Verify services stabilize and metrics recover
+## CDN Invalidation
+- Purge cached assets via `scripts/deploy_assetlinks.sh --purge`
+- For manual purge hit the CDN provider console with the tenant domain
 
-## Communications template
-```
-**Incident**: <summary>
-**Impact**: <what users experience>
-**Timeline**:
-- Start: <timestamp>
-- Resolution: <timestamp>
-**Root cause**: <cause>
-**Mitigation**: <actions taken>
-**Next steps**: <follow-up tasks>
-```
+## Logs & Metrics
+- Application logs: `/var/log/neo/*.log`
+- Metrics dashboard: `https://grafana.example.com`
+- Access logs: cloud provider "load balancer" panel

--- a/docs/SLO_SLA.md
+++ b/docs/SLO_SLA.md
@@ -1,0 +1,8 @@
+# SLO / SLA
+
+| KPI | Target |
+| --- | --- |
+| API availability | 99.9% |
+| Order placement p95 latency | < 800ms |
+| KDS WebSocket reconnect | < 5s |
+| PDF render error rate | < 0.5% |

--- a/scripts/make_qr_pack.py
+++ b/scripts/make_qr_pack.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Wrapper to generate a QR poster pack for the pilot tenant."""
+
+from __future__ import annotations
+
+import argparse
+
+from qr_poster_pack import generate_pack
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render QR pack for a tenant")
+    parser.add_argument("--tenant", default="pilot", help="Tenant identifier")
+    parser.add_argument("--size", choices=["A4", "A5"], default="A4")
+    parser.add_argument(
+        "--output", default="pilot_qr_pack.zip", help="Output ZIP filename"
+    )
+    args = parser.parse_args()
+
+    data = generate_pack(args.tenant, args.size)
+    with open(args.output, "wb") as fh:
+        fh.write(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_pilot.py
+++ b/scripts/seed_pilot.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Seed a pilot tenant with demo data and helpers.
+
+This utility prepares a demo tenant with a basic menu, ten tables and
+mock configuration suitable for staging-to-pilot refreshes.  It creates the
+tenant database, runs migrations, seeds demo menu data and activates the
+license for 30 days in mock UPI mode.  QR posters are generated for the
+allocated tables and basic staff PINs are created for owner, kitchen and
+manager roles.
+
+The script relies on environment variables used by other seeding helpers
+(``POSTGRES_MASTER_URL`` and ``POSTGRES_TENANT_DSN_TEMPLATE``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Ensure project root and ``api`` package are importable when invoked as a
+# standalone script.
+BASE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BASE_DIR))
+
+from api.app.db.tenant import get_tenant_session  # noqa: E402
+from api.app.db.master import get_session as get_master_session  # noqa: E402
+from api.app.models_master import Tenant  # noqa: E402
+from api.app.models_tenant import Staff, Table  # noqa: E402
+from api.app.routes_onboarding import TENANTS  # noqa: E402
+from qr_poster_pack import generate_pack  # noqa: E402
+
+
+async def _add_tables(session: AsyncSession) -> None:
+    """Ensure ten tables exist in the tenant database."""
+    result = await session.execute(select(Table))
+    existing = len(result.scalars().all())
+    for i in range(existing + 1, 11):
+        session.add(
+            Table(
+                tenant_id=uuid.uuid4(),
+                name=f"Table {i}",
+                code=f"T-{i:03d}",
+                qr_token=uuid.uuid4().hex,
+            )
+        )
+    await session.commit()
+
+
+def _pilot_staff() -> list[Staff]:
+    """Return basic staff records with simple PINs."""
+    pins = {
+        "owner": "1111",
+        "kitchen": "2222",
+        "manager": "3333",
+    }
+    staff = []
+    for role, pin in pins.items():
+        staff.append(Staff(name=role.title(), role=role, pin_hash=pin))
+    return staff
+
+
+async def _create_staff(session: AsyncSession) -> None:
+    session.add_all(_pilot_staff())
+    await session.commit()
+
+
+async def _activate_license(tenant_id: str) -> None:
+    """Mark tenant license active for 30 days and enable UPI mock mode."""
+    async with get_master_session() as session:
+        tenant = await session.get(Tenant, tenant_id)
+        if tenant:
+            tenant.subscription_expires_at = dt.datetime.utcnow() + dt.timedelta(days=30)
+            limits = tenant.license_limits or {}
+            limits["upi_mock"] = True
+            tenant.license_limits = limits
+            await session.commit()
+
+
+async def _generate_qr_pack(tenant_id: str) -> None:
+    """Render QR posters for the tenant's tables."""
+    async with get_tenant_session(tenant_id) as session:
+        rows = await session.execute(select(Table.code, Table.qr_token))
+        tables = [
+            {"code": code, "qr_token": token}
+            for code, token in rows.all()
+        ]
+    TENANTS[tenant_id] = {"tables": tables}
+    data = generate_pack(tenant_id)
+    Path(f"{tenant_id}_qr_pack.zip").write_bytes(data)
+
+
+async def seed(tenant_id: str) -> None:
+    subprocess.run(["python", "scripts/tenant_create_db.py", "--tenant", tenant_id], check=True)
+    subprocess.run(["python", "scripts/tenant_migrate.py", "--tenant", tenant_id], check=True)
+    subprocess.run(["python", "scripts/demo_seed.py", "--tenant", tenant_id, "--reset"], check=True)
+
+    async with get_tenant_session(tenant_id) as session:
+        await _add_tables(session)
+        await _create_staff(session)
+
+    await _activate_license(tenant_id)
+    await _generate_qr_pack(tenant_id)
+    # TODO: sample orders, coupons and referral code
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed pilot tenant with demo data")
+    parser.add_argument("--tenant", default="pilot", help="Tenant identifier")
+    args = parser.parse_args()
+    asyncio.run(seed(args.tenant))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_e2e.sh
+++ b/scripts/smoke_e2e.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+status=0
+
+cd "$(dirname "$0")/.."
+
+echo 'Running Playwright e2e tests'
+if ! (cd e2e/playwright && npx playwright test --reporter=line); then
+  status=1
+fi
+
+echo 'Running Playwright visual regression tests'
+if ! npx playwright test -c playwright.vr.config.ts --reporter=line; then
+  status=1
+fi
+
+echo 'Running Lighthouse CI checks'
+if ! npx lhci autorun --config=lighthouserc.json \
+  --collect.url=http://localhost:5173/guest/menu \
+  --collect.url=http://localhost:5174/kds/expo \
+  --collect.url=http://localhost:5175/admin/dashboard; then
+  status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo -e "${GREEN}smoke ok${RESET}"
+else
+  echo -e "${RED}smoke failed${RESET}" >&2
+fi
+
+exit $status


### PR DESCRIPTION
## Summary
- add seed script for pilot tenant with license and QR pack helpers
- provide QR pack wrapper and smoke test script
- document runbook, SLO/SLA and backup/DR procedures
- schedule nightly pilot checklist workflow

## Testing
- `pytest` *(fails: import file mismatch)*
- `bash scripts/smoke_e2e.sh` *(fails: Playwright/lhci dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b28e545910832a9a45903aef63465c