### PR TITLE
feat: enhance owner insights workflow

### DIFF
--- a/.github/workflows/owner_insights.yml
+++ b/.github/workflows/owner_insights.yml
@@ -2,7 +2,7 @@ name: Owner insights
 
 on:
   schedule:
-    - cron: '30 3 * * 1'
+    - cron: '0 3 * * 1'
   workflow_dispatch:
 
 jobs:
@@ -14,5 +14,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Run weekly owner insights
+        env:
+          OWNER_INSIGHTS_EMAIL: owner@sandbox.example.com
         run: |
-          python scripts/owner_insights.py --week_start $(date -u -d 'last monday' +%F) --tenant all
+          python scripts/owner_insights.py --week_start last_mon --tenants demo


### PR DESCRIPTION
## Summary
- schedule owner insights workflow weekly on Mondays at 03:00 UTC
- pass sandbox email and demo tenant to owner insights script
- support multiple tenants and automatic last Monday calculation in owner insights CLI

## Testing
- `pytest tests/test_owner_insights.py tests/test_owner_insights_email.py`
- `ruff check scripts/owner_insights.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2ce77b2a8832aa23d9eb108b0f157