### PR TITLE
test: relax ops summary breaker expectation

### DIFF
--- a/api/tests/test_admin_ops_summary.py
+++ b/api/tests/test_admin_ops_summary.py
@@ -60,5 +60,6 @@ def test_admin_ops_summary(tmp_path, monkeypatch):
     data = resp.json()["data"]
     assert data["uptime"] == "ok"
     assert round(data["webhook_success_rate"], 1) == 0.8
-    assert data["breaker_open_time"] >= 30
+    # Account for small delays between setting and reading the breaker TTL
+    assert data["breaker_open_time"] >= 29
     assert data["median_kot_prep_time"] == 30.0


### PR DESCRIPTION
## Summary
- allow small delay when calculating admin ops breaker open time

## Testing
- `pytest api/tests/test_admin_ops_summary.py::test_admin_ops_summary -q`


------
https://chatgpt.com/codex/tasks/task_e_68b56d01b6cc832abe843e3ad3f64b88