### PR TITLE
Ensure PDF routes set content type and support composition scheme

### DIFF
--- a/api/app/pdf/render.py
+++ b/api/app/pdf/render.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Literal, Optional, Tuple
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+
 from .fonts import FONTS_DIR, ensure_fonts
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
@@ -82,6 +83,7 @@ def render_template(
         )
         return pdf_bytes, "application/pdf"
     except Exception:
+        ensure_fonts()
         return html.encode("utf-8"), "text/html"
 
 
@@ -98,7 +100,11 @@ def render_invoice(
     """
     template_name = _TEMPLATE_MAP.get(size, _TEMPLATE_MAP["80mm"])
     template = _env.get_template(template_name)
-    html = template.render(invoice=invoice_json, csp_nonce=nonce)
+    html = template.render(
+        invoice=invoice_json,
+        csp_nonce=nonce,
+        composition_scheme=invoice_json.get("composition_scheme"),
+    )
     try:
         weasyprint = importlib.import_module("weasyprint")
         font_config = weasyprint.text.fonts.FontConfiguration()
@@ -108,4 +114,5 @@ def render_invoice(
         )
         return pdf_bytes, "application/pdf"
     except Exception:
+        ensure_fonts()
         return html.encode("utf-8"), "text/html"

--- a/api/app/routes_daybook_pdf.py
+++ b/api/app/routes_daybook_pdf.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 """Route for owner daybook PDF with HTML fallback."""
 
-from contextlib import asynccontextmanager
-from datetime import datetime, timezone, time
 import os
-
-from fastapi import APIRouter, Response, HTTPException
-from sqlalchemy import select, func, desc
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from contextlib import asynccontextmanager
+from datetime import datetime, time, timezone
 from zoneinfo import ZoneInfo
 
+from fastapi import APIRouter, HTTPException, Response
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
 from .db.tenant import get_engine
-from .models_tenant import OrderItem, Order
-from .repos_sqlalchemy import invoices_repo_sql
+from .models_tenant import Order, OrderItem
 from .pdf.render import render_template
+from .repos_sqlalchemy import invoices_repo_sql
 
 router = APIRouter()
 
@@ -82,6 +82,7 @@ async def owner_daybook_pdf(tenant_id: str, date: str) -> Response:
         },
     )
     response = Response(content=content, media_type=mimetype)
+    response.headers["Content-Type"] = mimetype
     ext = "pdf" if mimetype == "application/pdf" else "html"
     response.headers["Content-Disposition"] = f"attachment; filename=daybook.{ext}"
     return response

--- a/api/app/routes_invoice_pdf.py
+++ b/api/app/routes_invoice_pdf.py
@@ -31,4 +31,6 @@ async def invoice_pdf(
         invoice, size=size, nonce=request.state.csp_nonce
     )
     invoices_generated_total.inc()
-    return Response(content, media_type=mimetype)
+    response = Response(content, media_type=mimetype)
+    response.headers["Content-Type"] = mimetype
+    return response

--- a/api/app/routes_kot.py
+++ b/api/app/routes_kot.py
@@ -105,7 +105,9 @@ async def kot_pdf(
                 for name, qty, mods in item_rows.all():
                     items.append({"name": name, "qty": qty, "notes": ""})
                     for mod in mods or []:
-                        items.append({"name": f"- {mod['label']}", "qty": qty, "notes": ""})
+                        items.append(
+                            {"name": f"- {mod['label']}", "qty": qty, "notes": ""}
+                        )
             else:
                 raise HTTPException(status_code=404, detail="order not found")
 
@@ -120,4 +122,6 @@ async def kot_pdf(
     content, mimetype = render_template(
         "kot_80mm.html", {"kot": kot}, nonce=request.state.csp_nonce
     )
-    return Response(content, media_type=mimetype)
+    response = Response(content, media_type=mimetype)
+    response.headers["Content-Type"] = mimetype
+    return response

--- a/api/app/routes_owner_aggregate.py
+++ b/api/app/routes_owner_aggregate.py
@@ -155,6 +155,7 @@ async def owner_daybook_pdf(owner_id: str, request: Request, date: str) -> Respo
         },
     )
     response = Response(content=content, media_type=mimetype)
+    response.headers["Content-Type"] = mimetype
     ext = "pdf" if mimetype == "application/pdf" else "html"
     response.headers["Content-Disposition"] = f"attachment; filename=daybook.{ext}"
     return response

--- a/api/app/routes_qrpack.py
+++ b/api/app/routes_qrpack.py
@@ -97,7 +97,9 @@ async def qrpack_pdf(
     if cached:
         content = base64.b64decode(cached.get("content", ""))
         mimetype = cached.get("mimetype", "application/pdf")
-        return Response(content, media_type=mimetype)
+        response = Response(content, media_type=mimetype)
+        response.headers["Content-Type"] = mimetype
+        return response
 
     tables = []
     for idx, t in enumerate(tenant.get("tables", [])):
@@ -134,7 +136,9 @@ async def qrpack_pdf(
     )
     await redis.expire(cache_key, 600)
 
-    return Response(content, media_type=mimetype)
+    response = Response(content, media_type=mimetype)
+    response.headers["Content-Type"] = mimetype
+    return response
 
 
 __all__ = ["router"]

--- a/api/app/tax/gst_engine.py
+++ b/api/app/tax/gst_engine.py
@@ -6,7 +6,7 @@ This module centralises GST/HSN handling with precise ₹0.01 rounding.
 """
 
 from collections import defaultdict
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Iterable, Mapping
 
 GSTMode = str  # "reg", "comp" or "unreg"
@@ -64,13 +64,19 @@ def generate_invoice(
         for rate, amount in tax_acc.items():
             amount = amount.quantize(ROUND, rounding=ROUND_HALF_UP)
             if is_interstate:
-                tax_lines.append({"label": f"IGST {int(rate)}%", "amount": float(amount)})
+                tax_lines.append(
+                    {"label": f"IGST {int(rate)}%", "amount": float(amount)}
+                )
                 total_tax += amount
             else:
                 half_rate = float(rate) / 2
                 half_amount = (amount / 2).quantize(ROUND, rounding=ROUND_HALF_UP)
-                tax_lines.append({"label": f"CGST {half_rate}%", "amount": float(half_amount)})
-                tax_lines.append({"label": f"SGST {half_rate}%", "amount": float(half_amount)})
+                tax_lines.append(
+                    {"label": f"CGST {half_rate}%", "amount": float(half_amount)}
+                )
+                tax_lines.append(
+                    {"label": f"SGST {half_rate}%", "amount": float(half_amount)}
+                )
                 total_tax += half_amount * 2
 
     grand_total = (subtotal + total_tax).quantize(ROUND, rounding=ROUND_HALF_UP)
@@ -82,6 +88,6 @@ def generate_invoice(
         "tax_lines": tax_lines,
         "grand_total": float(grand_total),
     }
-    if gstin and gst_mode == "reg":
+    if gstin and gst_mode != "unreg":
         invoice["gstin"] = gstin
     return invoice

--- a/api/tests/test_invoice_render_modes.py
+++ b/api/tests/test_invoice_render_modes.py
@@ -54,6 +54,16 @@ def test_render_unregistered():
     assert "Composition Scheme" not in html
 
 
+def test_render_composition_scheme_flag():
+    invoice = billing_service.build_invoice_context(ITEMS, "reg", gstin=GSTIN)
+    invoice["number"] = "INV-1"
+    invoice["composition_scheme"] = True
+    html_bytes, mimetype = render_invoice(invoice, size="80mm")
+    assert mimetype == "text/html"
+    html = html_bytes.decode("utf-8")
+    assert "GSTIN: 22AAAAA0000A1Z5 (Composition Scheme)" in html
+
+
 def test_comp_invoice_no_gst_lines():
     invoice = billing_service.build_invoice_context(ITEMS, "comp", gstin=GSTIN)
     assert invoice["tax_lines"] == []

--- a/templates/invoice_80mm.html
+++ b/templates/invoice_80mm.html
@@ -51,7 +51,7 @@
     {% set L = _labels.get(_lang, _labels['en']) %}
     <h1>{{ L.invoice }} #{{ invoice['number'] }}</h1>
     {% if invoice['gst_mode'] != 'unreg' and invoice.get('gstin') %}
-      <p>GSTIN: {{ invoice['gstin'] }}{% if invoice['gst_mode'] == 'comp' %} (Composition Scheme){% endif %}</p>
+      <p>GSTIN: {{ invoice['gstin'] }}{% if composition_scheme or invoice['gst_mode'] == 'comp' %} (Composition Scheme){% endif %}</p>
     {% endif %}
     {% if invoice.get('fssai') %}
       <!-- Optional FSSAI license number -->

--- a/templates/invoice_a4.html
+++ b/templates/invoice_a4.html
@@ -51,7 +51,7 @@
     {% set L = _labels.get(_lang, _labels['en']) %}
     <h1>{{ L.invoice }} #{{ invoice['number'] }}</h1>
     {% if invoice['gst_mode'] != 'unreg' and invoice.get('gstin') %}
-      <p>GSTIN: {{ invoice['gstin'] }}{% if invoice['gst_mode'] == 'comp' %} (Composition Scheme){% endif %}</p>
+      <p>GSTIN: {{ invoice['gstin'] }}{% if composition_scheme or invoice['gst_mode'] == 'comp' %} (Composition Scheme){% endif %}</p>
     {% endif %}
     {% if invoice.get('fssai') %}
       <!-- Optional FSSAI license number -->


### PR DESCRIPTION
## Summary
- set explicit `Content-Type` headers on PDF/HTML responses
- register Noto fonts on HTML fallback and pass `composition_scheme` context to templates
- render GSTIN for composition invoices and cover with new tests

## Testing
- `pre-commit run --files api/app/pdf/render.py templates/invoice_80mm.html templates/invoice_a4.html api/app/routes_invoice_pdf.py api/app/routes_daybook_pdf.py api/app/routes_owner_aggregate.py api/app/routes_kot.py api/app/routes_qrpack.py api/tests/test_invoice_render_modes.py api/app/tax/gst_engine.py`
- `pytest api/tests/test_invoice_render_modes.py api/tests/test_invoice_print_conformance.py`

------
https://chatgpt.com/codex/tasks/task_e_68b580efa214832aa46554ab31f43044