### PR TITLE
ci: use secrets for kube config checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           git push origin HEAD:deploy --force
   deploy-staging:
     needs: build-and-push
-    if: ${{ env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    if: ${{ secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -99,7 +99,7 @@ jobs:
 
   deploy-prod:
     needs: manual-approval
-    if: ${{ env.KUBE_CONFIG_PROD != '' && env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    if: ${{ secrets.KUBE_CONFIG_PROD != '' && secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: prod
     env:


### PR DESCRIPTION
## Summary
- use secrets variables in deploy workflow conditions

## Testing
- `pre-commit run --files .github/workflows/deploy.yml`
- `gh workflow validate .github/workflows/deploy.yml` *(fails: command not found)*
- `act -n` *(fails: command not found)*
- `pytest` *(fails: 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a841c760832a9a71bcaec8a74147