### PR TITLE
Check DB deps on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 
 - Correct sales register and GST summary exports to emit expected CSV headers and values.
 - Replace `/telemetry/error` fetch with SSR-safe `captureError` in the global error boundary.
+- Verify Redis and Postgres dependencies during startup to surface missing packages early.
 
 ## v1.0.0 - 2025-08-26
 

--- a/start_app.py
+++ b/start_app.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import os
 import subprocess
 import sys
@@ -27,6 +28,20 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     load_dotenv()  # load environment variables from a .env file
+
+    for module, package in [
+        ("asyncpg", "asyncpg"),
+        ("psycopg2", "psycopg2-binary"),
+        ("redis", "redis"),
+    ]:
+        try:
+            importlib.import_module(module)
+        except ModuleNotFoundError:
+            print(
+                f"Missing dependency: {package}. Install it with 'pip install {package}'",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
 
     env_flag = os.getenv("SKIP_DB_MIGRATIONS")
     skip = args.skip_db_migrations or (


### PR DESCRIPTION
## Summary
- verify asyncpg, psycopg2, and redis modules during startup so missing packages surface early
- document dependency check in changelog

## Testing
- `pre-commit run --files start_app.py CHANGELOG.md`
- `pytest tests/test_config.py` *(fails: AssertionError in `test_database_url_populates_master`)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ee59b650832a82226499a3162eeb