### PR TITLE
Run tests without Docker

### DIFF
--- a/run_all.py
+++ b/run_all.py
@@ -229,6 +229,7 @@ def start_processes():
 
 def run_tests():
     ensure_python_venv()
+    install_backend()
     pip = pip_exe()
     # Ensure pytest present (api/requirements.txt already includes it, but be safe)
     run([pip, "install", "pytest"])
@@ -238,10 +239,13 @@ def run_tests():
         env["PGDATABASE"] = "testdb"
         print("ℹ️ PGDATABASE not set, defaulting to 'testdb'")
 
-    bootstrap = ROOT / ".ci" / "scripts" / "bootstrap_test_db.sh"
-    bootstrap.chmod(bootstrap.stat().st_mode | 0o111)
-    print("📦 Bootstrapping test database ...")
-    run([str(bootstrap)], env=env)
+    if not which("docker"):
+        print("⚠️ Docker not installed or not on PATH. Skipping test DB bootstrap.")
+    else:
+        bootstrap = ROOT / ".ci" / "scripts" / "bootstrap_test_db.sh"
+        bootstrap.chmod(bootstrap.stat().st_mode | 0o111)
+        print("📦 Bootstrapping test database ...")
+        run([str(bootstrap)], env=env)
 
     print("🧪 Running backend tests ...")
     run([python_exe(), "-m", "pytest", "-q"], cwd=API_DIR, env=env)


### PR DESCRIPTION
## Summary
- ensure backend deps install before tests
- skip test DB bootstrap when Docker is missing

## Testing
- `python3 -m py_compile run_all.py`
- `python3 run_all.py --test` *(fails: keyboard interrupt during pytest run)*
- `.venv/bin/pytest -q --maxfail=1` *(fails: api/tests/test_counter_flow.py::test_counter_order_delivered_invoice)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a79b7104832a9bed2e96af4a5198