### PR TITLE
Handle PIN rate-limit separately and use standard 429 response

### DIFF
--- a/api/tests/test_pin_rate_limit.py
+++ b/api/tests/test_pin_rate_limit.py
@@ -1,0 +1,34 @@
+import asyncio
+import time
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+
+from api.app.main import app
+from api.app.security import pin_lockout
+
+
+def test_pin_rate_limit_does_not_block_ip():
+    app.state.redis = fakeredis.aioredis.FakeRedis()
+    redis = app.state.redis
+    ip = "testclient"
+    key = f"ratelimit:/login/pin:-:{ip}"
+    now = int(time.time())
+    for i in range(10):
+        asyncio.run(redis.zadd(key, {str(i): now}))
+    asyncio.run(redis.expire(key, 300))
+
+    client = TestClient(app)
+    payload = {"username": "cashier1", "pin": "1234"}
+    res1 = client.post("/login/pin", json=payload)
+    assert res1.status_code == 429
+    assert "Retry-After" in res1.headers
+
+    res2 = client.post("/login/pin", json=payload)
+    assert res2.status_code == 429
+
+    locked = asyncio.run(pin_lockout.is_locked(redis, "demo", "cashier1", ip))
+    assert locked is False
+    fail_key = f"pin:fail:demo:cashier1:{ip}"
+    assert asyncio.run(redis.get(fail_key)) is None
+


### PR DESCRIPTION
## Summary
- use shared `rate_limited` helper for auth rate limiting middleware and include `Retry-After`
- ignore 429 responses in PIN security to avoid counting them as failed attempts
- add regression test for PIN login rate limiting

## Testing
- `pytest tests/test_pin_security.py api/tests/test_exports_rate_limit.py api/tests/test_pin_rate_limit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b580f2a4a0832a88a334e0ecb67386