### PR TITLE
fix(security): wire CSP nonces across UI + sanitize HTML content

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -30,10 +30,12 @@ from fastapi import (
     WebSocketDisconnect,
     status,
 )
+
 # Removing unused FileResponse
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
+
 
 class _LoopPolicy(asyncio.DefaultEventLoopPolicy):
     def get_event_loop(self):
@@ -216,7 +218,6 @@ from .routes_whatsapp_status import router as whatsapp_status_router
 from .services import notifications
 from .utils import PrepTimeTracker
 from .utils.responses import err, ok
-
 
 sys.modules.setdefault("db", app_db)
 sys.modules.setdefault("domain", app_domain)

--- a/api/app/routes_guest_menu.py
+++ b/api/app/routes_guest_menu.py
@@ -16,6 +16,7 @@ from config import get_settings
 from .db.replica import read_only
 from .i18n import get_msg, resolve_lang
 from .menu.dietary import filter_items
+from .middlewares.sanitize import sanitize_html
 from .repos_sqlalchemy.menu_repo_sql import MenuRepoSQL
 from .utils.i18n import get_text
 from .utils.responses import ok
@@ -73,9 +74,8 @@ async def fetch_menu(
     for item in items:
         item["name"] = get_text(item.get("name"), lang, item.get("name_i18n"))
         if item.get("description") or item.get("desc_i18n"):
-            item["description"] = get_text(
-                item.get("description"), lang, item.get("desc_i18n")
-            )
+            desc = get_text(item.get("description"), lang, item.get("desc_i18n"))
+            item["description"] = sanitize_html(desc)
     data["items"] = items
 
     resp_data = {**data, "items": items}

--- a/api/app/routes_staff_support.py
+++ b/api/app/routes_staff_support.py
@@ -9,6 +9,7 @@ from sqlalchemy import func, select
 
 from .auth import User, role_required
 from .db import SessionLocal
+from .middlewares.sanitize import sanitize_html
 from .models_master import SupportMessage, SupportTicket
 from .providers import email_stub
 from .utils.responses import ok
@@ -69,7 +70,7 @@ async def staff_get_ticket(
             {
                 "id": str(m.id),
                 "author": m.author,
-                "body": m.body,
+                "body": sanitize_html(m.body),
                 "attachments": m.attachments,
                 "internal": m.internal,
                 "created_at": m.created_at.isoformat() if m.created_at else None,
@@ -105,7 +106,7 @@ async def staff_reply_ticket(
         msg = SupportMessage(
             ticket_id=ticket.id,
             author=user.role,
-            body=payload.message,
+            body=sanitize_html(payload.message),
             attachments=payload.attachments,
             internal=payload.internal,
         )

--- a/api/tests/test_spa_nonce.py
+++ b/api/tests/test_spa_nonce.py
@@ -1,0 +1,26 @@
+import pathlib
+import re
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from starlette.staticfiles import StaticFiles  # noqa: E402
+
+from api.app.middleware.csp import CSPMiddleware  # noqa: E402
+
+
+def test_spa_index_nonce(tmp_path):
+    (tmp_path / "index.html").write_text('<script nonce="{{ csp_nonce }}"></script>')
+    app = FastAPI()
+    app.add_middleware(CSPMiddleware)
+    app.mount("/", StaticFiles(directory=tmp_path, html=True))
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    m = re.search(r'nonce="([^"]+)"', resp.text)
+    assert m
+    nonce = m.group(1)
+    assert f"nonce-{nonce}" in resp.headers["content-security-policy"]
+    assert "{{ csp_nonce }}" not in resp.text

--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" nonce="{{ csp_nonce }}" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -18,6 +18,7 @@
     "@neo/ui": "workspace:*",
     "@neo/utils": "workspace:*",
     "@tanstack/react-query": "^5.40.1",
+    "dompurify": "^3.2.6",
     "i18next": "^23.8.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -30,6 +31,9 @@
   },
   "devDependencies": {
     "@neo/config": "workspace:*",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
@@ -37,9 +41,6 @@
     "typescript": "^5.0.0",
     "vite": "^5.1.4",
     "vitest": "^1.3.0",
-    "@testing-library/react": "^14.0.0",
-    "@testing-library/user-event": "^14.4.3",
-    "@testing-library/jest-dom": "^6.1.5",
     "workbox-precaching": "^7.0.0",
     "workbox-routing": "^7.0.0"
   }

--- a/apps/admin/src/pages/Support.tsx
+++ b/apps/admin/src/pages/Support.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import DOMPurify from 'dompurify';
 import { collectDiagnostics } from '../diagnostics';
 
 const secretRe = /(bearer|token|authorization)[\s=]+[A-Za-z0-9\._-]+|\b(utr|upi|card)\b\s*[A-Za-z0-9\._-]*/gi;
@@ -129,14 +130,16 @@ export function Support() {
             {faqs.length === 0 ? (
               <p>Loading...</p>
             ) : (
-              <div
-                dangerouslySetInnerHTML={{
-                  __html: faqs[selected]?.content
-                    .replace(/^# (.*$)/gim, '<h1>$1</h1>')
-                    .replace(/^## (.*$)/gim, '<h2>$1</h2>')
-                    .replace(/\n/g, '<br/>'),
-                }}
-              />
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: DOMPurify.sanitize(
+                      faqs[selected]?.content
+                        .replace(/^# (.*$)/gim, '<h1>$1</h1>')
+                        .replace(/^## (.*$)/gim, '<h2>$1</h2>')
+                        .replace(/\n/g, '<br/>') || ''
+                    ),
+                  }}
+                />
             )}
           </div>
         </div>
@@ -185,11 +188,16 @@ export function Support() {
               </button>
               <h3>{current.subject}</h3>
               <ul>
-                {current.messages.map((m: any) => (
-                  <li key={m.id}>
-                    <b>{m.author}:</b> {m.body}
-                  </li>
-                ))}
+                  {current.messages.map((m: any) => (
+                    <li key={m.id}>
+                      <b>{m.author}:</b>{' '}
+                      <span
+                        dangerouslySetInnerHTML={{
+                          __html: DOMPurify.sanitize(m.body || ''),
+                        }}
+                      />
+                    </li>
+                  ))}
               </ul>
               <textarea
                 placeholder="Reply"

--- a/apps/admin/src/pages/SupportStaff.tsx
+++ b/apps/admin/src/pages/SupportStaff.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, ChangeEvent } from 'react';
+import DOMPurify from 'dompurify';
 
 interface Ticket {
   id: string;
@@ -171,12 +172,17 @@ export function SupportStaff() {
           <button onClick={close}>Close</button>
           <button onClick={reopen}>Reopen</button>
           <ul className="my-2 space-y-1">
-            {current.messages.map((m: Message) => (
-              <li key={m.id}>
-                <b>{m.author}:</b> {m.body}{' '}
-                {m.internal ? '(internal)' : ''}
-              </li>
-            ))}
+              {current.messages.map((m: Message) => (
+                <li key={m.id}>
+                  <b>{m.author}:</b>{' '}
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: DOMPurify.sanitize(m.body || ''),
+                    }}
+                  />{' '}
+                  {m.internal ? '(internal)' : ''}
+                </li>
+              ))}
           </ul>
           <textarea
             className="w-full border"

--- a/apps/guest/index.html
+++ b/apps/guest/index.html
@@ -25,22 +25,14 @@
         as="style"
         href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
       />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
-      media="print"
-      onload="this.media='all'"
-    />
-    <noscript>
       <link
         rel="stylesheet"
         href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
       />
-    </noscript>
     <title>Guest</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" nonce="{{ csp_nonce }}" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/kds/index.html
+++ b/apps/kds/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" nonce="{{ csp_nonce }}" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.40.1
         version: 5.85.5(react@18.3.1)
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.2.6
       i18next:
         specifier: ^23.8.2
         version: 23.16.8
@@ -2390,6 +2393,9 @@ packages:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
     deprecated: Use your platform's native DOMException instead
+
+  dompurify@3.2.6:
+    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -6369,6 +6375,10 @@ snapshots:
   domexception@4.0.0:
     dependencies:
       webidl-conversions: 7.0.0
+
+  dompurify@3.2.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add CSP nonce placeholders to SPA entrypoints
- sanitize support messages and menu item descriptions on server and client
- replace CSP nonce tokens in HTML at response time and test it

## Testing
- `pre-commit run --files api/app/main.py api/app/middleware/csp.py api/tests/test_spa_nonce.py api/app/routes_support.py api/app/routes_staff_support.py api/app/routes_guest_menu.py apps/guest/index.html apps/admin/index.html apps/kds/index.html apps/admin/package.json pnpm-lock.yaml apps/admin/src/pages/Support.tsx apps/admin/src/pages/SupportStaff.tsx`
- `pnpm -F @neo/admin test tests/support.ui.spec.tsx tests/support.staff.spec.tsx`
- `pytest api/tests/test_support_tickets.py::test_ticket_creation_redaction api/tests/test_support_tickets.py::test_listing_and_reply_updates api/tests/test_spa_nonce.py api/tests/test_security_headers.py::test_csp_header_blocks_inline`


------
https://chatgpt.com/codex/tasks/task_e_68b29090740c832a8af5abdaaf99b46c