### PR TITLE
refactor: send mixpanel events via raw content

### DIFF
--- a/api/app/analytics/posthog.py
+++ b/api/app/analytics/posthog.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 from typing import Any, Dict, List
+from urllib.parse import urlencode
 
 import httpx
 
@@ -102,8 +103,13 @@ async def _send(batch: List[Dict[str, Any]]) -> None:
                             },
                         }
                         data = base64.b64encode(json.dumps(payload).encode()).decode()
+                        encoded_bytes = urlencode({"data": data}).encode()
                         await client.post(
-                            "https://api.mixpanel.com/track", data={"data": data}
+                            "https://api.mixpanel.com/track",
+                            content=encoded_bytes,
+                            headers={
+                                "Content-Type": "application/x-www-form-urlencoded"
+                            },
                         )
             break
         except httpx.HTTPError as exc:  # network issue


### PR DESCRIPTION
## Summary
- send mixpanel analytics events via `content=` with form-encoded bytes
- audit httpx calls for raw uploads; none required changes

## Testing
- `pre-commit run --files api/app/analytics/posthog.py`
- `pytest api/tests/test_analytics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b580f752f4832a80b51aef107cffca