### PR TITLE
feat(api): add stats endpoint

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -202,6 +202,7 @@ from .routes_staff import router as staff_router
 from .routes_staff_support import router as staff_support_router
 from .routes_status import router as status_router
 from .routes_status_json import router as status_json_router
+from .routes_stats import router as stats_router
 from .routes_support import router as support_router
 from .routes_support_bundle import router as support_bundle_router
 from .routes_support_console import router as support_console_router
@@ -996,6 +997,7 @@ app.include_router(time_skew_router)
 app.include_router(pwa_version_router)
 app.include_router(status_json_router)
 app.include_router(status_router)
+app.include_router(stats_router)
 app.include_router(version_router)
 app.include_router(ready_router)
 app.include_router(eta_router)

--- a/api/app/routes_stats.py
+++ b/api/app/routes_stats.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Expose simple aggregate metrics via /api/stats."""
+
+from datetime import datetime
+
+from fastapi import APIRouter
+from sqlalchemy import func
+
+from .db import SessionLocal
+from .models_tenant import Staff
+
+router = APIRouter()
+
+_START_TIME = datetime.utcnow()
+
+
+@router.get("/api/stats")
+async def get_stats() -> dict[str, int]:
+    """Return basic uptime and user metrics."""
+    uptime = int((datetime.utcnow() - _START_TIME).total_seconds())
+    with SessionLocal() as session:
+        staff_count = session.execute(func.count(Staff.id)).scalar() or 0
+    return {"uptime_s": uptime, "staff_count": staff_count}
+

--- a/apps/admin/src/pages/Health.tsx
+++ b/apps/admin/src/pages/Health.tsx
@@ -5,7 +5,7 @@ export function Health() {
   const [ok, setOk] = useState(false);
 
   useEffect(() => {
-    fetch(`${API_BASE}/status.json`)
+    fetch(`${API_BASE}/stats`)
       .then((r) => setOk(r.ok))
       .catch(() => setOk(false));
   }, []);

--- a/apps/guest/src/pages/Health.tsx
+++ b/apps/guest/src/pages/Health.tsx
@@ -7,7 +7,7 @@ export function Health() {
   const [sse, setSse] = useState<'pending' | 'ok' | 'unsupported'>('pending');
 
   useEffect(() => {
-    fetch(`${API_BASE}/status.json`)
+    fetch(`${API_BASE}/stats`)
       .then((r) => setOk(r.ok))
       .catch(() => setOk(false));
   }, []);

--- a/apps/kds/src/pages/Health.tsx
+++ b/apps/kds/src/pages/Health.tsx
@@ -5,7 +5,7 @@ export function Health() {
   const [ok, setOk] = useState(false);
 
   useEffect(() => {
-    fetch(`${API_BASE}/status.json`)
+    fetch(`${API_BASE}/stats`)
       .then((r) => setOk(r.ok))
       .catch(() => setOk(false));
   }, []);


### PR DESCRIPTION
## Summary
- add `/api/stats` endpoint exposing uptime and staff count
- include stats router in app and update health checks to call it

## Testing
- `python -m pytest` *(fails: KeyboardInterrupt: _workspace/neo/api/app/obs/queries.py:34_)*
- `pnpm --filter @neo/admin test` *(fails: Test Files 1 failed | 9 passed (10))*
- `pnpm --filter @neo/guest test`
- `pnpm --filter @neo/kds test`


------
https://chatgpt.com/codex/tasks/task_e_68b55c28d00c832a837663581478d8c4