### PR TITLE
Add Referrer-Policy header via CSP middleware

### DIFF
--- a/api/app/middleware/csp.py
+++ b/api/app/middleware/csp.py
@@ -35,6 +35,9 @@ class CSPMiddleware(BaseHTTPMiddleware):
             "frame-ancestors 'self'"
         )
         response.headers.setdefault("Content-Security-Policy", csp)
+        response.headers.setdefault(
+            "Referrer-Policy", "strict-origin-when-cross-origin"
+        )
         if response.headers.get("content-type", "").startswith("text/html"):
             body = b"".join([chunk async for chunk in response.body_iterator])
             content = body.decode("utf-8").replace("{{ csp_nonce }}", nonce)

--- a/api/tests/test_security_headers.py
+++ b/api/tests/test_security_headers.py
@@ -11,6 +11,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
 def _setup_app(monkeypatch):
     monkeypatch.setenv("ORIGINS", "https://allowed.com")
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://allowed.com")
     monkeypatch.setenv("RATE_LIMIT_LOGIN", "2/1s")
     monkeypatch.setenv("RATE_LIMIT_REFRESH", "60/5m")
     monkeypatch.setenv("DB_URL", "postgresql://localhost/test")
@@ -35,6 +36,14 @@ def test_csp_header_blocks_inline(monkeypatch):
         if part.strip().startswith("script-src"):
             assert "'unsafe-inline'" not in part
             break
+    assert resp.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+
+
+def test_referrer_policy_on_other_routes(monkeypatch):
+    app = _setup_app(monkeypatch)
+    client = TestClient(app)
+    resp = client.get("/ready", headers={"Origin": "https://allowed.com"})
+    assert resp.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
 
 
 def test_cors_rejects_unknown_origin(monkeypatch):
@@ -70,6 +79,6 @@ def test_login_rate_limit_resets(monkeypatch):
 def test_sw_not_served_on_admin(monkeypatch):
     app = _setup_app(monkeypatch)
     client = TestClient(app)
-    resp = client.get('/admin/')
-    assert 'Service-Worker' not in resp.headers
-    assert 'Service-Worker-Allowed' not in resp.headers
+    resp = client.get("/admin/")
+    assert "Service-Worker" not in resp.headers
+    assert "Service-Worker-Allowed" not in resp.headers


### PR DESCRIPTION
## Summary
- add `Referrer-Policy: strict-origin-when-cross-origin` in CSP middleware
- test referrer policy header for `/health` and `/ready`

## Testing
- `pytest api/tests/test_security_headers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b580e24b44832ab23a070a3e6bd4bd