### PR TITLE
Fix secret reference in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           git push origin HEAD:deploy --force
   deploy-staging:
     needs: build-and-push
-    if: ${{ secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    if: ${{ env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -99,7 +99,7 @@ jobs:
 
   deploy-prod:
     needs: manual-approval
-    if: ${{ secrets.KUBE_CONFIG_PROD != '' && secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    if: ${{ env.KUBE_CONFIG_PROD != '' && env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: prod
     env:


### PR DESCRIPTION
## Summary
- use `env` context in deploy workflow conditions to safely check kube configs

## Testing
- `pre-commit run --files .github/workflows/deploy.yml`
- `pytest` *(fails: 7 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a2656fc4832a86b6bf089e2f2c0d