### PR TITLE
feat: add debug guards for worker tasks

### DIFF
--- a/api/app/analytics/posthog.py
+++ b/api/app/analytics/posthog.py
@@ -41,6 +41,8 @@ def _ensure_worker() -> None:
     global _worker_started
     if _worker_started:
         return
+    if os.getenv("DEBUG") or os.getenv("TESTING"):
+        return
     loop = asyncio.get_event_loop()
     loop.create_task(_worker())
     _worker_started = True

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -200,9 +200,9 @@ from .routes_security import router as security_router
 from .routes_slo import router as slo_router
 from .routes_staff import router as staff_router
 from .routes_staff_support import router as staff_support_router
+from .routes_stats import router as stats_router
 from .routes_status import router as status_router
 from .routes_status_json import router as status_json_router
-from .routes_stats import router as stats_router
 from .routes_support import router as support_router
 from .routes_support_bundle import router as support_bundle_router
 from .routes_support_console import router as support_console_router
@@ -364,6 +364,8 @@ prep_trackers: dict[str, PrepTimeTracker] = {}
 @app.on_event("startup")
 async def start_event_consumers() -> None:
     """Launch background tasks for event processing."""
+    if os.getenv("DEBUG") or os.getenv("TESTING"):
+        return
 
     asyncio.create_task(alerts_sender(event_bus.subscribe("order.placed")))
     asyncio.create_task(ema_updater(event_bus.subscribe("payment.verified")))
@@ -374,6 +376,8 @@ async def start_event_consumers() -> None:
 @app.on_event("startup")
 async def start_replica_monitor() -> None:
     await replica.check_replica(app)
+    if os.getenv("DEBUG") or os.getenv("TESTING"):
+        return
     asyncio.create_task(replica.monitor(app))
 
 

--- a/api/scripts/notify_worker.py
+++ b/api/scripts/notify_worker.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Placeholder notify worker for tests.
+
+Prints a message and exits successfully.
+"""
+
+import sys
+
+print("notify_worker stub running")
+sys.exit(0)


### PR DESCRIPTION
## Summary
- add notify_worker stub script for tests
- avoid spawning background workers when DEBUG or TESTING is set

## Testing
- `pre-commit run --files api/scripts/notify_worker.py api/app/main.py api/app/analytics/posthog.py`
- `pytest -q` *(fails: assert 401 == 200, AssertionError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b580f15b90832aae56570425876090