### PR TITLE
Use env staging URL in ZAP baseline workflow

### DIFF
--- a/.github/workflows/zap_baseline.yml
+++ b/.github/workflows/zap_baseline.yml
@@ -8,11 +8,13 @@ on:
 jobs:
   zap:
     runs-on: ubuntu-latest
+    env:
+      STAGING_URL: ${{ secrets.STAGING_URL }}
     steps:
       - name: ZAP Baseline Scan
-        if: ${{ secrets.STAGING_URL != '' }}
+        if: ${{ env.STAGING_URL != '' }}
         uses: zaproxy/action-baseline@v0.14.0
         with:
-          target: ${{ secrets.STAGING_URL }}
+          target: ${{ env.STAGING_URL }}
           cmd_options: '--allowlist /auth --allowlist /callback -r zap_report.html'
           artifact_name: zap-baseline-report


### PR DESCRIPTION
## Summary
- set `STAGING_URL` from secrets in ZAP baseline workflow
- reference `env.STAGING_URL` for conditional and target

## Testing
- `pre-commit run --files .github/workflows/zap_baseline.yml`
- `pytest -q` *(fails: import file mismatch between api/tests and tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b2033928832a98d1cc61a38a9a35