### PR TITLE
fix: remove secrets from workflow conditions

### DIFF
--- a/.github/workflows/synthetic_monitor.yml
+++ b/.github/workflows/synthetic_monitor.yml
@@ -14,11 +14,7 @@ jobs:
       SYN_TENANT_ID: ${{ secrets.SYN_TENANT_ID_STAGING }}
       SYN_TABLE_CODE: ${{ secrets.SYN_TABLE_CODE_STAGING }}
       AUTH_TOKEN: ${{ secrets.AUTH_TOKEN_STAGING }}
-    if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
-            secrets.API_BASE_URL_STAGING != '' &&
-            secrets.SYN_TENANT_ID_STAGING != '' &&
-            secrets.SYN_TABLE_CODE_STAGING != '' &&
-            secrets.AUTH_TOKEN_STAGING != '' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -110,14 +106,7 @@ jobs:
       SYN_TABLE_CODE: ${{ secrets.SYN_TABLE_CODE }}
       AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
       SYN_ENABLED_PROD: ${{ secrets.SYN_ENABLED_PROD }}
-    if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
-            github.ref == 'refs/heads/main' &&
-            !github.event.pull_request.head.repo.fork &&
-            secrets.API_BASE_URL != '' &&
-            secrets.SYN_TENANT_ID != '' &&
-            secrets.SYN_TABLE_CODE != '' &&
-            secrets.AUTH_TOKEN != '' &&
-            secrets.SYN_ENABLED_PROD != '' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.ref == 'refs/heads/main' && !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -6,7 +6,7 @@
         "http://localhost:5174/",
         "http://localhost:5175/"
       ],
-      "startServerCommand": "pnpm --filter @neo/guest build && pnpm --filter @neo/kds build && pnpm --filter @neo/admin build && pnpm --filter @neo/guest preview --port 5173 & pnpm --filter @neo/kds preview --port 5174 & pnpm --filter @neo/admin preview --port 5175 & wait",
+      "startServerCommand": "pnpm --filter @neo/guest build && pnpm --filter @neo/kds build && pnpm --filter @neo/admin build && (pnpm --filter @neo/guest preview --port 5173 & pnpm --filter @neo/kds preview --port 5174 & pnpm --filter @neo/admin preview --port 5175 & wait)",
       "startServerReadyPattern": "http://localhost:5175/",
       "numberOfRuns": 1,
       "output": [

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -6,7 +6,7 @@
         "http://localhost:5174/",
         "http://localhost:5175/"
       ],
-      "startServerCommand": "pnpm --filter @neo/guest build && pnpm --filter @neo/kds build && pnpm --filter @neo/admin build && (pnpm --filter @neo/guest preview --port 5173 & pnpm --filter @neo/kds preview --port 5174 & pnpm --filter @neo/admin preview --port 5175 & wait)",
+      "startServerCommand": "pnpm --filter @neo/guest build && pnpm --filter @neo/kds build && pnpm --filter @neo/admin build && (pnpm --filter @neo/guest preview --port 5173 --strictPort </dev/null & pnpm --filter @neo/kds preview --port 5174 --strictPort </dev/null & pnpm --filter @neo/admin preview --port 5175 --strictPort </dev/null & wait)",
       "startServerReadyPattern": "http://localhost:5175/",
       "numberOfRuns": 1,
       "output": [


### PR DESCRIPTION
## Summary
- simplify staging job condition to only check event type
- limit prod job run condition to event and branch, relying on Guard step

## Testing
- `pre-commit run --files .github/workflows/synthetic_monitor.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b2e312ba98832a82576826b8b2b0f0