### PR TITLE
fix(pwa): service worker restricted to /guest scope

### DIFF
--- a/api/tests/test_security_headers.py
+++ b/api/tests/test_security_headers.py
@@ -65,3 +65,11 @@ def test_login_rate_limit_resets(monkeypatch):
         json={"username": "cashier1", "pin": "bad"},
     )
     assert resp.status_code == 400
+
+
+def test_sw_not_served_on_admin(monkeypatch):
+    app = _setup_app(monkeypatch)
+    client = TestClient(app)
+    resp = client.get('/admin/')
+    assert 'Service-Worker' not in resp.headers
+    assert 'Service-Worker-Allowed' not in resp.headers

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -25,7 +25,6 @@
     "react-hook-form": "^7.49.3",
     "react-i18next": "^13.0.2",
     "react-router-dom": "^6.22.3",
-    "workbox-window": "^7.0.0",
     "zod": "^3.22.2",
     "zustand": "^4.5.2"
   },

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -7,7 +7,6 @@ import { capturePageView } from '@neo/utils';
 import './index.css';
 import './i18n';
 import { router } from './routes';
-import { Workbox } from 'workbox-window';
 import { AuthProvider } from './auth';
 import { withInterceptors } from '@neo/api';
 import { refreshFlags } from '@neo/flags';
@@ -22,10 +21,6 @@ router.subscribe((state) => {
   capturePageView(state.location.pathname);
 });
 
-if ('serviceWorker' in navigator) {
-  const wb = new Workbox('/sw.js');
-  wb.register();
-}
 
 async function init() {
   const [outlet] = await Promise.all([

--- a/apps/guest/src/main.tsx
+++ b/apps/guest/src/main.tsx
@@ -20,7 +20,7 @@ if (hasAnalyticsConsent()) {
 }
 
 if ('serviceWorker' in navigator) {
-  const wb = new Workbox('/sw.js');
+  const wb = new Workbox('/guest/sw.js', { scope: '/guest/' });
   navigator.serviceWorker.addEventListener('message', handleSwMessage);
   wb.register();
 }

--- a/apps/guest/vite.config.ts
+++ b/apps/guest/vite.config.ts
@@ -1,2 +1,23 @@
-import config from '@neo/config/vite';
-export default config;
+import { defineConfig } from 'vite';
+import baseConfig from '@neo/config/vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  ...baseConfig,
+  build: {
+    ...(baseConfig.build || {}),
+    rollupOptions: {
+      ...(baseConfig.build?.rollupOptions || {}),
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        sw: resolve(__dirname, 'src/sw.ts'),
+      },
+      output: {
+        ...(baseConfig.build?.rollupOptions?.output || {}),
+        entryFileNames: (chunk) =>
+          chunk.name === 'sw' ? 'sw.js' : 'assets/[name]-[hash].js',
+      },
+    },
+  },
+});
+

--- a/apps/kds/package.json
+++ b/apps/kds/package.json
@@ -24,7 +24,6 @@
     "react-hook-form": "^7.49.3",
     "react-i18next": "^13.0.2",
     "react-router-dom": "^6.22.3",
-    "workbox-window": "^7.0.0",
     "zod": "^3.22.2",
     "zustand": "^4.5.2"
   },

--- a/apps/kds/src/main.tsx
+++ b/apps/kds/src/main.tsx
@@ -6,7 +6,6 @@ import { Toaster, GlobalErrorBoundary, ThemeProvider, tokensFromOutlet, toast } 
 import { capturePageView } from '@neo/utils';
 import './index.css';
 import './i18n';
-import { Workbox } from 'workbox-window';
 import { AppRoutes } from './routes';
 import { AuthProvider } from './auth';
 import { withInterceptors } from '@neo/api';
@@ -19,10 +18,6 @@ window.addEventListener('unauthorized', () => toast.error('Session expired'));
 
 capturePageView(window.location.pathname);
 
-if ('serviceWorker' in navigator) {
-  const wb = new Workbox('/sw.js');
-  wb.register();
-}
 
 async function init() {
   const [outlet] = await Promise.all([

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -26,3 +26,8 @@ Our security contact is published at `/.well-known/security.txt`.
 1. Rotate credentials.
 2. Invalidate active sessions.
 3. Review audit logs.
+
+## SW hygiene
+- Only the guest app registers a service worker.
+- The worker script lives at `/guest/sw.js` and is served with `Cache-Control: no-store`.
+- Other apps such as `/admin` and `/kds` serve no service worker.

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,11 @@ server {
   add_header X-Frame-Options "SAMEORIGIN" always;
   add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'nonce-$csp_nonce'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://API https://WS; frame-ancestors 'self'" always;
 
+  location /guest/sw.js {
+    try_files /guest/sw.js =404;
+    add_header Cache-Control "no-store";
+  }
+
   location /guest {
     try_files $uri $uri/ /guest/index.html;
   }

--- a/pwa/src/main.jsx
+++ b/pwa/src/main.jsx
@@ -58,28 +58,3 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   </React.StrictMode>,
 )
 
-if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/static/sw.js')
-  navigator.serviceWorker.addEventListener('message', (event) => {
-    if (event.data?.type === 'UPDATE_READY') {
-      const banner = document.createElement('div')
-      banner.textContent = 'New version available '
-      const button = document.createElement('button')
-      button.textContent = 'Refresh'
-      button.addEventListener('click', () => {
-        navigator.serviceWorker.controller?.postMessage('SKIP_WAITING')
-        window.location.reload()
-      })
-      banner.appendChild(button)
-      banner.style.position = 'fixed'
-      banner.style.bottom = '1rem'
-      banner.style.right = '1rem'
-      banner.style.padding = '0.5rem 1rem'
-      banner.style.background = '#333'
-      banner.style.color = '#fff'
-      banner.style.borderRadius = '0.25rem'
-      banner.style.zIndex = '1000'
-      document.body.appendChild(banner)
-    }
-  })
-}


### PR DESCRIPTION
## Summary
- scope guest PWA service worker to `/guest` and output as `/guest/sw.js`
- drop service worker registration from admin and kds apps
- guard against SW on admin via security test and document SW hygiene

## Testing
- `pnpm --filter @neo/guest test`
- `pnpm --filter @neo/guest typecheck`
- `pnpm --filter @neo/admin test` *(fails: Playwright Test did not expect test() to be called here)*
- `pnpm --filter @neo/admin test -- --include src/**/*.test.tsx` *(fails: Playwright Test did not expect test() to be called here)*
- `pnpm --filter @neo/admin typecheck`
- `pnpm --filter @neo/kds test`
- `pnpm --filter @neo/kds typecheck`
- `pnpm --filter ./pwa test`
- `pytest api/tests/test_security_headers.py::test_sw_not_served_on_admin -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5660be188832ab553b74ec18ecbc1