### PR TITLE
Route /health through security middleware

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -83,7 +83,7 @@ template_globals = {"build_renew_url": build_renew_url}
 
 from .menu import router as menu_router
 from .middleware.cors import CORSMiddleware
-from .middleware.csp import CSPMiddleware
+from .middlewares.csp import CSPMiddleware
 from .middleware.rate_limit import SlidingWindowRateLimitMiddleware
 from .middlewares import (
     APIKeyAuthMiddleware,

--- a/api/tests/test_security_headers.py
+++ b/api/tests/test_security_headers.py
@@ -10,7 +10,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
 
 def _setup_app(monkeypatch):
-    monkeypatch.setenv("ORIGINS", "https://allowed.com")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://allowed.com")
     monkeypatch.setenv("RATE_LIMIT_LOGIN", "2/1s")
     monkeypatch.setenv("RATE_LIMIT_REFRESH", "60/5m")
     monkeypatch.setenv("DB_URL", "postgresql://localhost/test")
@@ -35,6 +35,13 @@ def test_csp_header_blocks_inline(monkeypatch):
         if part.strip().startswith("script-src"):
             assert "'unsafe-inline'" not in part
             break
+    assert resp.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+    assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+    assert resp.headers.get("X-Frame-Options") == "SAMEORIGIN"
+    assert (
+        resp.headers.get("Permissions-Policy")
+        == "geolocation=(), microphone=(), camera=(), notifications=(self)"
+    )
 
 
 def test_cors_rejects_unknown_origin(monkeypatch):

--- a/api/tests/test_security_headers_guest.py
+++ b/api/tests/test_security_headers_guest.py
@@ -15,15 +15,24 @@ def test_guest_page_headers(monkeypatch):
     monkeypatch.setenv("SECRET_KEY", "x" * 32)
 
     import api.app.config.cors as cors
-
-    importlib.reload(cors)
+    import api.app.middleware.cors as cors_mw
+    import api.app.middlewares.csp as csp
     import api.app.middlewares.security as security
 
+    importlib.reload(cors)
+    importlib.reload(cors_mw)
+    importlib.reload(csp)
     importlib.reload(security)
+    CORSMiddleware = cors_mw.CORSMiddleware
+    CSPMiddleware = csp.CSPMiddleware
     SecurityMiddleware = security.SecurityMiddleware
 
     app = FastAPI()
     app.state.redis = fakeredis.aioredis.FakeRedis()
+    app.add_middleware(
+        CORSMiddleware, allowed_origins=["https://allowed.com"]
+    )
+    app.add_middleware(CSPMiddleware)
     app.add_middleware(SecurityMiddleware)
 
     @app.get("/g/test")


### PR DESCRIPTION
## Summary
- use consolidated CSP middleware so `/health` responses include security headers
- extend security header tests to verify Referrer-Policy, X-Frame-Options, etc.
- adjust guest header test to include CSP and CORS middleware

## Testing
- `pytest api/tests/test_security_headers.py -q`
- `pytest api/tests/test_security_headers_guest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b580f0fd38832ab708ca8853806edf