### PR TITLE
Ensure tenant engines are disposed after async sessions

### DIFF
--- a/api/app/routes_counter.py
+++ b/api/app/routes_counter.py
@@ -43,8 +43,11 @@ async def get_tenant_session(
     sessionmaker = async_sessionmaker(
         engine, expire_on_commit=False, class_=AsyncSession
     )
-    async with sessionmaker() as session:
-        yield session
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        await engine.dispose()
 
 
 async def get_session_from_path(
@@ -54,8 +57,11 @@ async def get_session_from_path(
     sessionmaker = async_sessionmaker(
         engine, expire_on_commit=False, class_=AsyncSession
     )
-    async with sessionmaker() as session:
-        yield session
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        await engine.dispose()
 
 
 @router.get("/{counter_token}/menu")

--- a/api/app/routes_refunds.py
+++ b/api/app/routes_refunds.py
@@ -23,8 +23,11 @@ async def get_tenant_session(
 
     engine = get_engine(tenant_id)
     Session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
-    async with Session() as session:  # pragma: no cover - simple generator
-        yield session
+    try:
+        async with Session() as session:  # pragma: no cover - simple generator
+            yield session
+    finally:
+        await engine.dispose()
 
 
 @router.post("/payments/{payment_id}/refund")

--- a/api/app/routes_voids.py
+++ b/api/app/routes_voids.py
@@ -39,8 +39,11 @@ async def get_session_from_path(tenant_id: str) -> AsyncGenerator[AsyncSession, 
     sessionmaker = async_sessionmaker(
         engine, expire_on_commit=False, class_=AsyncSession
     )
-    async with sessionmaker() as session:
-        yield session
+    try:
+        async with sessionmaker() as session:
+            yield session
+    finally:
+        await engine.dispose()
 
 
 @router.post("/api/outlet/{tenant_id}/orders/{order_id}/void/request")


### PR DESCRIPTION
## Summary
- wrap tenant session dependencies in `try/finally` blocks that dispose the engine
- close engines after batch order ingestion and other session uses to prevent warnings

## Testing
- `pre-commit run --files api/app/routes_counter.py api/app/routes_guest_consent.py api/app/routes_guest_order.py api/app/routes_order_void.py api/app/routes_orders_batch.py api/app/routes_refunds.py api/app/routes_voids.py`
- `pytest` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b580f6e9ac832a992b5b28d66d4cb0