### PR TITLE
feat: configure Playwright base URL

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests',
   use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
     headless: true,
     video: 'retain-on-failure',
     trace: 'retain-on-failure',


### PR DESCRIPTION
## Summary
- allow Playwright tests to use BASE_URL env or localhost:3000

## Testing
- `curl -I http://localhost:5173/guest/menu`
- `curl -I http://localhost:5174/kds/expo`
- `curl -I http://localhost:5175/admin/dashboard`
- `scripts/smoke_e2e.sh` *(fails: SyntaxError: Unexpected end of JSON input; visual regression and Lighthouse pending)*
- `gh auth login --with-token <<<"$GITHUB_TOKEN"` *(fails: device authorization code provided, login aborted)*
- `gh auth status` *(fails: not logged in)*
- `gh workflow run pilot_checklist.yml` *(fails: not logged in)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ab38a974832a8c4cfc84b73e2b02