### PR TITLE
chore: expand env example with database and redis settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,34 @@
 # WEBHOOK=https://hooks.example.com/endpoint
 # DSN template for tenant databases; if the database is absent, scripts will
 # connect to a server-level database (postgres/template1) and create it.
-# POSTGRES_TENANT_DSN_TEMPLATE=postgresql+asyncpg://tenant:tenant@postgres:5432/tenant_{tenant_id}
+# POSTGRES_TENANT_DSN_TEMPLATE=postgresql+asyncpg://tenant:tenant@localhost:5432/tenant_{tenant_id}
+
+# Preferred primary database connection URL
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/app
+
+# Legacy primary database connection URL
+POSTGRES_MASTER_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/app
+
+# Redis connection URL (overrides host/port/db)
+REDIS_URL=redis://localhost:6379/0
+
+# Redis host
+REDIS_HOST=localhost
+
+# Redis port
+REDIS_PORT=6379
+
+# Redis database index
+REDIS_DB=0
+
+# API server port
+API_PORT=8000
+
+# Application environment
+APP_ENV=development
 
 # Allowed CORS origins (comma-separated)
 ALLOWED_ORIGINS=http://localhost:3000
 
-# Primary database connection URL
-DB_URL=postgresql+asyncpg://user:password@postgres:5432/app
-
-# Async connection URL for the shared "master" database
-POSTGRES_MASTER_URL=postgresql+asyncpg://user:password@postgres:5432/app
-
-# Redis connection URL
-REDIS_URL=redis://redis:6379/0
-
 # Secret key for signing; replace with a long random string in production
-SECRET_KEY=0123456789abcdef0123456789abcdef
+SECRET_KEY=change-me


### PR DESCRIPTION
## Summary
- document preferred `DATABASE_URL` and legacy `POSTGRES_MASTER_URL`
- add redis connection settings and app port/env defaults in `.env.example`

## Testing
- `pre-commit run --files .env.example`
- `pytest -q` *(fails: KeyboardInterrupt: ???)*

------
https://chatgpt.com/codex/tasks/task_e_68b59754da98832a90a7faa8e42e5bf1