### PR TITLE
Add CI workflow with Postgres and Redis services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run migrations
+        run: scripts/migrate.sh
+      - name: Smoke check
+        run: python scripts/smoke_check.py
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add CI workflow with Python setup, Postgres 15, and Redis 7 services
- run migrations, smoke check, and pytest in CI

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest` *(fails: KeyboardInterrupt with failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ae514bbc832a8b42900c1ac6dedb