### PR TITLE
fix: configure zap baseline target

### DIFF
--- a/.github/workflows/zap_baseline.yml
+++ b/.github/workflows/zap_baseline.yml
@@ -10,11 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ZAP Baseline Scan
+        if: ${{ secrets.STAGING_URL != '' }}
         uses: zaproxy/action-baseline@v0.14.0
         with:
           target: ${{ secrets.STAGING_URL }}
-          allowlist: |
-            /auth
-            /callback
-          cmd_options: '-r zap_report.html'
+          cmd_options: '--allowlist /auth --allowlist /callback -r zap_report.html'
           artifact_name: zap-baseline-report


### PR DESCRIPTION
## Summary
- Skip ZAP baseline when `STAGING_URL` secret is missing
- Pass allowlist paths via `cmd_options` for ZAP baseline

## Testing
- `pre-commit run --files .github/workflows/zap_baseline.yml`
- `pytest` *(fails: 7 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a3ac7948832aa718855cda13b1c7