### PR TITLE
propagate CSP nonce through renderers and templates

### DIFF
--- a/api/app/routes_admin_qrposter_pack.py
+++ b/api/app/routes_admin_qrposter_pack.py
@@ -8,7 +8,7 @@ from typing import Literal
 from zipfile import ZipFile
 
 import qrcode
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, HTTPException, Request, Response
 
 from .pdf.render import render_template
 from .routes_onboarding import TENANTS
@@ -31,7 +31,7 @@ def _qr_data_url(url: str) -> str:
 
 @router.get("/api/admin/outlets/{tenant_id}/qrposters.zip")
 async def qr_poster_pack(
-    tenant_id: str, size: Literal["A4", "A5"] = "A4"
+    tenant_id: str, request: Request, size: Literal["A4", "A5"] = "A4"
 ) -> Response:
     tenant = TENANTS.get(tenant_id)
     if not tenant:
@@ -50,6 +50,7 @@ async def qr_poster_pack(
                     "size": size,
                     "instructions": "Scan to order & pay",
                 },
+                nonce=request.state.csp_nonce,
             )
             zf.writestr(f"{t['code']}.pdf", content)
     buffer.seek(0)

--- a/api/app/routes_daybook_pdf.py
+++ b/api/app/routes_daybook_pdf.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone, time
 import os
 
-from fastapi import APIRouter, Response, HTTPException
+from fastapi import APIRouter, Request, Response, HTTPException
 from sqlalchemy import select, func, desc
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from zoneinfo import ZoneInfo
@@ -34,7 +34,7 @@ async def _session(tenant_id: str):
 
 
 @router.get("/api/outlet/{tenant_id}/reports/daybook.pdf")
-async def owner_daybook_pdf(tenant_id: str, date: str) -> Response:
+async def owner_daybook_pdf(tenant_id: str, request: Request, date: str) -> Response:
     """Return a daily owner daybook in PDF or HTML format."""
 
     tz = os.getenv("DEFAULT_TZ", "UTC")
@@ -80,6 +80,7 @@ async def owner_daybook_pdf(tenant_id: str, date: str) -> Response:
             "payments": payments,
             "top_items": top_items,
         },
+        nonce=request.state.csp_nonce,
     )
     response = Response(content=content, media_type=mimetype)
     ext = "pdf" if mimetype == "application/pdf" else "html"

--- a/api/app/routes_owner_aggregate.py
+++ b/api/app/routes_owner_aggregate.py
@@ -153,6 +153,7 @@ async def owner_daybook_pdf(owner_id: str, request: Request, date: str) -> Respo
             "payments": payments,
             "top_outlets": top_outlets,
         },
+        nonce=request.state.csp_nonce,
     )
     response = Response(content=content, media_type=mimetype)
     ext = "pdf" if mimetype == "application/pdf" else "html"

--- a/api/app/routes_qrpack.py
+++ b/api/app/routes_qrpack.py
@@ -117,6 +117,7 @@ async def qrpack_pdf(
             "pages": pages,
             "size": size,
         },
+        nonce=request.state.csp_nonce,
     )
 
     content = content.replace(b' aria-label="QR codes"', b"")

--- a/api/app/routes_support_console.py
+++ b/api/app/routes_support_console.py
@@ -57,7 +57,7 @@ async def console_page(
     return templates.TemplateResponse(
         request,
         "support_console.html",
-        {"macros": macros, "is_admin": is_admin},
+        {"macros": macros, "is_admin": is_admin, "csp_nonce": request.state.csp_nonce},
     )
 
 

--- a/api/tests/test_csp_nonce_printables.py
+++ b/api/tests/test_csp_nonce_printables.py
@@ -10,6 +10,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
 from api.app import routes_kot  # noqa: E402
 from api.app.middlewares.security import SecurityMiddleware  # noqa: E402
+from api.app.middleware.csp import CSPMiddleware  # noqa: E402
 from api.app.routes_invoice_pdf import router as invoice_router  # noqa: E402
 
 
@@ -23,6 +24,7 @@ def _extract_nonce(resp):
 def test_invoice_csp_nonce():
     app = FastAPI()
     app.add_middleware(SecurityMiddleware)
+    app.add_middleware(CSPMiddleware)
     app.include_router(invoice_router)
     client = TestClient(app)
     resp = client.get("/invoice/123/pdf?size=80mm")
@@ -34,6 +36,7 @@ def test_invoice_csp_nonce():
 def test_kot_csp_nonce():
     app = FastAPI()
     app.add_middleware(SecurityMiddleware)
+    app.add_middleware(CSPMiddleware)
     app.include_router(routes_kot.router)
 
     class DummyResult1:

--- a/api/tests/test_onboarding_e2e.py
+++ b/api/tests/test_onboarding_e2e.py
@@ -11,6 +11,7 @@ import fakeredis.aioredis
 
 from api.app.routes_onboarding import router as onboarding_router, TENANTS
 from api.app.routes_qrpack import router as qrpack_router
+from api.app.middleware.csp import CSPMiddleware  # noqa: E402
 
 
 
@@ -20,6 +21,7 @@ def _setup_app() -> FastAPI:
     app.include_router(onboarding_router)
     app.include_router(qrpack_router)
     app.state.redis = fakeredis.aioredis.FakeRedis()
+    app.add_middleware(CSPMiddleware)
     return app
 
 

--- a/api/tests/test_onboarding_qrpack.py
+++ b/api/tests/test_onboarding_qrpack.py
@@ -13,11 +13,13 @@ from api.app.pdf.render import render_template  # noqa: E402
 from api.app.routes_onboarding import TENANTS  # noqa: E402
 from api.app.routes_onboarding import router as onboarding_router  # noqa: E402
 from api.app.routes_qrpack import router as qrpack_router  # noqa: E402
+from api.app.middleware.csp import CSPMiddleware  # noqa: E402
 
 
 def _setup_app():
     app = FastAPI()
     app.state.redis = fakeredis.aioredis.FakeRedis()
+    app.add_middleware(CSPMiddleware)
     app.include_router(onboarding_router)
     app.include_router(qrpack_router)
     return app

--- a/templates/admin_menu_editor.html
+++ b/templates/admin_menu_editor.html
@@ -39,7 +39,7 @@
     </form>
   </section>
   <div id="toaster"></div>
-  <script>
+  <script nonce="{{ csp_nonce }}">
     function showToast(msg){
       const t=document.getElementById('toaster');
       t.textContent=msg;

--- a/templates/base_guest.html
+++ b/templates/base_guest.html
@@ -20,7 +20,7 @@
       </select>
     </header>
     {% block content %}{% endblock %}
-    <script>
+    <script nonce="{{ csp_nonce }}">
       const sel = document.getElementById('lang-switcher');
       sel.addEventListener('change', () => {
         const code = sel.value;

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -50,7 +50,7 @@
       <a href="/legal/contact">Contact</a>
     </footer>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
       const refundBtn = document.getElementById('refund-btn');
       const modal = document.getElementById('refund-modal');
       const confirmBtn = document.getElementById('confirm-refund');

--- a/templates/support_console.html
+++ b/templates/support_console.html
@@ -19,7 +19,7 @@
   <option value="{{ text|e }}">{{ name }}</option>
   {% endfor %}
 </select>
-<script>
+<script nonce="{{ csp_nonce }}">
 document.getElementById('macro').addEventListener('change', function() {
   if (this.value) {
     const ta = document.getElementById('reply');

--- a/tests/test_checkout_template.py
+++ b/tests/test_checkout_template.py
@@ -14,6 +14,7 @@ app.include_router(routes_refunds.router)
 
 @app.get("/checkout")
 async def checkout(request: Request, order_id: int):
+    request.state.csp_nonce = "nonce"
     return templates.TemplateResponse(
         "checkout.html",
         {
@@ -22,6 +23,7 @@ async def checkout(request: Request, order_id: int):
             "tip_enabled": False,
             "payment_methods": ["cash"],
             "payment_id": 1,
+            "csp_nonce": request.state.csp_nonce,
         },
     )
 
@@ -66,6 +68,7 @@ def test_checkout_links_and_refund_confirm(client):
     assert resp.status_code == 200
     for path in ("terms", "refund", "contact"):
         assert f"/legal/{path}" in resp.text
+    assert 'nonce="nonce"' in resp.text
 
     resp = client.post("/payments/1/refund")
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- pass `request.state.csp_nonce` into PDF and HTML renderers
- add `nonce="{{ csp_nonce }}"` to inline scripts across templates
- exercise CSP middleware in tests to ensure nonce propagation

## Testing
- `pytest api/tests/test_csp_nonce_printables.py tests/test_checkout_template.py api/tests/test_onboarding_qrpack.py api/tests/test_qrpack_audit.py api/tests/test_onboarding_e2e.py`

------
https://chatgpt.com/codex/tasks/task_e_68b580e48e3c832aaf95c6f994f119b0