### PR TITLE
chore: use env refs in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           git push origin HEAD:deploy --force
   deploy-staging:
     needs: build-and-push
-    if: ${{ secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    if: ${{ env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: staging
     env:
@@ -99,7 +99,7 @@ jobs:
 
   deploy-prod:
     needs: manual-approval
-    if: ${{ secrets.KUBE_CONFIG_PROD != '' && secrets.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+    if: ${{ env.KUBE_CONFIG_PROD != '' && env.KUBE_CONFIG_STAGING != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     runs-on: ubuntu-latest
     environment: prod
     env:


### PR DESCRIPTION
## Summary
- use `env.*` variables for deploy gating conditions

## Testing
- `npm test` *(fails: apps/guest test: Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2acce36bc832a83737b85c7457188