### PR TITLE
refactor: enforce master DB env vars

### DIFF
--- a/api/app/db/master.py
+++ b/api/app/db/master.py
@@ -9,10 +9,15 @@ from sqlalchemy.orm import sessionmaker
 
 from api.app.obs import add_query_logger
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL",
-    os.getenv("POSTGRES_MASTER_URL", "sqlite+aiosqlite:///./dev_master.db"),
-)
+DEV_SQLITE_ENV = "DEV_SQLITE"
+
+url = os.getenv("DATABASE_URL") or os.getenv("POSTGRES_MASTER_URL")
+if not url:
+    if os.getenv(DEV_SQLITE_ENV):
+        url = "sqlite+aiosqlite:///:memory:"
+    else:
+        raise RuntimeError("DATABASE_URL or POSTGRES_MASTER_URL must be set")
+DATABASE_URL = url
 
 _engine: AsyncEngine | None = None
 _sessionmaker: sessionmaker[AsyncSession] | None = None


### PR DESCRIPTION
## Summary
- require explicit master DB URL and allow optional dev sqlite fallback

## Testing
- `pre-commit run --files api/app/db/master.py`
- `ALLOWED_ORIGINS=* pytest api/tests/test_status_api.py::test_status_json_endpoint -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ae556734832a99228dc56dac5871