### PR TITLE
fix: make dunning scheduler importable

### DIFF
--- a/scripts/dunning_scheduler.py
+++ b/scripts/dunning_scheduler.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from datetime import date
 from pathlib import Path
 import os
+import sys
+
+# Ensure `api` package is importable when running as a standalone script
+BASE_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(BASE_DIR))
 
 from api.app.dunning import Tenant, schedule_dunning
 from api.app.main import TENANTS


### PR DESCRIPTION
## Summary
- ensure dunning scheduler can import api package by appending repo root to sys.path

## Testing
- `python scripts/dunning_scheduler.py`
- `pytest -q` *(fails: import file mismatch in tests/test_alembic_env.py etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b29b1d59b4832aa22b3d407b48013b