### PR TITLE
Parse CORS origins and harden middleware

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -251,9 +251,9 @@ app = FastAPI(
 )
 static_dir = Path(__file__).resolve().parent.parent.parent / "static"
 app.mount("/static", SWStaticFiles(directory=static_dir), name="static")
-allowed_origins = [
-    o.strip() for o in os.getenv("ALLOWED_ORIGINS", "").split(",") if o.strip()
-]
+# Parse comma separated origins from environment and pass as list
+allowed_origins_env = os.getenv("ALLOWED_ORIGINS", "")
+allowed_origins = [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
 app.add_middleware(CORSMiddleware, allowed_origins=allowed_origins)
 
 # Serve built front-end SPAs

--- a/api/app/middleware/cors.py
+++ b/api/app/middleware/cors.py
@@ -24,7 +24,7 @@ class CORSMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: Callable) -> Response:  # type: ignore[override]
         origin = request.headers.get("origin")
         if origin and self.allowed and origin not in self.allowed:
-            return Response(status_code=HTTP_403_FORBIDDEN)
+            return Response(status_code=HTTP_403_FORBIDDEN, headers={"Vary": "Origin"})
 
         # Handle preflight
         if (
@@ -48,9 +48,9 @@ class CORSMiddleware(BaseHTTPMiddleware):
             return Response(status_code=200, headers=headers)
 
         response = await call_next(request)
+        response.headers.setdefault("Vary", "Origin")
         if origin and (not self.allowed or origin in self.allowed):
             response.headers.setdefault("Access-Control-Allow-Origin", origin)
-            response.headers.setdefault("Vary", "Origin")
             response.headers.setdefault("Access-Control-Allow-Credentials", "true")
             response.headers.setdefault("Access-Control-Max-Age", str(self.max_age))
         return response

--- a/api/app/middlewares/cors.py
+++ b/api/app/middlewares/cors.py
@@ -29,10 +29,11 @@ class CORSMiddleware(BaseHTTPMiddleware):
             return JSONResponse(
                 err("FORBIDDEN_ORIGIN", "ForbiddenOrigin"),
                 status_code=HTTP_403_FORBIDDEN,
+                headers={"Vary": "Origin"},
             )
         response = await call_next(request)
+        response.headers.setdefault("Vary", "Origin")
         if origin and (not self.allowed or origin in self.allowed):
             response.headers.setdefault("Access-Control-Allow-Origin", origin)
-            response.headers.setdefault("Vary", "Origin")
             response.headers.setdefault("Access-Control-Max-Age", str(self.max_age))
         return response


### PR DESCRIPTION
## Summary
- Parse `ALLOWED_ORIGINS` from env and pass as list to CORS middleware
- Ensure CORS middleware always sets `Vary: Origin` and rejects disallowed origins with 403
- Return structured 403 for forbidden origins from legacy middleware

## Testing
- `pytest -q -x` *(fails: api/tests/test_checkout_gateway.py::test_e2e_start_webhook_flow - assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68b580ea63f4832a8775afd3c6af3b25