### PR TITLE
chore(pilot): seed demo tenant, smoke scripts, runbooks & SLOs + nightly pilot checklist

### DIFF
--- a/scripts/seed_pilot.py
+++ b/scripts/seed_pilot.py
@@ -2,10 +2,11 @@
 """Seed a pilot tenant with demo data and helpers.
 
 This utility prepares a demo tenant with a basic menu, ten tables and
-mock configuration suitable for staging-to-pilot refreshes.  It creates the
+mock configuration suitable for staging-to-pilot refreshes. It creates the
 tenant database, runs migrations, seeds demo menu data and activates the
-license for 30 days in mock UPI mode.  QR posters are generated for the
-allocated tables and basic staff PINs are created for owner, kitchen and
+license for 30 days in mock UPI mode. QR posters are generated for the
+allocated tables, sample orders and coupons are inserted, a referral code
+is generated and basic staff PINs are created for owner, kitchen and
 manager roles.
 
 The script relies on environment variables used by other seeding helpers
@@ -33,8 +34,17 @@ sys.path.insert(0, str(BASE_DIR))
 from api.app.db.tenant import get_tenant_session  # noqa: E402
 from api.app.db.master import get_session as get_master_session  # noqa: E402
 from api.app.models_master import Tenant  # noqa: E402
-from api.app.models_tenant import Staff, Table  # noqa: E402
+from api.app.models_tenant import (
+    Coupon,
+    MenuItem,
+    Order,
+    OrderItem,
+    OrderStatus,
+    Staff,
+    Table,
+)  # noqa: E402
 from api.app.routes_onboarding import TENANTS  # noqa: E402
+from api.app.billing import create_referral  # noqa: E402
 from qr_poster_pack import generate_pack  # noqa: E402
 
 
@@ -72,12 +82,57 @@ async def _create_staff(session: AsyncSession) -> None:
     await session.commit()
 
 
+async def _create_coupons(session: AsyncSession) -> None:
+    """Insert a couple of demo coupons."""
+    session.add_all(
+        [
+            Coupon(code="WELCOME10", percent=10),
+            Coupon(code="FLAT50", flat=50),
+        ]
+    )
+    await session.commit()
+
+
+async def _create_sample_orders(session: AsyncSession) -> None:
+    """Create sample orders using existing menu items."""
+    items = (await session.execute(select(MenuItem).limit(2))).scalars().all()
+    tables = (await session.execute(select(Table.id).limit(2))).scalars().all()
+    for table_id in tables:
+        order = Order(
+            table_id=table_id,
+            status=OrderStatus.CONFIRMED,
+            placed_at=dt.datetime.utcnow(),
+        )
+        session.add(order)
+        await session.flush()
+        for item in items:
+            session.add(
+                OrderItem(
+                    order_id=order.id,
+                    item_id=item.id,
+                    name_snapshot=item.name,
+                    price_snapshot=item.price,
+                    qty=1,
+                    status="SERVED",
+                )
+            )
+    await session.commit()
+
+
+def _create_referral_code(tenant_id: str) -> None:
+    """Generate a referral code for the tenant and print it."""
+    ref = create_referral(tenant_id)
+    print(f"Referral code: {ref.code}")
+
+
 async def _activate_license(tenant_id: str) -> None:
     """Mark tenant license active for 30 days and enable UPI mock mode."""
     async with get_master_session() as session:
         tenant = await session.get(Tenant, tenant_id)
         if tenant:
-            tenant.subscription_expires_at = dt.datetime.utcnow() + dt.timedelta(days=30)
+            tenant.subscription_expires_at = dt.datetime.utcnow() + dt.timedelta(
+                days=30
+            )
             limits = tenant.license_limits or {}
             limits["upi_mock"] = True
             tenant.license_limits = limits
@@ -88,27 +143,32 @@ async def _generate_qr_pack(tenant_id: str) -> None:
     """Render QR posters for the tenant's tables."""
     async with get_tenant_session(tenant_id) as session:
         rows = await session.execute(select(Table.code, Table.qr_token))
-        tables = [
-            {"code": code, "qr_token": token}
-            for code, token in rows.all()
-        ]
+        tables = [{"code": code, "qr_token": token} for code, token in rows.all()]
     TENANTS[tenant_id] = {"tables": tables}
     data = generate_pack(tenant_id)
     Path(f"{tenant_id}_qr_pack.zip").write_bytes(data)
 
 
 async def seed(tenant_id: str) -> None:
-    subprocess.run(["python", "scripts/tenant_create_db.py", "--tenant", tenant_id], check=True)
-    subprocess.run(["python", "scripts/tenant_migrate.py", "--tenant", tenant_id], check=True)
-    subprocess.run(["python", "scripts/demo_seed.py", "--tenant", tenant_id, "--reset"], check=True)
+    subprocess.run(
+        ["python", "scripts/tenant_create_db.py", "--tenant", tenant_id], check=True
+    )
+    subprocess.run(
+        ["python", "scripts/tenant_migrate.py", "--tenant", tenant_id], check=True
+    )
+    subprocess.run(
+        ["python", "scripts/demo_seed.py", "--tenant", tenant_id, "--reset"], check=True
+    )
 
     async with get_tenant_session(tenant_id) as session:
         await _add_tables(session)
         await _create_staff(session)
+        await _create_coupons(session)
+        await _create_sample_orders(session)
 
     await _activate_license(tenant_id)
     await _generate_qr_pack(tenant_id)
-    # TODO: sample orders, coupons and referral code
+    _create_referral_code(tenant_id)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- extend pilot seeding to add demo coupons, sample orders, and referral code

## Testing
- `python -m py_compile scripts/seed_pilot.py`
- `pytest scripts/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b2908630b4832a9da25c5d33e5c590