### PR TITLE
fix: validate secrets in workflow

### DIFF
--- a/.github/workflows/synthetic_monitor.yml
+++ b/.github/workflows/synthetic_monitor.yml
@@ -15,10 +15,10 @@ jobs:
       SYN_TABLE_CODE: ${{ secrets.SYN_TABLE_CODE_STAGING }}
       AUTH_TOKEN: ${{ secrets.AUTH_TOKEN_STAGING }}
     if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
-            env.API_BASE_URL != '' &&
-            env.SYN_TENANT_ID != '' &&
-            env.SYN_TABLE_CODE != '' &&
-            env.AUTH_TOKEN != '' }}
+            secrets.API_BASE_URL_STAGING != '' &&
+            secrets.SYN_TENANT_ID_STAGING != '' &&
+            secrets.SYN_TABLE_CODE_STAGING != '' &&
+            secrets.AUTH_TOKEN_STAGING != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -113,11 +113,11 @@ jobs:
     if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
             github.ref == 'refs/heads/main' &&
             !github.event.pull_request.head.repo.fork &&
-            env.API_BASE_URL != '' &&
-            env.SYN_TENANT_ID != '' &&
-            env.SYN_TABLE_CODE != '' &&
-            env.AUTH_TOKEN != '' &&
-            env.SYN_ENABLED_PROD != '' }}
+            secrets.API_BASE_URL != '' &&
+            secrets.SYN_TENANT_ID != '' &&
+            secrets.SYN_TABLE_CODE != '' &&
+            secrets.AUTH_TOKEN != '' &&
+            secrets.SYN_ENABLED_PROD != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- reference secrets directly in synthetic monitor job conditions to avoid invalid env context

## Testing
- `pre-commit run --files .github/workflows/synthetic_monitor.yml`
- `pytest scripts/tests/test_emit_test_alert.py::test_emit_alert_success -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2a839d534832a8912347f40db9849