### PR TITLE
feat: manage pubsub lifetime via FastAPI lifespan

### DIFF
--- a/api/app/routes_tables_sse.py
+++ b/api/app/routes_tables_sse.py
@@ -119,7 +119,6 @@ async def stream_table_map(
         finally:
             reader_task.cancel()
             await pubsub.unsubscribe(channel)
-            await pubsub.close()
             sse_clients_gauge.dec()
             unregister(ip)
 


### PR DESCRIPTION
## Summary
- manage application lifecycle with FastAPI lifespan
- close application pubsub on shutdown
- drop per-route pubsub close calls now handled centrally

## Testing
- `pytest -q --maxfail=1` *(fails: api/tests/test_checkout_gateway.py::test_e2e_start_webhook_flow - assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68b580f9d1e4832abf12abb875b95cb8