### PR TITLE
Coerce order item IDs and validate order quantities

### DIFF
--- a/api/app/routes_counter.py
+++ b/api/app/routes_counter.py
@@ -6,7 +6,7 @@ import json
 from typing import AsyncGenerator, List
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from .auth import User, role_required
@@ -24,8 +24,21 @@ router_admin = APIRouter(prefix="/api/outlet/{tenant_id}/counters")
 
 
 class OrderLine(BaseModel):
-    item_id: str
+    item_id: int | str
     qty: int
+
+    @validator("item_id", pre=True)
+    def _coerce_item_id(cls, v: int | str) -> int:  # noqa: N805 - pydantic validator
+        try:
+            return int(v)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("item_id must be an integer") from exc
+
+    @validator("qty")
+    def _validate_qty(cls, v: int) -> int:  # noqa: N805 - pydantic validator
+        if v <= 0:
+            raise ValueError("qty must be greater than 0")
+        return v
 
 
 class OrderPayload(BaseModel):
@@ -101,7 +114,7 @@ async def create_order(
     tenant_id: str = Depends(get_tenant_id),
     session: AsyncSession = Depends(get_tenant_session),
 ) -> dict:
-    lines = [line.model_dump() for line in payload.items]
+    lines = [{"item_id": line.item_id, "qty": line.qty} for line in payload.items]
     try:
         order_id = await counter_orders_repo_sql.create_order(
             session, counter_token, lines

--- a/api/app/routes_guest_hotel.py
+++ b/api/app/routes_guest_hotel.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 
 from fastapi import APIRouter, Header, HTTPException, Request, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from sqlalchemy import func
 
 from .db import SessionLocal
@@ -27,8 +27,21 @@ router = APIRouter(prefix="/h")
 
 
 class OrderLine(BaseModel):
-    item_id: int
+    item_id: int | str
     qty: int
+
+    @validator("item_id", pre=True)
+    def _coerce_item_id(cls, v: int | str) -> int:  # noqa: N805 - pydantic validator
+        try:
+            return int(v)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("item_id must be an integer") from exc
+
+    @validator("qty")
+    def _validate_qty(cls, v: int) -> int:  # noqa: N805 - pydantic validator
+        if v <= 0:
+            raise ValueError("qty must be greater than 0")
+        return v
 
 
 class OrderPayload(BaseModel):
@@ -100,7 +113,7 @@ def fetch_menu(
 
 @router.post("/{room_token}/order")
 def create_order(room_token: str, payload: OrderPayload) -> dict:
-    lines = [line.model_dump() for line in payload.items]
+    lines = [{"item_id": line.item_id, "qty": line.qty} for line in payload.items]
     with SessionLocal() as session:
         room = session.query(Room).filter_by(code=room_token).one_or_none()
         if room is None:

--- a/api/app/routes_guest_order.py
+++ b/api/app/routes_guest_order.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import AsyncGenerator, List
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from .db import SessionLocal
@@ -26,8 +26,21 @@ router = APIRouter(prefix="/g")
 class OrderLine(BaseModel):
     """Single line item for a guest order."""
 
-    item_id: str
+    item_id: int | str
     qty: int
+
+    @validator("item_id", pre=True)
+    def _coerce_item_id(cls, v: int | str) -> int:  # noqa: N805 - pydantic validator
+        try:
+            return int(v)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("item_id must be an integer") from exc
+
+    @validator("qty")
+    def _validate_qty(cls, v: int) -> int:  # noqa: N805 - pydantic validator
+        if v <= 0:
+            raise ValueError("qty must be greater than 0")
+        return v
 
 
 class OrderPayload(BaseModel):
@@ -59,7 +72,7 @@ async def create_guest_order(
 ) -> dict:
     """Create a new order for ``table_token`` within the tenant context."""
     await abuse_guard.guard(request, tenant_id, request.app.state.redis)
-    lines = [line.model_dump() for line in payload.items]
+    lines = [{"item_id": line.item_id, "qty": line.qty} for line in payload.items]
     try:
         order_id = await orders_repo_sql.create_order(session, table_token, lines)
     except HTTPException as exc:


### PR DESCRIPTION
## Summary
- accept string or integer item identifiers in order line models
- ensure item IDs are coerced to integers and quantities are positive
- pass normalized IDs to repository calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b580e65eb4832ab1783f6c69dacd1b