### PR TITLE
chore: default API test DB

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -3,7 +3,13 @@ import os
 
 import api.app.db as app_db
 
+# Provide default settings so tests can run without requiring a full
+# environment configuration.
 os.environ.setdefault("SECRET_KEY", "x" * 32)
 os.environ.setdefault("ALLOWED_ORIGINS", "http://example.com")
+# Use an in-memory SQLite database when explicit connection URLs are not
+# supplied. This mirrors the behaviour in top-level tests and prevents
+# import-time failures when DATABASE_URL or POSTGRES_MASTER_URL are missing.
+os.environ.setdefault("POSTGRES_MASTER_URL", "sqlite+aiosqlite:///:memory:")
 
 app_db.SessionLocal, app_db.engine = app_db.create_test_session()


### PR DESCRIPTION
## Summary
- prevent import-time DB config errors in API test suite

## Testing
- `.venv/bin/python -m pytest api/tests/test_ab_report.py::test_report_and_lift -q -p no:warnings`

------
https://chatgpt.com/codex/tasks/task_e_68b6d6daeffc832a9f5c0e56ac9f76d8