### PR TITLE
refactor: isolate test DB initialization

### DIFF
--- a/api/app/db/__init__.py
+++ b/api/app/db/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -9,15 +10,35 @@ from api.app.obs import add_query_logger
 from ..models_master import Base as MasterBase
 from ..models_tenant import Base as TenantBase
 
-# Shared database engine and session factory for the application.
-engine = create_engine(
-    "sqlite://",
-    connect_args={"check_same_thread": False},
-    poolclass=StaticPool,
-)
-add_query_logger(engine, "test")
-SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
-MasterBase.metadata.create_all(bind=engine)
-TenantBase.metadata.create_all(bind=engine)
+# Helpers to initialise an in-memory database for tests. These helpers are
+# intentionally side-effect free; the returned session factory and engine are
+# not exposed until tests explicitly assign them to module-level variables.
 
-__all__ = ["SessionLocal", "engine"]
+
+def create_test_session() -> tuple[sessionmaker, Engine]:
+    """Return a session factory and engine for tests.
+
+    The database uses an in-memory SQLite engine with a static pool so that
+    multiple connections share the same data. Both master and tenant schemas
+    are created to mirror the production setup.
+    """
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    add_query_logger(engine, "test")
+    MasterBase.metadata.create_all(bind=engine)
+    TenantBase.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    return session_factory, engine
+
+
+# Placeholders to be populated by tests. Application code should import these
+# names and, during tests, they will be initialised via ``create_test_session``
+# from the respective ``conftest.py``.
+SessionLocal: sessionmaker | None = None
+engine: Engine | None = None
+
+__all__ = ["SessionLocal", "engine", "create_test_session"]

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,4 +1,9 @@
 """Test configuration for API tests."""
 import os
 
+import api.app.db as app_db
+
 os.environ.setdefault("SECRET_KEY", "x" * 32)
+os.environ.setdefault("ALLOWED_ORIGINS", "http://example.com")
+
+app_db.SessionLocal, app_db.engine = app_db.create_test_session()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,10 @@ os.environ.setdefault("REDIS_URL", "redis://redis:6379/0")
 os.environ.setdefault("SECRET_KEY", "x" * 32)
 os.environ.setdefault("ALLOWED_ORIGINS", "http://example.com")
 
+import api.app.db as app_db
+
+app_db.SessionLocal, app_db.engine = app_db.create_test_session()
+
 try:  # pragma: no cover - fallback for broken app imports
     from api.app.main import app  # noqa: E402
 except Exception:  # pragma: no cover


### PR DESCRIPTION
## Summary
- remove engine and session side effects from db module
- add `create_test_session` helper for tests
- initialise test DB in conftest files

## Testing
- `pre-commit run --files api/app/db/__init__.py tests/conftest.py api/tests/conftest.py`
- `pytest tests/test_whatsapp_status.py::test_notify_status_enqueues_and_audits -q`
- `pytest api/tests/test_hotel.py::test_room_service_and_cleaning -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ae5862e8832ab5a200cea2542c58