### PR TITLE
chore: update pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       react-router-dom:
         specifier: ^6.22.3
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      workbox-window:
-        specifier: ^7.0.0
-        version: 7.3.0
       zod:
         specifier: ^3.22.2
         version: 3.25.76
@@ -268,9 +265,6 @@ importers:
       react-router-dom:
         specifier: ^6.22.3
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      workbox-window:
-        specifier: ^7.0.0
-        version: 7.3.0
       zod:
         specifier: ^3.22.2
         version: 3.25.76


### PR DESCRIPTION
## Summary
- sync pnpm lockfile after removing workbox-window from admin

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm lint` *(fails: pwa linting issues)*
- `pnpm test` *(fails: apps/admin test failure)*
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b571637e30832a93f3839b69524428