### PR TITLE
Prevent duplicate gateway refund payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to this project will be documented in this file.
 - Fix YAML indentation in `flags_guard` workflow to resolve CI parsing error.
 - Reference `ASSETLINKS_HOST` secret via env in TWA workflow to fix invalid conditional.
 
+- Avoid duplicate refund payments by checking existing records and caching responses.
+
 - Correct sales register and GST summary exports to emit expected CSV headers and values.
 - Replace `/telemetry/error` fetch with SSR-safe `captureError` in the global error boundary.
 


### PR DESCRIPTION
## Summary
- cache idempotent POST responses as base64 to handle compressed payloads
- avoid duplicate gateway_refund payments by checking existing records and respecting Idempotency-Key
- test refund idempotency with different keys

## Testing
- `pytest api/tests/test_checkout_gateway.py::test_refund_duplicate_no_new_payment -q`
- `pytest api/tests/test_checkout_gateway.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b580ebd370832ab8a06fd72409f61a