### PR TITLE
Allow read-only guest routes for closed tenants

### DIFF
--- a/api/tests/test_maintenance.py
+++ b/api/tests/test_maintenance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import pathlib
 import sys
 import uuid
@@ -12,6 +13,7 @@ from fastapi.testclient import TestClient
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
+os.environ.setdefault("ALLOWED_ORIGINS", "*")
 from api.app import main as app_main  # noqa: E402
 from api.app.db import SessionLocal  # noqa: E402
 from api.app.main import app  # noqa: E402
@@ -142,6 +144,18 @@ def test_close_blocks_guest(client, monkeypatch):
     resp = client.get("/version", headers={"X-Tenant-ID": str(tenant_id)})
     assert resp.status_code == 403
     assert resp.json()["code"] == "TENANT_CLOSED"
+
+    resp_menu = client.get("/guest/foo", headers={"X-Tenant-ID": str(tenant_id)})
+    assert resp_menu.status_code != 403
+
+    item = {"item": "tea", "price": 2.0, "quantity": 1}
+    resp_cart = client.post(
+        "/tables/10/cart",
+        headers={"X-Tenant-ID": str(tenant_id)},
+        json=item,
+    )
+    assert resp_cart.status_code == 403
+    assert resp_cart.json()["code"] == "TENANT_CLOSED"
 
 
 def test_restore_reopens(client, monkeypatch):


### PR DESCRIPTION
## Summary
- allow closed tenants to serve static guest paths and menu endpoints
- keep order/cart requests blocked with TENANT_CLOSED

## Testing
- `pre-commit run --files api/app/middlewares/maintenance.py api/tests/test_maintenance.py`
- `pytest api/tests/test_maintenance.py`


------
https://chatgpt.com/codex/tasks/task_e_68b580f450dc832a99ab7dcbb30b872e