### PR TITLE
Gracefully skip backup smoke without env vars

### DIFF
--- a/deploy/BACKUP_RESTORE.md
+++ b/deploy/BACKUP_RESTORE.md
@@ -97,7 +97,8 @@ primary database, encrypting the SQL with `age`, restoring it into a temporary
 Postgres database, and running a basic tenant count query. It reports the
 encrypted size, timings, and row count. The `backup-smoke` GitHub workflow runs
 this weekly against the staging cluster and posts a summary to the workflow
-run.
+run. If the required environment variables are missing, the script exits
+without error and prints a skip message.
 
 To run the script manually, set `POSTGRES_URL`, `BACKUP_PUBLIC_KEY`, and
 `BACKUP_PRIVATE_KEY` in the environment and invoke:

--- a/scripts/backup_smoke.sh
+++ b/scripts/backup_smoke.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-: "${POSTGRES_URL:?POSTGRES_URL is required}"
-: "${BACKUP_PUBLIC_KEY:?BACKUP_PUBLIC_KEY is required}"
-: "${BACKUP_PRIVATE_KEY:?BACKUP_PRIVATE_KEY is required}"
+# Skip when required env vars are missing.
+if [[ -z "${POSTGRES_URL:-}" || -z "${BACKUP_PUBLIC_KEY:-}" || -z "${BACKUP_PRIVATE_KEY:-}" ]]; then
+    echo "skipping backup smoke: POSTGRES_URL, BACKUP_PUBLIC_KEY, and BACKUP_PRIVATE_KEY are required" >&2
+    exit 0
+fi
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT


### PR DESCRIPTION
## Summary
- avoid failing backup smoke script when env vars missing
- document backup smoke skip behavior

## Testing
- `pre-commit run --files scripts/backup_smoke.sh deploy/BACKUP_RESTORE.md`
- `bash scripts/backup_smoke.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b29afc0adc832ab4eeabcbdf84d658