### PR TITLE
fix: handle missing redis on startup

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional
 
+import redis as redis_sync
 import redis.asyncio as redis
 from fastapi import (
     Depends,
@@ -275,9 +276,8 @@ else:
 init_tracing(app)
 asyncio.set_event_loop(asyncio.new_event_loop())
 try:
-    redis_client = from_url(settings.redis_url, decode_responses=True)
-    asyncio.get_event_loop().run_until_complete(redis_client.ping())
-    app.state.redis = redis_client
+    redis_sync.Redis.from_url(settings.redis_url).ping()
+    app.state.redis = from_url(settings.redis_url, decode_responses=True)
 except Exception:  # pragma: no cover - fallback when Redis is unreachable
     import fakeredis.aioredis
 


### PR DESCRIPTION
## Summary
- ensure startup falls back cleanly to fakeredis when Redis is unavailable

## Testing
- `pre-commit run --files api/app/main.py`
- `pytest` *(fails: KeyboardInterrupt)*
- `python start_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68b549260aac832ab59a2d907aff6e39