### PR TITLE
Use env vars in synthetic monitor job conditions

### DIFF
--- a/.github/workflows/synthetic_monitor.yml
+++ b/.github/workflows/synthetic_monitor.yml
@@ -15,10 +15,10 @@ jobs:
       SYN_TABLE_CODE: ${{ secrets.SYN_TABLE_CODE_STAGING }}
       AUTH_TOKEN: ${{ secrets.AUTH_TOKEN_STAGING }}
     if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
-            secrets.API_BASE_URL_STAGING != '' &&
-            secrets.SYN_TENANT_ID_STAGING != '' &&
-            secrets.SYN_TABLE_CODE_STAGING != '' &&
-            secrets.AUTH_TOKEN_STAGING != '' }}
+            env.API_BASE_URL != '' &&
+            env.SYN_TENANT_ID != '' &&
+            env.SYN_TABLE_CODE != '' &&
+            env.AUTH_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -113,11 +113,11 @@ jobs:
     if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
             github.ref == 'refs/heads/main' &&
             !github.event.pull_request.head.repo.fork &&
-            secrets.API_BASE_URL != '' &&
-            secrets.SYN_TENANT_ID != '' &&
-            secrets.SYN_TABLE_CODE != '' &&
-            secrets.AUTH_TOKEN != '' &&
-            secrets.SYN_ENABLED_PROD != '' }}
+            env.API_BASE_URL != '' &&
+            env.SYN_TENANT_ID != '' &&
+            env.SYN_TABLE_CODE != '' &&
+            env.AUTH_TOKEN != '' &&
+            env.SYN_ENABLED_PROD != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- reference `env.*` variables instead of `secrets.*` in synthetic monitor staging job condition
- reference `env.*` variables instead of `secrets.*` in synthetic monitor prod job condition

## Testing
- `pre-commit run --files .github/workflows/synthetic_monitor.yml`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2b15cd0d8832a86970222d8267766