### PR TITLE
fix: resolve flag imports and export conflict

### DIFF
--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -8,7 +8,8 @@
     "paths": {
       "@neo/api": ["../../packages/api/src"],
       "@neo/ui": ["../../packages/ui/src"],
-      "@neo/utils": ["../../packages/utils/src"]
+      "@neo/utils": ["../../packages/utils/src"],
+      "@neo/flags": ["../../packages/flags/src"]
     }
   }
 }

--- a/apps/guest/tsconfig.json
+++ b/apps/guest/tsconfig.json
@@ -8,7 +8,8 @@
     "paths": {
       "@neo/utils": ["../../packages/utils/src"],
       "@neo/ui": ["../../packages/ui/src"],
-      "@neo/api": ["../../packages/api/src"]
+      "@neo/api": ["../../packages/api/src"],
+      "@neo/flags": ["../../packages/flags/src"]
     }
   }
 }

--- a/apps/kds/tsconfig.json
+++ b/apps/kds/tsconfig.json
@@ -7,7 +7,8 @@
     "paths": {
       "@neo/api": ["../../packages/api/src"],
       "@neo/ui": ["../../packages/ui/src"],
-      "@neo/utils": ["../../packages/utils/src"]
+      "@neo/utils": ["../../packages/utils/src"],
+      "@neo/flags": ["../../packages/flags/src"]
     },
     "resolveJsonModule": true
   }

--- a/packages/ui/src/icons/index.ts
+++ b/packages/ui/src/icons/index.ts
@@ -1,1 +1,1 @@
-export * from 'lucide-react';
+export { Flag as FlagIcon, ShoppingCart, Utensils } from 'lucide-react';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -6,7 +6,8 @@
     "baseUrl": ".",
     "paths": {
       "@neo/utils": ["../utils/src"],
-      "@neo/api": ["../api/src"]
+      "@neo/api": ["../api/src"],
+      "@neo/flags": ["../flags/src"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `@neo/flags` path aliases to UI and app tsconfigs
- export specific lucide icons and alias `FlagIcon` to avoid naming collision

## Testing
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a5a78e30832aa494942f6e57d8e4